### PR TITLE
feat: deployment revision history with targeted rollback

### DIFF
--- a/src-tauri/src/commands/k8s_commands.rs
+++ b/src-tauri/src/commands/k8s_commands.rs
@@ -5,7 +5,7 @@ use k8s::cost::{CostOverview, NodeCostInfo, NodeMetricsInfo};
 use k8s::crd::{CrdGroup, CrdInfo, CrdResourceList, StatusCondition};
 use k8s::diagnostics::DiagnosticResult;
 use k8s::portforward::PortForwardResult;
-use k8s::resources::{EventItem, ResourceList};
+use k8s::resources::{EventItem, ResourceList, RevisionInfo};
 use k8s::security::{ImageScanResult, SecurityOverview};
 use k8s::topology::TopologyGraph;
 
@@ -177,6 +177,16 @@ pub async fn rollback_deployment(
     revision: Option<u64>,
 ) -> Result<String, String> {
     k8s::resources::rollback_deployment(&name, &namespace, revision)
+        .await
+        .str_err()
+}
+
+#[tauri::command]
+pub async fn list_deployment_revisions(
+    name: String,
+    namespace: String,
+) -> Result<Vec<RevisionInfo>, String> {
+    k8s::resources::list_deployment_revisions(&name, &namespace)
         .await
         .str_err()
 }

--- a/src-tauri/src/k8s/resources/mod.rs
+++ b/src-tauri/src/k8s/resources/mod.rs
@@ -22,7 +22,8 @@ pub use listing::{get_resource_yaml, list_pods_by_selector, list_resources};
 #[allow(unused_imports)]
 pub use namespace::get_namespace_info;
 pub use operations::{
-    apply_resource_yaml, delete_resource, restart_workload, rollback_deployment, scale_workload,
+    apply_resource_yaml, delete_resource, list_deployment_revisions, restart_workload,
+    rollback_deployment, scale_workload, RevisionInfo,
 };
 #[allow(unused_imports)]
 pub use types::{EventItem, NamespaceInfo, Resource, ResourceList, ResourceMetadata};

--- a/src-tauri/src/k8s/resources/operations.rs
+++ b/src-tauri/src/k8s/resources/operations.rs
@@ -1,10 +1,72 @@
 use anyhow::Result;
 use k8s_openapi::api::apps::v1::ReplicaSet;
 use kube::api::{DynamicObject, ListParams};
-use kube::Api;
+use kube::{Api, Client};
+use serde::{Deserialize, Serialize};
 
 use super::helpers::{api_resource_for_kind, dynamic_api_for_resource};
 use crate::k8s::client::get_client;
+
+/// Summary of a Deployment revision surfaced in the UI for rollback selection.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RevisionInfo {
+    pub revision: u64,
+    pub name: String,
+    pub created_at: Option<String>,
+    pub images: Vec<String>,
+    pub replicas: i32,
+    pub is_current: bool,
+}
+
+/// Extract the revision number from a ReplicaSet's annotations. Returns 0 if missing or unparseable.
+fn rs_revision(rs: &ReplicaSet) -> u64 {
+    rs.metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get("deployment.kubernetes.io/revision"))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Container images from a ReplicaSet's pod template.
+fn rs_images(rs: &ReplicaSet) -> Vec<String> {
+    rs.spec
+        .as_ref()
+        .and_then(|s| s.template.as_ref())
+        .and_then(|t| t.spec.as_ref())
+        .map(|pod_spec| {
+            pod_spec
+                .containers
+                .iter()
+                .filter_map(|c| c.image.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Fetch ReplicaSets owned by the given Deployment, sorted by revision descending (newest first).
+async fn fetch_sorted_revisions(
+    client: &Client,
+    name: &str,
+    namespace: &str,
+) -> Result<Vec<ReplicaSet>> {
+    let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
+    let rs_list = rs_api.list(&ListParams::default()).await?;
+
+    let mut owned: Vec<ReplicaSet> = rs_list
+        .items
+        .into_iter()
+        .filter(|rs| {
+            rs.metadata.owner_references.as_ref().is_some_and(|refs| {
+                refs.iter()
+                    .any(|r| r.kind == "Deployment" && r.name == name)
+            })
+        })
+        .collect();
+
+    owned.sort_by(|a, b| rs_revision(b).cmp(&rs_revision(a)));
+    Ok(owned)
+}
 
 /// Apply (create or update) a resource from raw YAML using server-side apply.
 pub async fn apply_resource_yaml(yaml_str: &str) -> Result<String> {
@@ -122,6 +184,38 @@ pub async fn restart_workload(kind: &str, name: &str, namespace: &str) -> Result
     Ok(())
 }
 
+/// List all revisions (ReplicaSets) belonging to a Deployment, newest first.
+///
+/// The revision with the highest number that has running pods is marked `is_current`.
+/// If no ReplicaSet is running (e.g. the Deployment is paused with 0 replicas), the
+/// newest revision is flagged as current so the UI can still distinguish it.
+pub async fn list_deployment_revisions(name: &str, namespace: &str) -> Result<Vec<RevisionInfo>> {
+    let client = get_client().await?;
+    let sorted = fetch_sorted_revisions(&client, name, namespace).await?;
+
+    let current_idx = sorted
+        .iter()
+        .position(|rs| rs.status.as_ref().is_some_and(|s| s.replicas > 0))
+        .unwrap_or(0);
+
+    Ok(sorted
+        .iter()
+        .enumerate()
+        .map(|(idx, rs)| RevisionInfo {
+            revision: rs_revision(rs),
+            name: rs.metadata.name.clone().unwrap_or_default(),
+            created_at: rs
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|t| t.0.to_rfc3339()),
+            images: rs_images(rs),
+            replicas: rs.status.as_ref().map(|s| s.replicas).unwrap_or(0),
+            is_current: idx == current_idx,
+        })
+        .collect())
+}
+
 /// Rollback a Deployment to a previous revision by copying the pod template from a target ReplicaSet.
 pub async fn rollback_deployment(
     name: &str,
@@ -129,23 +223,7 @@ pub async fn rollback_deployment(
     revision: Option<u64>,
 ) -> Result<String> {
     let client = get_client().await?;
-
-    // Get all ReplicaSets in the namespace
-    let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
-    let lp = ListParams::default();
-    let rs_list = rs_api.list(&lp).await?;
-
-    // Find ReplicaSets owned by this deployment and sort by revision (descending)
-    let mut sorted_rs: Vec<_> = rs_list
-        .items
-        .iter()
-        .filter(|rs| {
-            rs.metadata.owner_references.as_ref().is_some_and(|refs| {
-                refs.iter()
-                    .any(|r| r.kind == "Deployment" && r.name == name)
-            })
-        })
-        .collect();
+    let sorted_rs = fetch_sorted_revisions(&client, name, namespace).await?;
 
     if sorted_rs.is_empty() {
         return Err(anyhow::anyhow!(
@@ -154,36 +232,10 @@ pub async fn rollback_deployment(
         ));
     }
 
-    sorted_rs.sort_by(|a, b| {
-        let rev_a: u64 = a
-            .metadata
-            .annotations
-            .as_ref()
-            .and_then(|a| a.get("deployment.kubernetes.io/revision"))
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0);
-        let rev_b: u64 = b
-            .metadata
-            .annotations
-            .as_ref()
-            .and_then(|a| a.get("deployment.kubernetes.io/revision"))
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0);
-        rev_b.cmp(&rev_a)
-    });
-
-    // Target is either the specified revision or the previous one
     let target_rs = if let Some(rev) = revision {
         sorted_rs
             .iter()
-            .find(|rs| {
-                rs.metadata
-                    .annotations
-                    .as_ref()
-                    .and_then(|a| a.get("deployment.kubernetes.io/revision"))
-                    .and_then(|v| v.parse::<u64>().ok())
-                    == Some(rev)
-            })
+            .find(|rs| rs_revision(rs) == rev)
             .ok_or_else(|| anyhow::anyhow!("Revision {} not found", rev))?
     } else {
         sorted_rs
@@ -191,15 +243,8 @@ pub async fn rollback_deployment(
             .ok_or_else(|| anyhow::anyhow!("No previous revision found"))?
     };
 
-    let target_rev = target_rs
-        .metadata
-        .annotations
-        .as_ref()
-        .and_then(|a| a.get("deployment.kubernetes.io/revision"))
-        .cloned()
-        .unwrap_or_default();
+    let target_rev = rs_revision(target_rs);
 
-    // Extract pod template from target RS and patch the deployment
     let target_template = target_rs
         .spec
         .as_ref()
@@ -217,4 +262,50 @@ pub async fn rollback_deployment(
         .await?;
 
     Ok(format!("Rolled back to revision {}", target_rev))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use std::collections::BTreeMap;
+
+    fn rs_with_revision(rev: Option<&str>) -> ReplicaSet {
+        let annotations = rev.map(|v| {
+            let mut m = BTreeMap::new();
+            m.insert("deployment.kubernetes.io/revision".to_string(), v.to_string());
+            m
+        });
+        ReplicaSet {
+            metadata: ObjectMeta {
+                annotations,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rs_revision_parses_valid_annotation() {
+        let rs = rs_with_revision(Some("7"));
+        assert_eq!(rs_revision(&rs), 7);
+    }
+
+    #[test]
+    fn rs_revision_returns_zero_when_missing() {
+        let rs = rs_with_revision(None);
+        assert_eq!(rs_revision(&rs), 0);
+    }
+
+    #[test]
+    fn rs_revision_returns_zero_when_unparseable() {
+        let rs = rs_with_revision(Some("not-a-number"));
+        assert_eq!(rs_revision(&rs), 0);
+    }
+
+    #[test]
+    fn rs_revision_handles_large_numbers() {
+        let rs = rs_with_revision(Some("18446744073709551615")); // u64::MAX
+        assert_eq!(rs_revision(&rs), u64::MAX);
+    }
 }

--- a/src-tauri/src/k8s/resources/operations.rs
+++ b/src-tauri/src/k8s/resources/operations.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use k8s_openapi::api::apps::v1::ReplicaSet;
+use k8s_openapi::api::apps::v1::{Deployment, ReplicaSet};
 use kube::api::{DynamicObject, ListParams};
 use kube::{Api, Client};
 use serde::{Deserialize, Serialize};
@@ -45,11 +45,22 @@ fn rs_images(rs: &ReplicaSet) -> Vec<String> {
 }
 
 /// Fetch ReplicaSets owned by the given Deployment, sorted by revision descending (newest first).
+///
+/// Matches ReplicaSets by the Deployment's UID (not name) so orphaned RSes left behind by a
+/// previously deleted Deployment of the same name are never mistaken for revisions of the
+/// current one.
 async fn fetch_sorted_revisions(
     client: &Client,
     name: &str,
     namespace: &str,
 ) -> Result<Vec<ReplicaSet>> {
+    let deploy_api: Api<Deployment> = Api::namespaced(client.clone(), namespace);
+    let deployment = deploy_api.get(name).await?;
+    let deployment_uid = deployment
+        .metadata
+        .uid
+        .ok_or_else(|| anyhow::anyhow!("Deployment {} has no UID", name))?;
+
     let rs_api: Api<ReplicaSet> = Api::namespaced(client.clone(), namespace);
     let rs_list = rs_api.list(&ListParams::default()).await?;
 
@@ -59,7 +70,7 @@ async fn fetch_sorted_revisions(
         .filter(|rs| {
             rs.metadata.owner_references.as_ref().is_some_and(|refs| {
                 refs.iter()
-                    .any(|r| r.kind == "Deployment" && r.name == name)
+                    .any(|r| r.controller == Some(true) && r.uid == deployment_uid)
             })
         })
         .collect();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -264,6 +264,7 @@ pub fn run() {
             scale_workload,
             restart_workload,
             rollback_deployment,
+            list_deployment_revisions,
             // Port Forwarding
             start_port_forward,
             stop_port_forward,

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -34,11 +34,14 @@ export async function restartWorkload(resource: Resource): Promise<void> {
   await k8sStore.refreshResources();
 }
 
-export async function rollbackDeployment(resource: Resource): Promise<void> {
+export async function rollbackDeployment(
+  resource: Resource,
+  revision?: number,
+): Promise<void> {
   const msg = await invoke<string>("rollback_deployment", {
     name: resource.metadata.name,
     namespace: resource.metadata.namespace ?? "",
-    revision: null,
+    revision: revision ?? null,
   });
   toastStore.success("Rollback successful", msg);
   await k8sStore.refreshResources();

--- a/src/lib/components/details/DeploymentDetails.svelte
+++ b/src/lib/components/details/DeploymentDetails.svelte
@@ -10,6 +10,7 @@
   import SmartAnnotationsCard from "./SmartAnnotationsCard.svelte";
   import RelatedResourcesCard from "./RelatedResourcesCard.svelte";
   import StrategyCard from "./StrategyCard.svelte";
+  import RevisionHistoryCard from "./RevisionHistoryCard.svelte";
   import { formatAge } from "$lib/utils/age";
   import { k8sStore } from "$lib/stores/k8s.svelte";
   import { openResourceDetail } from "$lib/actions/navigation";
@@ -188,6 +189,9 @@
 
   <!-- Strategy & Rollout -->
   <StrategyCard {spec} kind="Deployment" />
+
+  <!-- Revision History -->
+  <RevisionHistoryCard {resource} />
 
   <!-- Activity Timeline -->
   <IncidentTimeline {resource} />

--- a/src/lib/components/details/RevisionHistoryCard.svelte
+++ b/src/lib/components/details/RevisionHistoryCard.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { History } from "lucide-svelte";
+  import { Button } from "$lib/components/ui/button";
+  import ConfirmDialog from "$lib/components/common/ConfirmDialog.svelte";
+  import { rollbackDeployment } from "$lib/actions/registry";
+  import { toastStore } from "$lib/stores/toast.svelte";
+  import { formatAge, formatTimestamp } from "$lib/utils/age";
+  import type { Resource } from "$lib/types";
+
+  interface RevisionInfo {
+    revision: number;
+    name: string;
+    created_at: string | null;
+    images: string[];
+    replicas: number;
+    is_current: boolean;
+  }
+
+  interface Props {
+    resource: Resource;
+  }
+
+  let { resource }: Props = $props();
+
+  let revisions = $state<RevisionInfo[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let pendingRevision = $state<RevisionInfo | null>(null);
+  let rollbackInFlight = $state(false);
+
+  let resourceKey = $derived(
+    `${resource.metadata.namespace ?? ""}:${resource.metadata.name}`,
+  );
+
+  function fetchRevisions(): Promise<RevisionInfo[]> {
+    return invoke<RevisionInfo[]>("list_deployment_revisions", {
+      name: resource.metadata.name,
+      namespace: resource.metadata.namespace ?? "",
+    });
+  }
+
+  $effect(() => {
+    const key = resourceKey;
+    let cancelled = false;
+
+    loading = true;
+    error = null;
+    fetchRevisions()
+      .then((result) => {
+        if (!cancelled) revisions = result;
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          error = String(err);
+          revisions = [];
+        }
+      })
+      .finally(() => {
+        if (!cancelled) loading = false;
+      });
+
+    return () => {
+      cancelled = true;
+      void key;
+    };
+  });
+
+  async function confirmRollback() {
+    if (!pendingRevision) return;
+    const target = pendingRevision;
+    rollbackInFlight = true;
+    try {
+      await rollbackDeployment(resource, target.revision);
+      revisions = await fetchRevisions();
+    } catch (err) {
+      toastStore.error("Rollback failed", String(err));
+    } finally {
+      rollbackInFlight = false;
+      pendingRevision = null;
+    }
+  }
+</script>
+
+<div class="overflow-hidden rounded border border-[var(--border-color)] bg-[var(--bg-secondary)]">
+  <div class="flex items-center justify-between px-5 py-4">
+    <div class="flex items-center gap-2">
+      <History class="h-3.5 w-3.5 text-[var(--text-muted)]" />
+      <h3 class="text-[13px] font-semibold text-[var(--text-primary)]">Revision History</h3>
+    </div>
+    <span class="text-[11px] text-[var(--text-muted)]">
+      {#if loading}
+        loading…
+      {:else}
+        {revisions.length} {revisions.length === 1 ? "revision" : "revisions"}
+      {/if}
+    </span>
+  </div>
+
+  {#if error}
+    <div class="border-t border-[var(--border-hover)] px-5 py-4">
+      <span class="text-xs text-[var(--status-failed)]">Failed to load revisions: {error}</span>
+    </div>
+  {:else if revisions.length > 0}
+    <div class="border-t border-[var(--border-hover)]">
+      <table class="w-full">
+        <thead>
+          <tr class="border-b border-[var(--border-hover)]">
+            <th class="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Rev</th>
+            <th class="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Images</th>
+            <th class="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">Age</th>
+            <th class="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each revisions as rev (rev.name)}
+            <tr class="border-b border-[var(--border-hover)] last:border-b-0">
+              <td class="px-4 py-2.5 text-[12px] font-mono font-medium text-[var(--text-primary)]">
+                <div class="flex items-center gap-2">
+                  <span>#{rev.revision}</span>
+                  {#if rev.is_current}
+                    <span class="rounded bg-[var(--status-running)]/15 px-1.5 py-0.5 text-[10px] font-medium text-[var(--status-running)]">
+                      current
+                    </span>
+                  {/if}
+                </div>
+              </td>
+              <td class="px-4 py-2.5 text-[11px] text-[var(--text-secondary)]">
+                {#if rev.images.length === 0}
+                  <span class="text-[var(--text-muted)]">—</span>
+                {:else}
+                  <div class="flex flex-col gap-0.5">
+                    {#each rev.images as image}
+                      <span class="break-all font-mono">{image}</span>
+                    {/each}
+                  </div>
+                {/if}
+              </td>
+              <td
+                class="px-4 py-2.5 text-[12px] text-[var(--text-muted)]"
+                title={rev.created_at ? formatTimestamp(rev.created_at) : ""}
+              >
+                {rev.created_at ? formatAge(rev.created_at) : "—"}
+              </td>
+              <td class="px-4 py-2.5 text-right">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={rev.is_current || rollbackInFlight}
+                  onclick={() => (pendingRevision = rev)}
+                  title={rev.is_current ? "Already the current revision" : `Rollback to revision ${rev.revision}`}
+                >
+                  Rollback
+                </Button>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {:else if !loading}
+    <div class="border-t border-[var(--border-hover)] px-5 py-4">
+      <span class="text-xs text-[var(--text-muted)]">No revisions found</span>
+    </div>
+  {/if}
+</div>
+
+<ConfirmDialog
+  open={pendingRevision !== null}
+  title="Rollback deployment"
+  description={pendingRevision
+    ? `Rollback ${resource.metadata.name} to revision #${pendingRevision.revision}? Running pods will be replaced with the template from this revision.`
+    : ""}
+  confirmLabel={rollbackInFlight ? "Rolling back..." : "Rollback"}
+  variant="destructive"
+  onconfirm={confirmRollback}
+  oncancel={() => (pendingRevision = null)}
+/>

--- a/src/lib/components/details/RevisionHistoryCard.svelte
+++ b/src/lib/components/details/RevisionHistoryCard.svelte
@@ -44,6 +44,10 @@
     const key = resourceKey;
     let cancelled = false;
 
+    // Dismiss any pending rollback so confirmRollback can't target a deployment
+    // different from the one the user originally opened the dialog on.
+    pendingRevision = null;
+
     loading = true;
     error = null;
     fetchRevisions()


### PR DESCRIPTION
## Summary

- Adds a Revision History card to the Deployment detail panel listing every ReplicaSet owned by the Deployment (revision, images, age, current marker).
- Each row has a Rollback button that targets that specific revision via a confirm dialog. The existing one-click Rollback (to the immediately previous revision) is preserved.
- Backend work consolidates the existing rollback logic behind shared helpers so listing and rollback use the same implementation.

## Backend

- New Tauri command `list_deployment_revisions(name, namespace)` returns sorted `RevisionInfo` entries. `is_current` is flagged on the newest ReplicaSet with running pods, falling back to the newest revision when nothing is scaled up.
- Extracted `fetch_sorted_revisions` and `rs_revision` helpers in `src-tauri/src/k8s/resources/operations.rs`. `rollback_deployment` reuses them and now performs a single `get_client()` call per rollback.
- 4 unit tests cover `rs_revision` parsing (valid, missing, unparseable, `u64::MAX`).

## Frontend

- New `RevisionHistoryCard.svelte` renders the table and a `ConfirmDialog` for the destructive action. Long image names wrap with `break-all` so fully-qualified registry URLs remain readable. Hovering Age shows the exact timestamp via the existing `formatTimestamp` utility.
- `rollbackDeployment(resource, revision?)` accepts an optional revision. Existing callers (header button, command palette) remain on the zero-arg path.
- The fetch `$effect` is keyed on a stable `namespace:name` derived value to avoid refetching on every watch event, with a `cancelled` flag to prevent stale responses from racing when the user switches deployments quickly.

## Test plan

- [ ] On a deployment with multiple revisions, open the detail panel → Revision History lists all ReplicaSets newest-first with the current one marked.
- [ ] Rollback button is disabled on the current revision.
- [ ] Clicking Rollback on a prior revision shows the confirm dialog; confirming triggers a new rollout and a success toast.
- [ ] Switching rapidly between deployments does not surface stale revision lists.
- [ ] The existing header Rollback button (rollback to previous) still works.
- [ ] Long image names like `registry.infra.svc.cluster.local:5000/folio:a22` render fully (no ellipsis).
- [ ] `cargo test --lib operations` → 4/4 pass.
- [ ] `bun test src/lib/actions/registry.test.ts` → 28/28 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Revision History card to deployment details showing revisions with images, creation timestamps, replica counts, and current status.
  * Enabled selecting and rolling back to a specific revision with confirmation and error feedback.
* **Backend**
  * New endpoint to list deployment revisions used by the UI.
* **Tests**
  * Added unit tests validating revision parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->