### PR TITLE
refactor(app): extract tab lifecycle, LazyView, and per-phase init errors

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,9 +12,7 @@
   import PortForwardView from "$lib/components/port-forwards/PortForwardView.svelte";
   import YamlEditor from "$lib/components/details/YamlEditor.svelte";
   import TabBar from "$lib/components/tabs/TabBar.svelte";
-  // Lazy-loaded views (secondary, not always needed)
-  // SettingsView, TopologyView, CostView, SecurityView are loaded via
-  // dynamic import below.
+  import LazyView from "$lib/components/common/LazyView.svelte";
   import { ToastContainer } from "$lib/components/ui/toast";
   import ContextMenu from "$lib/components/context-menu/ContextMenu.svelte";
   import UpdateBanner from "$lib/components/common/UpdateBanner.svelte";
@@ -23,70 +21,18 @@
   import ConfirmDialog from "$lib/components/common/ConfirmDialog.svelte";
   import { extensions } from "$lib/extensions";
   import { k8sStore } from "$lib/stores/k8s.svelte";
-  import { uiStore, RESOURCE_TAB_TYPES } from "$lib/stores/ui.svelte";
+  import { uiStore, viewShowsTitleBar } from "$lib/stores/ui.svelte";
   import { settingsStore } from "$lib/stores/settings.svelte";
   import { dialogStore } from "$lib/stores/dialogs.svelte";
-  import { toastStore } from "$lib/stores/toast.svelte";
+  import { deleteResource } from "$lib/actions/registry";
   import { initKeyboardShortcuts } from "$lib/utils/keyboard";
+  import { handleTabSwitch } from "$lib/utils/tabLifecycle";
 
-  // Synchronous hook: restore cached data BEFORE the view changes (prevents empty state flash)
+  // Synchronous hook: restore cached data BEFORE the view changes
+  // (prevents empty state flash). Implementation lives in tabLifecycle
+  // util so the race-guard + namespace sync logic is unit-testable.
   uiStore.onBeforeTabSwitch = (fromTab, toTab) => {
-    // Save outgoing tab's selected resource
-    if (fromTab && RESOURCE_TAB_TYPES.has(fromTab.type) && k8sStore.selectedResource) {
-      fromTab.cachedResource = k8sStore.selectedResource;
-    }
-    // Skip save when store holds a different resource_type (in-flight load).
-    if (fromTab && (fromTab.type === "table" || fromTab.type === "crd-table")) {
-      if (
-        fromTab.resourceType &&
-        k8sStore.resources.resource_type === fromTab.resourceType
-      ) {
-        fromTab.cachedItems = k8sStore.resources.items;
-        fromTab.count = k8sStore.resources.items.length;
-        fromTab.cacheReady = true;
-      }
-    }
-
-    // Restore incoming tab's selected resource
-    if (RESOURCE_TAB_TYPES.has(toTab.type) && toTab.cachedResource) {
-      k8sStore.selectedResource = toTab.cachedResource;
-    }
-
-    if ((toTab.type === "table" || toTab.type === "crd-table") && toTab.resourceType) {
-      if (toTab.cacheReady && toTab.cachedItems) {
-        // Cached: set namespace synchronously (no async switchNamespace to avoid race)
-        if (toTab.namespace !== undefined && toTab.namespace !== k8sStore.currentNamespace) {
-          k8sStore.currentNamespace = toTab.namespace;
-        }
-        k8sStore.restoreResources(toTab.resourceType, toTab.cachedItems);
-      } else {
-        // No cache: fetch. Set the type first so switchNamespace's internal
-        // load picks up the new resourceType and we don't fire two concurrent
-        // list_resources calls.
-        k8sStore.setResourceType(toTab.resourceType);
-        toTab.cacheReady = false;
-        const expectedType = toTab.resourceType;
-        const needsNamespaceSwitch =
-          toTab.namespace !== undefined && toTab.namespace !== k8sStore.currentNamespace;
-
-        let loadPromise: Promise<void>;
-        if (needsNamespaceSwitch) {
-          loadPromise = k8sStore.switchNamespace(toTab.namespace!);
-        } else {
-          k8sStore.isLoading = true;
-          k8sStore.resources = { items: [], resource_type: toTab.resourceType };
-          loadPromise = k8sStore.loadResources(toTab.resourceType);
-        }
-
-        loadPromise.then(() => {
-          if (k8sStore.selectedResourceType === expectedType && !k8sStore.error) {
-            toTab.cachedItems = k8sStore.resources.items;
-            toTab.count = k8sStore.resources.items.length;
-            toTab.cacheReady = true;
-          }
-        });
-      }
-    }
+    handleTabSwitch(fromTab, toTab, k8sStore);
   };
 
   // When namespace changes, save it to the active tab and invalidate cache.
@@ -111,20 +57,7 @@
     const resource = dialogStore.deleteResource;
     if (!resource) return;
     dialogStore.closeDelete();
-    try {
-      await invoke("delete_resource", {
-        kind: resource.kind,
-        name: resource.metadata.name,
-        namespace: resource.metadata.namespace ?? "",
-        uid: resource.metadata.uid,
-        resource_version: resource.metadata.resource_version,
-      });
-      toastStore.success("Resource deleted", `${resource.kind} "${resource.metadata.name}" deleted`);
-      k8sStore.selectResource(null);
-      await k8sStore.refreshResources();
-    } catch (err) {
-      toastStore.error("Delete failed", String(err));
-    }
+    await deleteResource(resource);
   }
 
   let cleanupKeyboard: (() => void) | undefined;
@@ -138,41 +71,68 @@
   });
 
   async function initApp() {
-    // Phase 1: Settings (fast, reads from Rust state)
     try {
       await settingsStore.loadSettings();
-    } catch {
-      // Defaults already applied
+    } catch (err) {
+      // Defaults already applied — log so debugging isn't blind.
+      console.error("[initApp] settings load failed (using defaults)", err);
     }
 
-    // Phase 3: Close splash now — app is visible with theme
+    // Close splash before the (possibly slow) cluster connection so the
+    // themed UI is visible while k8s calls hang.
     invoke("close_splashscreen").catch(() => {});
 
-    // Phase 3: K8s connection (can hang — app is already visible)
+    // Per-step try/catch so a late failure doesn't mask an earlier one and
+    // the user message reflects the real cause.
     try {
       await k8sStore.loadContexts();
+    } catch (err) {
+      console.error("[initApp] loadContexts failed", err);
+      k8sStore.connectionStatus = "error";
+      k8sStore.error = "Failed to load kubeconfig contexts. Check your kubeconfig file.";
+      return;
+    }
+
+    try {
       await k8sStore.restoreConnection(
         settingsStore.settings.context,
         settingsStore.settings.namespace,
       );
-      await k8sStore.loadNamespaces();
-      k8sStore.loadAllResourceCounts();
-    } catch {
+    } catch (err) {
+      console.error("[initApp] restoreConnection failed", err);
       k8sStore.connectionStatus = "error";
-      k8sStore.error = "Failed to connect to cluster. Check your kubeconfig.";
+      k8sStore.error = "Failed to connect to cluster. Check your kubeconfig credentials.";
+      return;
     }
+
+    try {
+      await k8sStore.loadNamespaces();
+    } catch (err) {
+      console.error("[initApp] loadNamespaces failed", err);
+      k8sStore.connectionStatus = "error";
+      k8sStore.error = "Connected, but failed to list namespaces. Check RBAC permissions.";
+      return;
+    }
+
+    // Fire-and-forget: sidebar counts are nice-to-have, never block init.
+    k8sStore.loadAllResourceCounts();
   }
 </script>
 
+<!--
+  Global contextmenu handler prevents the native browser menu everywhere.
+  Individual components (table rows, editors) stop propagation to show
+  their own menus. The a11y_no_static_element_interactions warning is
+  suppressed because this div is a chrome container, not an interactive
+  control.
+-->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="sidebar-grid h-screen w-screen select-none overflow-hidden bg-[var(--bg-primary)]"
-  style="grid-template-columns: {uiStore.sidebarCollapsed ? 44 : 260}px 1fr"
-  oncontextmenu={(e) => {
-    // Prevent default browser context menu app-wide
-    // Individual components (table rows) handle their own contextmenu
-    e.preventDefault();
-  }}
+  style="grid-template-columns: {uiStore.sidebarCollapsed
+    ? 'var(--sidebar-width-collapsed)'
+    : 'var(--sidebar-width-expanded)'} 1fr"
+  oncontextmenu={(e) => e.preventDefault()}
 >
   <!-- Sidebar -->
   <Sidebar />
@@ -184,19 +144,18 @@
       <!-- Tab Bar -->
       <TabBar />
 
-      <!-- Title Bar / Header (hidden in detail view which has its own header) -->
-      {#if uiStore.activeView === "table" || uiStore.activeView === "crd-table" || uiStore.activeView === "portforwards" || uiStore.activeView === "topology" || uiStore.activeView === "cost" || uiStore.activeView === "security"}
+      <!-- Title Bar (hidden in views that render their own header) -->
+      {#if viewShowsTitleBar(uiStore.activeView)}
         <TitleBar />
       {/if}
 
       <!-- Content Area: one view at a time -->
       <div class="min-h-0 flex-1">
         {#if uiStore.activeView === "overview"}
-          {#await import("$lib/components/overview/OverviewDashboard.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load overview.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/overview/OverviewDashboard.svelte")}
+            name="overview"
+          />
         {:else if uiStore.activeView === "table"}
           <ResourceTable />
         {:else if uiStore.activeView === "details"}
@@ -210,35 +169,30 @@
         {:else if uiStore.activeView === "yaml"}
           <YamlEditor />
         {:else if uiStore.activeView === "settings"}
-          {#await import("$lib/components/settings/SettingsView.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load settings view.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/settings/SettingsView.svelte")}
+            name="settings"
+          />
         {:else if uiStore.activeView === "topology"}
-          {#await import("$lib/components/topology/TopologyView.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load topology view.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/topology/TopologyView.svelte")}
+            name="topology"
+          />
         {:else if uiStore.activeView === "cost"}
-          {#await import("$lib/components/cost/CostView.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load cost view.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/cost/CostView.svelte")}
+            name="cost"
+          />
         {:else if uiStore.activeView === "security"}
-          {#await import("$lib/components/security/SecurityView.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load security view.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/security/SecurityView.svelte")}
+            name="security"
+          />
         {:else if uiStore.activeView === "crd-table"}
-          {#await import("$lib/components/crd/CrdTableView.svelte") then mod}
-            <mod.default />
-          {:catch}
-            <p class="p-4 text-xs text-[var(--status-failed)]">Failed to load CRD view.</p>
-          {/await}
+          <LazyView
+            loader={() => import("$lib/components/crd/CrdTableView.svelte")}
+            name="CRDs"
+          />
         {/if}
       </div>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -115,7 +115,9 @@
     }
 
     // Fire-and-forget: sidebar counts are nice-to-have, never block init.
-    k8sStore.loadAllResourceCounts();
+    void k8sStore.loadAllResourceCounts().catch((err) => {
+      console.error("[initApp] loadAllResourceCounts failed", err);
+    });
   }
 </script>
 

--- a/src/app.css
+++ b/src/app.css
@@ -13,6 +13,12 @@ html, body {
   color: var(--text-primary, #E5E5E5);
 }
 
+/* Layout tokens (theme-agnostic) */
+:root {
+  --sidebar-width-collapsed: 44px;
+  --sidebar-width-expanded: 260px;
+}
+
 /* ========================================
    kdashboard v2 - Theme System
    11 Theme Presets with CSS Variables

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -47,6 +47,29 @@ export async function rollbackDeployment(
   await k8sStore.refreshResources();
 }
 
+/** Callers that opened a confirmation dialog should close it BEFORE calling. */
+export async function deleteResource(resource: Resource): Promise<void> {
+  try {
+    await invoke("delete_resource", {
+      kind: resource.kind,
+      name: resource.metadata.name,
+      namespace: resource.metadata.namespace ?? "",
+      uid: resource.metadata.uid,
+      resource_version: resource.metadata.resource_version,
+    });
+    toastStore.success(
+      "Resource deleted",
+      `${resource.kind} "${resource.metadata.name}" deleted`,
+    );
+    if (k8sStore.selectedResource?.metadata.uid === resource.metadata.uid) {
+      k8sStore.selectResource(null);
+    }
+    await k8sStore.refreshResources();
+  } catch (err) {
+    toastStore.error("Delete failed", String(err));
+  }
+}
+
 /** Wrapper that passes live port-forwards from the k8s store */
 function getResourceUrlWithPf(resource: Resource): string | null {
   return getResourceUrlPure(resource, k8sStore.portForwards as any);

--- a/src/lib/components/common/LazyView.svelte
+++ b/src/lib/components/common/LazyView.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Component } from "svelte";
+
+  interface Props {
+    loader: () => Promise<{ default: Component }>;
+    /** Display label used in the error fallback (e.g. "overview", "settings"). */
+    name: string;
+  }
+
+  const { loader, name }: Props = $props();
+
+  // Pin the promise to this component instance so parent re-renders (which
+  // pass a fresh arrow for `loader`) don't trigger a remount of the loaded
+  // view. A real re-import happens naturally when the parent's {#if} branch
+  // changes, because that mounts a new LazyView instance.
+  // svelte-ignore state_referenced_locally
+  const promise = loader();
+</script>
+
+{#await promise then mod}
+  <mod.default />
+{:catch}
+  <p class="p-4 text-xs text-[var(--status-failed)]">
+    Failed to load {name} view.
+  </p>
+{/await}

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -40,6 +40,24 @@ const SINGLETON_VIEWS = new Set<ActiveView>(["overview", "settings", "topology",
 /** View types tied to a specific resource (cache selectedResource on tab switch) */
 export const RESOURCE_TAB_TYPES = new Set<ActiveView>(["details", "logs", "yaml", "terminal"]);
 
+/**
+ * View types that render their own header and should suppress the global
+ * `<TitleBar />`. Kept as the allowlist's *complement* because new views
+ * default to having a title bar (fail safe — surface > hide).
+ */
+const VIEWS_WITHOUT_TITLE_BAR = new Set<ActiveView>([
+  "overview",
+  "details",
+  "logs",
+  "terminal",
+  "yaml",
+  "settings",
+]);
+
+export function viewShowsTitleBar(view: ActiveView): boolean {
+  return !VIEWS_WITHOUT_TITLE_BAR.has(view);
+}
+
 /** Canonical display labels for each view type */
 export const VIEW_LABELS: Record<ActiveView, string> = {
   overview: "Overview", table: "Resources", details: "Detail",

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -6,10 +6,11 @@ import {
   type Tab,
   RESOURCE_TAB_TYPES,
   VIEW_LABELS,
+  viewShowsTitleBar,
 } from "./ui.logic.js";
 
 export type { ActiveView, Tab };
-export { RESOURCE_TAB_TYPES, VIEW_LABELS };
+export { RESOURCE_TAB_TYPES, VIEW_LABELS, viewShowsTitleBar };
 
 class UiStore extends UiStoreLogic {
   override sidebarCollapsed = $state<boolean>(false);

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { UiStoreLogic, resetTabCounter } from "./ui.logic.js";
+import {
+  UiStoreLogic,
+  resetTabCounter,
+  viewShowsTitleBar,
+  type ActiveView,
+} from "./ui.logic.js";
 
 describe("UiStore", () => {
   let store: UiStoreLogic;
@@ -319,6 +324,36 @@ describe("UiStore", () => {
       expect(store.selectedRowIndex).toBe(-1);
       expect(store.selectedCount).toBe(0);
       expect(store.statFilter).toBeNull();
+    });
+  });
+
+  describe("viewShowsTitleBar", () => {
+    test("hides TitleBar for views that render their own header", () => {
+      const hidden: ActiveView[] = [
+        "overview",
+        "details",
+        "logs",
+        "terminal",
+        "yaml",
+        "settings",
+      ];
+      for (const v of hidden) {
+        expect(viewShowsTitleBar(v)).toBe(false);
+      }
+    });
+
+    test("shows TitleBar for resource/list/dashboard views", () => {
+      const shown: ActiveView[] = [
+        "table",
+        "crd-table",
+        "portforwards",
+        "topology",
+        "cost",
+        "security",
+      ];
+      for (const v of shown) {
+        expect(viewShowsTitleBar(v)).toBe(true);
+      }
     });
   });
 });

--- a/src/lib/utils/tabLifecycle.test.ts
+++ b/src/lib/utils/tabLifecycle.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+import type { Resource, ResourceList } from "$lib/types";
+import type { Tab } from "$lib/stores/ui.logic";
+import { handleTabSwitch, type TabLifecycleK8sStore } from "./tabLifecycle";
+
+function mkResource(name: string, namespace = "default"): Resource {
+  return {
+    kind: "Pod",
+    api_version: "v1",
+    metadata: {
+      name,
+      namespace,
+      uid: `uid-${name}`,
+      creation_timestamp: "2024-01-01T00:00:00Z",
+      labels: {},
+      annotations: {},
+      owner_references: [],
+      resource_version: "1",
+    },
+    spec: {},
+    status: {},
+  };
+}
+
+function mkTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: "tab-1",
+    type: "table",
+    label: "Resources",
+    closable: true,
+    ...overrides,
+  };
+}
+
+function mkStore(overrides: Partial<TabLifecycleK8sStore> = {}): TabLifecycleK8sStore {
+  const base: TabLifecycleK8sStore = {
+    selectedResource: null,
+    resources: { items: [], resource_type: "" },
+    currentNamespace: "default",
+    selectedResourceType: "pods",
+    isLoading: false,
+    error: null,
+    selectResource(resource) {
+      this.selectedResource = resource;
+    },
+    setResourceType: () => {},
+    restoreResources: () => {},
+    switchNamespace: async () => {},
+    loadResources: async () => {},
+  };
+  return { ...base, ...overrides };
+}
+
+describe("handleTabSwitch", () => {
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  // --- Outgoing tab state ---
+
+  test("saves selected resource on outgoing resource tab", () => {
+    const fromTab = mkTab({ id: "from", type: "details" });
+    const toTab = mkTab({ id: "to", type: "overview" });
+    const resource = mkResource("pod-a");
+    const k8s = mkStore({ selectedResource: resource });
+
+    handleTabSwitch(fromTab, toTab, k8s);
+
+    expect(fromTab.cachedResource).toBe(resource);
+  });
+
+  test("saves items on outgoing table tab when resource_type matches", () => {
+    const items = [mkResource("a"), mkResource("b")];
+    const fromTab = mkTab({ id: "from", type: "table", resourceType: "pods" });
+    const toTab = mkTab({ id: "to", type: "overview" });
+    const k8s = mkStore({ resources: { items, resource_type: "pods" } });
+
+    handleTabSwitch(fromTab, toTab, k8s);
+
+    expect(fromTab.cachedItems).toBe(items);
+    expect(fromTab.count).toBe(2);
+    expect(fromTab.cacheReady).toBe(true);
+  });
+
+  test("skips save when store holds a different resource_type (in-flight)", () => {
+    const fromTab = mkTab({ id: "from", type: "table", resourceType: "pods" });
+    const toTab = mkTab({ id: "to", type: "overview" });
+    const k8s = mkStore({
+      resources: { items: [mkResource("wrong")], resource_type: "services" },
+    });
+
+    handleTabSwitch(fromTab, toTab, k8s);
+
+    expect(fromTab.cachedItems).toBeUndefined();
+    expect(fromTab.cacheReady).toBeUndefined();
+  });
+
+  // --- Incoming tab restoration ---
+
+  test("restores cachedResource onto store for incoming detail tab", () => {
+    const fromTab = mkTab({ id: "from", type: "overview" });
+    const cached = mkResource("pod-b");
+    const toTab = mkTab({ id: "to", type: "details", cachedResource: cached });
+    const k8s = mkStore();
+
+    handleTabSwitch(fromTab, toTab, k8s);
+
+    expect(k8s.selectedResource).toBe(cached);
+  });
+
+  // --- Cache hit path ---
+
+  test("restores from cache synchronously when cacheReady", () => {
+    const cachedItems = [mkResource("a")];
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "kube-system",
+      cachedItems,
+      cacheReady: true,
+    });
+    const restoreResources = mock((_type: string, _items: Resource[]) => {
+      calls.push("restoreResources");
+    });
+    const k8s = mkStore({
+      currentNamespace: "default",
+      restoreResources,
+      switchNamespace: async () => {
+        calls.push("switchNamespace");
+      },
+      loadResources: async () => {
+        calls.push("loadResources");
+      },
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+
+    expect(k8s.currentNamespace).toBe("kube-system");
+    expect(restoreResources).toHaveBeenCalledWith("pods", cachedItems);
+    expect(calls).toEqual(["restoreResources"]);
+  });
+
+  test("cache hit with matching namespace does not mutate currentNamespace", () => {
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+      cachedItems: [],
+      cacheReady: true,
+    });
+    const k8s = mkStore({ currentNamespace: "default" });
+    const nsBefore = k8s.currentNamespace;
+
+    handleTabSwitch(undefined, toTab, k8s);
+
+    expect(k8s.currentNamespace).toBe(nsBefore);
+  });
+
+  // --- Cache miss / load path ---
+
+  test("cache miss triggers switchNamespace when namespace differs", async () => {
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "kube-system",
+    });
+    const setResourceType = mock((_type: string) => {});
+    const switchNamespace = mock(async (_ns: string) => {});
+    const loadResources = mock(async (_type: string) => {});
+    const k8s = mkStore({
+      currentNamespace: "default",
+      setResourceType,
+      switchNamespace,
+      loadResources,
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setResourceType).toHaveBeenCalledWith("pods");
+    expect(switchNamespace).toHaveBeenCalledWith("kube-system");
+    expect(loadResources).not.toHaveBeenCalled();
+  });
+
+  test("cache miss without namespace diff triggers loadResources", async () => {
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+    });
+    const loadResources = mock(async (_type: string) => {});
+    const switchNamespace = mock(async (_ns: string) => {});
+    const k8s = mkStore({
+      currentNamespace: "default",
+      loadResources,
+      switchNamespace,
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(loadResources).toHaveBeenCalledWith("pods");
+    expect(switchNamespace).not.toHaveBeenCalled();
+    // Sync side effects before the fetch resolves.
+    expect(k8s.isLoading).toBe(true);
+    expect(k8s.resources.resource_type).toBe("pods");
+  });
+
+  test("populates cache after successful load", async () => {
+    const loaded = [mkResource("fresh-a"), mkResource("fresh-b")];
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+    });
+    const k8s = mkStore({
+      currentNamespace: "default",
+      loadResources: async () => {
+        k8s.resources = { items: loaded, resource_type: "pods" };
+        k8s.selectedResourceType = "pods";
+      },
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    // Wait for the microtask chain (loadResources -> then).
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(toTab.cachedItems).toBe(loaded);
+    expect(toTab.count).toBe(2);
+    expect(toTab.cacheReady).toBe(true);
+  });
+
+  test("skips cache population when resourceType drifted (race guard)", async () => {
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+    });
+    const k8s = mkStore({
+      currentNamespace: "default",
+      loadResources: async () => {
+        // Simulate user switching to a different type before load completed.
+        k8s.selectedResourceType = "services";
+        k8s.resources = { items: [mkResource("svc")], resource_type: "services" };
+      },
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(toTab.cachedItems).toBeUndefined();
+    expect(toTab.cacheReady).toBe(false);
+  });
+
+  test("skips cache population when store reported error", async () => {
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+    });
+    const k8s = mkStore({
+      currentNamespace: "default",
+      loadResources: async () => {
+        k8s.selectedResourceType = "pods";
+        k8s.error = "boom";
+      },
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(toTab.cacheReady).toBe(false);
+    expect(toTab.cachedItems).toBeUndefined();
+  });
+
+  test("rejected load does not throw unhandled", async () => {
+    const original = console.error;
+    const errSpy = mock((..._args: unknown[]) => {});
+    console.error = errSpy;
+    try {
+      const toTab = mkTab({
+        id: "to",
+        type: "table",
+        resourceType: "pods",
+        namespace: "default",
+      });
+      const k8s = mkStore({
+        currentNamespace: "default",
+        loadResources: async () => {
+          throw new Error("nope");
+        },
+      });
+
+      handleTabSwitch(undefined, toTab, k8s);
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(errSpy).toHaveBeenCalled();
+      expect(toTab.cacheReady).toBe(false);
+    } finally {
+      console.error = original;
+    }
+  });
+
+  // --- No-op branches ---
+
+  test("non-table incoming tab with no resourceType does nothing to store", () => {
+    const toTab = mkTab({ id: "to", type: "overview", resourceType: undefined });
+    const loadResources = mock(async (_type: string) => {});
+    const k8s = mkStore({ loadResources });
+
+    handleTabSwitch(undefined, toTab, k8s);
+
+    expect(loadResources).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleTabSwitch — crd-table path", () => {
+  test("crd-table cache hit restores via restoreResources", () => {
+    const items = [mkResource("crd-a")];
+    const toTab: Tab = {
+      id: "to",
+      type: "crd-table",
+      label: "Foo",
+      closable: true,
+      resourceType: "foos.example.com",
+      namespace: "default",
+      cachedItems: items,
+      cacheReady: true,
+    };
+    const restoreResources = mock((_type: string, _items: Resource[]) => {});
+    const k8s = mkStore({ currentNamespace: "default", restoreResources });
+
+    handleTabSwitch(undefined, toTab, k8s);
+
+    expect(restoreResources).toHaveBeenCalledWith("foos.example.com", items);
+  });
+});

--- a/src/lib/utils/tabLifecycle.ts
+++ b/src/lib/utils/tabLifecycle.ts
@@ -1,0 +1,129 @@
+import type { Resource, ResourceList } from "$lib/types";
+import type { Tab } from "$lib/stores/ui.logic";
+import { RESOURCE_TAB_TYPES } from "$lib/stores/ui.logic";
+
+/**
+ * Minimal k8s store surface used by the tab lifecycle. Kept narrow so the
+ * logic can be unit-tested against a hand-rolled fake without importing
+ * the real store (and its Tauri dependency).
+ */
+export interface TabLifecycleK8sStore {
+  selectedResource: Resource | null;
+  resources: ResourceList;
+  currentNamespace: string;
+  selectedResourceType: string;
+  isLoading: boolean;
+  error: string | null;
+  selectResource(resource: Resource | null): void;
+  setResourceType(resourceType: string): void;
+  restoreResources(resourceType: string, items: Resource[]): void;
+  switchNamespace(namespace: string): Promise<void>;
+  loadResources(resourceType: string): Promise<void>;
+}
+
+type TableTabType = Extract<Tab["type"], "table" | "crd-table">;
+
+function isTableTab(tab: Tab | undefined): tab is Tab & { type: TableTabType } {
+  return !!tab && (tab.type === "table" || tab.type === "crd-table");
+}
+
+/**
+ * Run synchronously before a tab switch commits:
+ *   1. save outgoing tab's selected resource + visible items (cache),
+ *   2. restore incoming tab's selected resource,
+ *   3. for table tabs: hydrate from cache if ready, else kick a load.
+ *
+ * Extracted from App.svelte so the race-guard and namespace-sync logic can
+ * be exercised without mounting the component.
+ */
+export function handleTabSwitch(
+  fromTab: Tab | undefined,
+  toTab: Tab,
+  k8s: TabLifecycleK8sStore,
+): void {
+  saveOutgoingTabState(fromTab, k8s);
+  restoreIncomingSelection(toTab, k8s);
+
+  if (!isTableTab(toTab) || !toTab.resourceType) return;
+
+  if (toTab.cacheReady && toTab.cachedItems) {
+    restoreFromCache(toTab, k8s);
+  } else {
+    triggerLoad(toTab, k8s);
+  }
+}
+
+function saveOutgoingTabState(
+  fromTab: Tab | undefined,
+  k8s: TabLifecycleK8sStore,
+): void {
+  if (!fromTab) return;
+
+  if (RESOURCE_TAB_TYPES.has(fromTab.type) && k8s.selectedResource) {
+    fromTab.cachedResource = k8s.selectedResource;
+  }
+
+  // Skip save when store holds a different resource_type (in-flight load).
+  if (isTableTab(fromTab) && fromTab.resourceType) {
+    if (k8s.resources.resource_type === fromTab.resourceType) {
+      fromTab.cachedItems = k8s.resources.items;
+      fromTab.count = k8s.resources.items.length;
+      fromTab.cacheReady = true;
+    }
+  }
+}
+
+function restoreIncomingSelection(toTab: Tab, k8s: TabLifecycleK8sStore): void {
+  if (RESOURCE_TAB_TYPES.has(toTab.type) && toTab.cachedResource) {
+    k8s.selectResource(toTab.cachedResource);
+  }
+}
+
+function restoreFromCache(toTab: Tab, k8s: TabLifecycleK8sStore): void {
+  // Cached: set namespace synchronously (no async switchNamespace to avoid race)
+  if (toTab.namespace !== undefined && toTab.namespace !== k8s.currentNamespace) {
+    k8s.currentNamespace = toTab.namespace;
+  }
+  // resourceType guaranteed by caller guard in handleTabSwitch.
+  k8s.restoreResources(toTab.resourceType!, toTab.cachedItems!);
+}
+
+function triggerLoad(toTab: Tab, k8s: TabLifecycleK8sStore): void {
+  // No cache: fetch. Set the type first so switchNamespace's internal load
+  // picks up the new resourceType and we don't fire two concurrent
+  // list_resources calls.
+  const expectedType = toTab.resourceType!;
+  k8s.setResourceType(expectedType);
+  toTab.cacheReady = false;
+
+  const tabNamespace = toTab.namespace;
+  const needsNamespaceSwitch =
+    tabNamespace !== undefined && tabNamespace !== k8s.currentNamespace;
+
+  const loadPromise: Promise<void> = needsNamespaceSwitch
+    ? k8s.switchNamespace(tabNamespace)
+    : (() => {
+        k8s.isLoading = true;
+        k8s.resources = { items: [], resource_type: expectedType };
+        return k8s.loadResources(expectedType);
+      })();
+
+  loadPromise
+    .then(() => {
+      if (k8s.selectedResourceType === expectedType && !k8s.error) {
+        toTab.cachedItems = k8s.resources.items;
+        toTab.count = k8s.resources.items.length;
+        toTab.cacheReady = true;
+      }
+    })
+    .catch((err) => {
+      // Store methods currently swallow errors internally and set k8s.error.
+      // This catch is defensive — if a future change re-throws, we still
+      // avoid an unhandled promise rejection and surface the problem.
+      console.error("[tabLifecycle] load for tab failed", {
+        tabId: toTab.id,
+        resourceType: expectedType,
+        error: err,
+      });
+    });
+}


### PR DESCRIPTION
## Summary

Refactor of `src/App.svelte` driven by code review findings. No behavior changes, only restructuring + test coverage + better error handling on startup.

- **Tab lifecycle extracted** to `$lib/utils/tabLifecycle.ts` as a pure helper — race-guard on `selectedResourceType` drift and rejected-load fallback now live behind a narrow `TabLifecycleK8sStore` interface, unit-tested against a fake (14 tests).
- **`<LazyView>` wrapper** dedupes the 5 `{#await import(...)}` branches. Promise is captured once per instance so parent re-renders don't flip the await back to its pending state.
- **Single-resource delete** moved into `registry.ts::deleteResource` alongside `restartWorkload` / `rollbackDeployment`. `App.svelte`'s `confirmGlobalDelete` is now a 3-line wrapper. Guard added: `selectResource(null)` only fires when the deleted resource was the selected one.
- **`initApp` per-phase error handling** — `loadContexts` vs `restoreConnection` vs `loadNamespaces` now surface distinct user messages (kubeconfig file / credentials / RBAC) instead of one generic catch. Each underlying error is logged.
- **`viewShowsTitleBar(view)`** replaces the 6-way inline OR condition. Implemented as an allowlist *complement* so new views default to showing the TitleBar (fail safe).
- **Sidebar widths → CSS custom properties** in `app.css` (`--sidebar-width-collapsed/expanded`), removing hardcoded `44` / `260` from the template.

### Files

- `src/App.svelte` — 296 → 233 lines (~−21%)
- `src/lib/utils/tabLifecycle.ts` (new) + test (14 cases)
- `src/lib/components/common/LazyView.svelte` (new)
- `src/lib/actions/registry.ts` — `deleteResource()` added
- `src/lib/stores/ui.{logic,svelte,test}.ts` — `viewShowsTitleBar` + tests
- `src/app.css` — layout tokens

## Test plan

- [x] `bun test` — 799/799 pass (14 new in tabLifecycle, 2 new in ui.test)
- [x] `bunx svelte-check` — 0 errors, 5 warnings (all pre-existing in files not touched)
- [ ] Manual smoke: start app, switch between overview/table/topology/cost/security/CRDs (the 5 lazy views)
- [ ] Manual smoke: switch namespaces while on a table view — cache invalidation + reload still works
- [ ] Manual smoke: open detail panel → switch to a sibling tab → switch back — `selectedResource` restored
- [ ] Manual smoke: simulate kubeconfig error (invalid path) and confirm the new per-phase error message surfaces
- [ ] Manual smoke: right-click delete from context menu → confirm dialog → toast

## Not in this PR (noted for follow-up)

- `ResourceTable.confirmBulkDelete` (`src/lib/components/table/ResourceTable.svelte:185`) duplicates the Tauri `delete_resource` invoke shape and could reuse the new `deleteResource()` helper. Out of scope here — bulk semantics differ (aggregate toast). Worth a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy-loaded views with unified error UI.
  * Centralized tab-switch behavior for smoother tab state restore and loading.
  * Dedicated delete action that shows success/error toasts and refreshes views.

* **Refactor**
  * Streamlined resource deletion flow.
  * Improved startup error handling with RBAC-specific namespace errors.
  * Sidebar sizing moved to CSS variables; simplified context-menu handling.
  * Title bar visibility now driven by view helper.

* **Tests**
  * Added coverage for tab lifecycle and title-bar visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->