### PR TITLE
test: priority-1 coverage and clippy/fmt fixes

### DIFF
--- a/src-tauri/benches/resource_serialization.rs
+++ b/src-tauri/benches/resource_serialization.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use k8s_openapi::api::core::v1::Pod;
 use kube::api::ObjectMeta;
-use serde_json;
 use std::collections::BTreeMap;
 
 /// Build a realistic Pod with N containers for benchmarking.

--- a/src-tauri/src/k8s/diagnostics/tests.rs
+++ b/src-tauri/src/k8s/diagnostics/tests.rs
@@ -437,7 +437,7 @@ fn diagnose_deployment_all_replicas_ready_no_warning() {
 
 #[test]
 fn health_unhealthy_when_critical_issue() {
-    let issues = vec![DiagnosticIssue {
+    let issues = [DiagnosticIssue {
         severity: "critical".into(),
         category: "crash".into(),
         title: "test".into(),
@@ -456,7 +456,7 @@ fn health_unhealthy_when_critical_issue() {
 
 #[test]
 fn health_degraded_when_warning_only() {
-    let issues = vec![DiagnosticIssue {
+    let issues = [DiagnosticIssue {
         severity: "warning".into(),
         category: "crash".into(),
         title: "test".into(),
@@ -475,7 +475,7 @@ fn health_degraded_when_warning_only() {
 
 #[test]
 fn health_healthy_when_only_info() {
-    let issues = vec![DiagnosticIssue {
+    let issues = [DiagnosticIssue {
         severity: "info".into(),
         category: "resources".into(),
         title: "test".into(),

--- a/src-tauri/src/k8s/logs.rs
+++ b/src-tauri/src/k8s/logs.rs
@@ -192,14 +192,14 @@ mod tests {
 
     #[test]
     fn batch_size_constant_is_reasonable() {
-        assert!(LOG_BATCH_SIZE > 0);
-        assert!(LOG_BATCH_SIZE <= 100);
+        const { assert!(LOG_BATCH_SIZE > 0) };
+        const { assert!(LOG_BATCH_SIZE <= 100) };
     }
 
     #[test]
     fn flush_interval_constant_is_reasonable() {
-        assert!(LOG_FLUSH_INTERVAL_MS > 0);
-        assert!(LOG_FLUSH_INTERVAL_MS <= 1000);
+        const { assert!(LOG_FLUSH_INTERVAL_MS > 0) };
+        const { assert!(LOG_FLUSH_INTERVAL_MS <= 1000) };
     }
 
     // -----------------------------------------------------------------------
@@ -309,15 +309,15 @@ mod tests {
     fn batch_size_and_flush_interval_are_compatible() {
         // The batch size should be small enough that flushing is responsive,
         // and the flush interval should be short enough for real-time streaming.
-        assert!(
-            LOG_BATCH_SIZE <= 50,
-            "Batch size {} too large for responsive log streaming",
-            LOG_BATCH_SIZE
-        );
-        assert!(
-            LOG_FLUSH_INTERVAL_MS <= 200,
-            "Flush interval {}ms too long for real-time streaming",
-            LOG_FLUSH_INTERVAL_MS
-        );
+        const {
+            assert!(
+                LOG_BATCH_SIZE <= 50,
+                "Batch size too large for responsive log streaming",
+            );
+            assert!(
+                LOG_FLUSH_INTERVAL_MS <= 200,
+                "Flush interval too long for real-time streaming",
+            );
+        }
     }
 }

--- a/src-tauri/src/k8s/resources/operations.rs
+++ b/src-tauri/src/k8s/resources/operations.rs
@@ -75,7 +75,7 @@ async fn fetch_sorted_revisions(
         })
         .collect();
 
-    owned.sort_by(|a, b| rs_revision(b).cmp(&rs_revision(a)));
+    owned.sort_by_key(|rs| std::cmp::Reverse(rs_revision(rs)));
     Ok(owned)
 }
 
@@ -286,7 +286,10 @@ mod tests {
     fn rs_with_revision(rev: Option<&str>) -> ReplicaSet {
         let annotations = rev.map(|v| {
             let mut m = BTreeMap::new();
-            m.insert("deployment.kubernetes.io/revision".to_string(), v.to_string());
+            m.insert(
+                "deployment.kubernetes.io/revision".to_string(),
+                v.to_string(),
+            );
             m
         });
         ReplicaSet {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,50 +126,6 @@ fn build_env_filter() -> tracing_subscriber::EnvFilter {
 }
 
 // ===========================================================================
-// Tests for infrastructure code
-// ===========================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::{clear_k8s_version_cache, get_hostname, get_os_version, k8s_version_cache};
-
-    #[test]
-    fn app_metadata_static_fields() {
-        assert!(!env!("CARGO_PKG_VERSION").is_empty());
-        assert!(!std::env::consts::OS.is_empty());
-        assert!(!std::env::consts::ARCH.is_empty());
-    }
-
-    #[test]
-    fn os_version_returns_nonempty_string() {
-        let version = get_os_version();
-        assert!(!version.is_empty());
-    }
-
-    #[tokio::test]
-    async fn k8s_version_cache_clear_works() {
-        {
-            let mut guard = k8s_version_cache().lock().await;
-            *guard = Some("1.28".to_string());
-        }
-        {
-            let guard = k8s_version_cache().lock().await;
-            assert_eq!(guard.as_deref(), Some("1.28"));
-        }
-        clear_k8s_version_cache().await;
-        {
-            let guard = k8s_version_cache().lock().await;
-            assert!(guard.is_none());
-        }
-    }
-
-    #[test]
-    fn hostname_resolves() {
-        assert!(!get_hostname().is_empty());
-    }
-}
-
-// ===========================================================================
 // App entry point
 // ===========================================================================
 
@@ -312,3 +268,46 @@ pub fn run() {
         .expect("error while running Tauri application");
 }
 
+// ===========================================================================
+// Tests for infrastructure code
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{clear_k8s_version_cache, get_hostname, get_os_version, k8s_version_cache};
+
+    #[test]
+    fn app_metadata_static_fields() {
+        assert!(!env!("CARGO_PKG_VERSION").is_empty());
+        assert!(!std::env::consts::OS.is_empty());
+        assert!(!std::env::consts::ARCH.is_empty());
+    }
+
+    #[test]
+    fn os_version_returns_nonempty_string() {
+        let version = get_os_version();
+        assert!(!version.is_empty());
+    }
+
+    #[tokio::test]
+    async fn k8s_version_cache_clear_works() {
+        {
+            let mut guard = k8s_version_cache().lock().await;
+            *guard = Some("1.28".to_string());
+        }
+        {
+            let guard = k8s_version_cache().lock().await;
+            assert_eq!(guard.as_deref(), Some("1.28"));
+        }
+        clear_k8s_version_cache().await;
+        {
+            let guard = k8s_version_cache().lock().await;
+            assert!(guard.is_none());
+        }
+    }
+
+    #[test]
+    fn hostname_resolves() {
+        assert!(!get_hostname().is_empty());
+    }
+}

--- a/src-tauri/tests/integration_operations.rs
+++ b/src-tauri/tests/integration_operations.rs
@@ -169,12 +169,7 @@ async fn cleanup_configmap(client: &Client, ns: &str, name: &str) {
 }
 
 /// Create a Deployment and wait until its current generation is observed and all replicas report available.
-async fn create_and_wait_deployment(
-    client: &Client,
-    ns: &str,
-    deploy: Deployment,
-    timeout_s: u64,
-) {
+async fn create_and_wait_deployment(client: &Client, ns: &str, deploy: Deployment, timeout_s: u64) {
     let api: Api<Deployment> = Api::namespaced(client.clone(), ns);
     let created = api
         .create(&PostParams::default(), &deploy)
@@ -214,7 +209,10 @@ async fn wait_for_rollout(client: &Client, ns: &str, name: &str, timeout_s: u64)
             }
         }
         if std::time::Instant::now() >= deadline {
-            panic!("rollout for {} did not complete within {}s", name, timeout_s);
+            panic!(
+                "rollout for {} did not complete within {}s",
+                name, timeout_s
+            );
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
@@ -753,4 +751,115 @@ async fn integration_delete_resource_with_uid_precondition_mismatch_errors() {
 
     // Ensure the apiserver actually observes the object as gone.
     wait_for_deleted(&api, name, 10).await;
+}
+
+#[tokio::test]
+async fn integration_delete_resource_with_resource_version_mismatch_errors() {
+    fresh_client();
+    let ns = test_namespace();
+    let name = "op-delete-rv-precond";
+
+    let client = kube_client().await;
+    cleanup_configmap(&client, &ns, name).await;
+
+    // Create a ConfigMap to target.
+    let api: Api<ConfigMap> = Api::namespaced(client.clone(), &ns);
+    let mut data = BTreeMap::new();
+    data.insert("k".to_string(), "v".to_string());
+    let cm = ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(ns.clone()),
+            ..Default::default()
+        },
+        data: Some(data),
+        ..Default::default()
+    };
+    api.create(&PostParams::default(), &cm).await.unwrap();
+
+    // Issue delete with an intentionally-wrong resourceVersion precondition.
+    // "0" is reserved by the apiserver for resource-version-unset semantics and
+    // will never match a real revision, so the delete must be rejected.
+    let res = delete_resource("configmap", name, &ns, None, Some("0")).await;
+
+    assert!(
+        res.is_err(),
+        "delete_resource with a mismatched resourceVersion precondition should fail"
+    );
+
+    // The target must still exist — a rejected precondition means no-op.
+    assert!(
+        api.get(name).await.is_ok(),
+        "configmap should still exist after a rejected delete"
+    );
+
+    // Happy-path delete with the real resourceVersion.
+    let real = api.get(name).await.unwrap();
+    let real_rv = real
+        .metadata
+        .resource_version
+        .clone()
+        .expect("created configmap should expose a resourceVersion");
+    delete_resource("configmap", name, &ns, None, Some(&real_rv))
+        .await
+        .expect("delete with correct resourceVersion should succeed");
+
+    wait_for_deleted(&api, name, 10).await;
+}
+
+// ---------------------------------------------------------------------------
+// rollback_deployment — only one revision path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_rollback_deployment_only_one_revision_errors() {
+    fresh_client();
+    let ns = test_namespace();
+    let name = "op-rollback-single";
+
+    let client = kube_client().await;
+    // Fresh deployment = exactly one ReplicaSet, so there is no "previous".
+    setup_basic_deployment(&client, &ns, name).await;
+
+    let result = rollback_deployment(name, &ns, None).await;
+    let err = result.expect_err("rollback without a previous revision should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("no previous revision"),
+        "error should mention the missing previous revision, got: {}",
+        msg
+    );
+
+    cleanup_deployment(&client, &ns, name).await;
+}
+
+// ---------------------------------------------------------------------------
+// apply_resource_yaml — unknown kind path
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_apply_resource_yaml_invalid_kind_errors() {
+    fresh_client();
+
+    // Use an obviously-invalid kind. No namespace or resources are created.
+    let yaml = r#"apiVersion: nonsense.kdashboard.test/v1
+kind: FooBarBaz
+metadata:
+  name: should-not-apply
+  namespace: default
+spec:
+  irrelevant: true
+"#;
+
+    let result = apply_resource_yaml(yaml).await;
+    let err = result.expect_err("apply_resource_yaml with unknown kind should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.to_lowercase().contains("foobarbaz")
+            || msg.to_lowercase().contains("unsupported")
+            || msg.to_lowercase().contains("unknown")
+            || msg.to_lowercase().contains("not found"),
+        "error should mention the unknown kind, got: {}",
+        msg
+    );
 }

--- a/src/lib/utils/k8s-helpers.test.ts
+++ b/src/lib/utils/k8s-helpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { getContainerState, resolveJsonPath, toggleSetItem } from "./k8s-helpers";
+
+describe("getContainerState", () => {
+  test("returns Running when running key is present", () => {
+    expect(getContainerState({ running: { startedAt: "2026-01-01T00:00:00Z" } })).toBe("Running");
+  });
+
+  test("returns waiting reason when present", () => {
+    expect(getContainerState({ waiting: { reason: "ImagePullBackOff" } })).toBe("ImagePullBackOff");
+  });
+
+  test("returns Waiting fallback when waiting has no reason", () => {
+    expect(getContainerState({ waiting: {} })).toBe("Waiting");
+  });
+
+  test("returns terminated reason when present", () => {
+    expect(getContainerState({ terminated: { reason: "Completed", exitCode: 0 } })).toBe(
+      "Completed",
+    );
+  });
+
+  test("returns Terminated fallback when terminated has no reason", () => {
+    expect(getContainerState({ terminated: {} })).toBe("Terminated");
+  });
+
+  test("returns Unknown when no known state key is present", () => {
+    expect(getContainerState({})).toBe("Unknown");
+  });
+
+  test("Running wins over other keys when both present (order of precedence)", () => {
+    expect(getContainerState({ running: {}, waiting: { reason: "X" } })).toBe("Running");
+  });
+});
+
+describe("toggleSetItem", () => {
+  test("adds missing key and returns a new Set", () => {
+    const original = new Set(["a"]);
+    const next = toggleSetItem(original, "b");
+    expect(next.has("a")).toBe(true);
+    expect(next.has("b")).toBe(true);
+    expect(next).not.toBe(original);
+    expect(original.has("b")).toBe(false);
+  });
+
+  test("removes existing key and returns a new Set", () => {
+    const original = new Set(["a", "b"]);
+    const next = toggleSetItem(original, "a");
+    expect(next.has("a")).toBe(false);
+    expect(next.has("b")).toBe(true);
+    expect(original.has("a")).toBe(true);
+  });
+
+  test("round-trip toggle returns equivalent Set", () => {
+    const original = new Set(["x"]);
+    const toggled = toggleSetItem(original, "x");
+    const back = toggleSetItem(toggled, "x");
+    expect(back.has("x")).toBe(true);
+    expect(back.size).toBe(1);
+  });
+});
+
+describe("resolveJsonPath", () => {
+  const base = {
+    metadata: { name: "nginx-1", namespace: "default" },
+    status: {
+      phase: "Running",
+      replicas: 3,
+      ready: true,
+      containerStatuses: [{ name: "web", ready: true }],
+    },
+    spec: {
+      replicas: 5,
+      template: { spec: { containers: [{ name: "web", image: "nginx:1.25" }] } },
+    },
+  };
+
+  test("resolves .metadata.name", () => {
+    expect(resolveJsonPath(base, ".metadata.name")).toBe("nginx-1");
+  });
+
+  test("resolves .metadata.namespace", () => {
+    expect(resolveJsonPath(base, ".metadata.namespace")).toBe("default");
+  });
+
+  test("returns empty string for unknown metadata field", () => {
+    expect(resolveJsonPath(base, ".metadata.labels")).toBe("");
+  });
+
+  test("returns empty string when metadata.name is missing", () => {
+    expect(resolveJsonPath({ metadata: {} }, ".metadata.name")).toBe("");
+  });
+
+  test("resolves a top-level string in status", () => {
+    expect(resolveJsonPath(base, ".status.phase")).toBe("Running");
+  });
+
+  test("stringifies numeric values", () => {
+    expect(resolveJsonPath(base, ".status.replicas")).toBe("3");
+  });
+
+  test("stringifies boolean values", () => {
+    expect(resolveJsonPath(base, ".status.ready")).toBe("true");
+  });
+
+  test("resolves an array element by numeric index", () => {
+    expect(resolveJsonPath(base, ".status.containerStatuses.0.name")).toBe("web");
+  });
+
+  test("resolves nested spec path", () => {
+    expect(resolveJsonPath(base, ".spec.template.spec.containers.0.image")).toBe("nginx:1.25");
+  });
+
+  test("JSON-stringifies object leaves", () => {
+    const result = resolveJsonPath(base, ".status.containerStatuses.0");
+    expect(result).toBe(JSON.stringify(base.status.containerStatuses[0]));
+  });
+
+  test("returns empty string when status is missing", () => {
+    expect(resolveJsonPath({ metadata: {} }, ".status.phase")).toBe("");
+  });
+
+  test("returns empty string when spec is missing", () => {
+    expect(resolveJsonPath({ metadata: {} }, ".spec.replicas")).toBe("");
+  });
+
+  test("returns empty string when intermediate key is missing", () => {
+    expect(resolveJsonPath(base, ".spec.template.doesNotExist.value")).toBe("");
+  });
+
+  test("returns empty string when root path is neither status, spec, nor metadata", () => {
+    expect(resolveJsonPath(base, ".unknown.field")).toBe("");
+  });
+
+  test("accepts path without leading dot", () => {
+    expect(resolveJsonPath(base, "status.phase")).toBe("Running");
+  });
+
+  test("returns empty string for null intermediate value", () => {
+    const r = { metadata: {}, status: { nested: null as unknown as Record<string, unknown> } };
+    expect(resolveJsonPath(r, ".status.nested.field")).toBe("");
+  });
+});

--- a/src/lib/utils/k8s-schema-resolver.test.ts
+++ b/src/lib/utils/k8s-schema-resolver.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { getFieldInfo, resolveSchemaAtPath } from "./k8s-schema-resolver";
+
+describe("resolveSchemaAtPath — array traversal", () => {
+  test("numeric segment stays within the same field map (behavior pin)", () => {
+    // Design: numeric segments are skipped. When a path has a numeric index
+    // WITHOUT the preceding array key, the index alone does not navigate.
+    // This test pins that behavior so a refactor does not silently change it.
+    const fields = resolveSchemaAtPath("Pod", ["spec", "containers", "0"]);
+    expect(fields).not.toBeNull();
+    expect(fields?.name?.required).toBe(true);
+
+    // Same path without the numeric index also resolves (numeric is a no-op):
+    const fieldsNoIndex = resolveSchemaAtPath("Pod", ["spec", "containers"]);
+    // Without the index, we land on the array field's item children (same map):
+    expect(fieldsNoIndex).not.toBeNull();
+    expect(fieldsNoIndex?.name?.required).toBe(true);
+  });
+
+  test("double numeric segment does not double-descend", () => {
+    // Two consecutive numeric indices on an object-array descend once.
+    const fields = resolveSchemaAtPath("Pod", ["spec", "containers", "0", "0"]);
+    expect(fields).not.toBeNull();
+    expect(fields?.name?.required).toBe(true);
+  });
+
+  test("deep nested array item fields resolve", () => {
+    const fields = resolveSchemaAtPath("Pod", [
+      "spec",
+      "containers",
+      "0",
+      "ports",
+      "0",
+    ]);
+    expect(fields).not.toBeNull();
+    expect(fields?.containerPort?.required).toBe(true);
+    expect(fields?.protocol?.enum).toContain("TCP");
+    expect(fields?.protocol?.enum).toContain("UDP");
+  });
+});
+
+describe("resolveSchemaAtPath — null paths", () => {
+  test("returns null for unknown kind even with empty path", () => {
+    expect(resolveSchemaAtPath("FooBar", [])).toBeNull();
+  });
+
+  test("returns null when a mid-path key does not exist", () => {
+    expect(resolveSchemaAtPath("Pod", ["spec", "doesNotExist"])).toBeNull();
+  });
+
+  test("returns null when path descends past a leaf string field", () => {
+    // restartPolicy is a string leaf; descending past it should return null.
+    expect(resolveSchemaAtPath("Pod", ["spec", "restartPolicy"])).toBeNull();
+    expect(resolveSchemaAtPath("Pod", ["spec", "restartPolicy", "child"])).toBeNull();
+  });
+
+  test("returns null for an array field of non-object items", () => {
+    // hostAliases.ip-like arrays or string arrays should not descend into children.
+    // Service.spec.externalIPs is string[]; walking past it returns null.
+    const direct = resolveSchemaAtPath("Service", ["spec", "externalIPs"]);
+    expect(direct).toBeNull();
+  });
+});
+
+describe("resolveSchemaAtPath — entry points", () => {
+  test("empty path returns top-level schema for known kind", () => {
+    const fields = resolveSchemaAtPath("Pod", []);
+    expect(fields).not.toBeNull();
+    expect(fields?.apiVersion).toBeDefined();
+    expect(fields?.kind).toBeDefined();
+    expect(fields?.metadata).toBeDefined();
+    expect(fields?.spec).toBeDefined();
+  });
+
+  test("resolves metadata object children (common to all kinds)", () => {
+    const fields = resolveSchemaAtPath("Deployment", ["metadata"]);
+    expect(fields).not.toBeNull();
+    expect(fields?.name?.required).toBe(true);
+    expect(fields?.namespace).toBeDefined();
+  });
+});
+
+describe("getFieldInfo", () => {
+  test("returns the field when kind, path, and key are valid", () => {
+    const field = getFieldInfo("Pod", ["spec", "containers", "0"], "image");
+    expect(field).not.toBeNull();
+    expect(field?.required).toBe(true);
+    expect(field?.type).toBe("string");
+  });
+
+  test("returns null for unknown kind", () => {
+    expect(getFieldInfo("UnknownKind", ["metadata"], "name")).toBeNull();
+  });
+
+  test("returns null when the path is invalid", () => {
+    expect(getFieldInfo("Pod", ["spec", "doesNotExist"], "anything")).toBeNull();
+  });
+
+  test("returns null when the key does not exist at a valid path", () => {
+    expect(getFieldInfo("Pod", ["metadata"], "thisFieldDoesNotExist")).toBeNull();
+  });
+
+  test("returns enum info for fields that declare enum values", () => {
+    const field = getFieldInfo("Pod", ["spec", "containers", "0", "ports", "0"], "protocol");
+    expect(field).not.toBeNull();
+    expect(field?.enum).toEqual(expect.arrayContaining(["TCP", "UDP"]));
+  });
+});


### PR DESCRIPTION
## Summary

Addresses priority-1 findings from the test review session:

- **Unblocks CI**: `cargo clippy --all-targets --features integration -- -D warnings` and `cargo fmt --check` now pass.
- **Fills real test gaps** identified by the multi-agent review (rust-reviewer + typescript-reviewer): 3 Rust integration tests and 40 TypeScript unit tests targeting untested branches.

Stacked on `test/integration-operations-watch-logs` so the diff shows only the new work.

## Changes

### `chore: satisfy clippy -D warnings and fmt` (716bd2e)
- `operations.rs`: `sort_by` -> `sort_by_key(|rs| Reverse(rs_revision(rs)))`
- `lib.rs`: move `#[cfg(test)] mod tests` below `run()` (items-after-test-module)
- `logs.rs`: wrap compile-time invariants in `const { assert!(...) }`
- `diagnostics/tests.rs`: replace single-element `vec![...]` with array literals
- `resource_serialization.rs` bench: drop redundant `use serde_json;`

### `test: add priority-1 coverage for operations and k8s utils` (26f37d4)

**TypeScript (`bun test`), 40 new tests:**
- `src/lib/utils/k8s-helpers.test.ts` — `getContainerState`, `toggleSetItem`, `resolveJsonPath` (array indexing, missing keys, JSON leaves, null intermediates, path without leading dot).
- `src/lib/utils/k8s-schema-resolver.test.ts` — pins real behavior of `resolveSchemaAtPath` / `getFieldInfo` (numeric segment no-op, descend past leaf, array of primitives, unknown kind, enum info).

**Rust integration (`--features integration`), 3 new tests in `integration_operations.rs`:**
- `delete_resource_with_resource_version_mismatch_errors` — covers the `resourceVersion` precondition branch in `operations.rs:150` (previously only UID was tested).
- `rollback_deployment_only_one_revision_errors` — covers `sorted_rs.get(1)` no-previous path so a refactor cannot silence the `No previous revision found` error seen by users.
- `apply_resource_yaml_invalid_kind_errors` — covers `api_resource_for_kind` failure on unknown kinds so the YAML editor surfaces a clear error.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --features integration -- -D warnings` passes
- [x] `cargo test --lib` — 274 pass
- [x] `bun test` — 768 pass (was 728, +40 added)
- [x] `cargo check --tests --features integration` compiles clean
- [ ] `cargo test --features integration` — run locally against Kind once cluster is available (the 3 new tests were only compile-checked here because no cluster was reachable)