### PR TITLE
feat(tabs): per-tab UI state with session persistence

### DIFF
--- a/src/lib/components/titlebar/TitleBar.svelte
+++ b/src/lib/components/titlebar/TitleBar.svelte
@@ -10,7 +10,6 @@
     k8sStore.selectedResourceType.slice(1)
   );
 
-  let searchValue = $state("");
   let searchInput: HTMLInputElement | undefined = $state();
   let nsOpen = $state(false);
   let nsFilter = $state("");
@@ -23,7 +22,6 @@
 
   function handleSearchInput(e: Event) {
     const target = e.target as HTMLInputElement;
-    searchValue = target.value;
     uiStore.setFilter(target.value);
   }
 
@@ -137,7 +135,7 @@
         id="resource-filter"
         type="text"
         placeholder="Search resources..."
-        value={searchValue}
+        value={uiStore.filter}
         oninput={handleSearchInput}
         onkeydown={handleSearchKeydown}
         class="h-full flex-1 bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none"

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -631,6 +631,7 @@ export function restoreTab(st: SerializableTab): Tab {
     resourceType: st.resourceType,
     namespace: st.namespace,
     filter: st.filter,
+    _debouncedFilter: st.filter,
     sortColumn: st.sortColumn,
     sortDirection: st.sortDirection,
     statFilter: st.statFilter,

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -2,6 +2,28 @@ import type { SortDirection, Resource } from "../types/index.js";
 
 export type ActiveView = "overview" | "table" | "details" | "logs" | "terminal" | "portforwards" | "yaml" | "settings" | "topology" | "cost" | "security" | "crd-table";
 
+/**
+ *                    ┌───────────────────────────────────────┐
+ *                    │  UiStoreLogic — single source of truth │
+ *                    └───────────────────────────────────────┘
+ *
+ *  Global (store-level):     Per-tab (in `Tab`):
+ *  ─────────────────────     ──────────────────────────
+ *  sidebarCollapsed          filter            ──┐
+ *  commandPaletteOpen        _debouncedFilter    │  getter/setter on
+ *  activeView                sortColumn          │  UiStoreLogic reads
+ *  previousView              sortDirection       │─ and writes
+ *  tabs[]                    statFilter          │  `this.activeTab.*`
+ *  activeTabId               selectedRows        │
+ *                            selectedRowIndex  ──┘
+ *                            cachedItems / cachedResource / count / cacheReady
+ *                            namespace / resourceName / resourceType
+ *
+ *  Tab switch:
+ *    activateTab(id) → flushDebounce() → swap activeTabId → getters now
+ *    read the new tab's state. No explicit reset of filter/sort/etc — each
+ *    tab owns its UI state and survives round-trips.
+ */
 export interface Tab {
   id: string;
   type: ActiveView;
@@ -22,7 +44,25 @@ export interface Tab {
   cacheReady?: boolean;
   /** Cached selected resource — restores detail/logs/yaml/terminal views on tab switch */
   cachedResource?: Resource;
+
+  // Per-tab UI state. All optional — absent means "default" via getter fallback.
+  /** Search filter text. */
+  filter?: string;
+  /** Debounced filter value (committed 150ms after last keystroke). */
+  _debouncedFilter?: string;
+  /** Active sort column. */
+  sortColumn?: string;
+  /** Active sort direction. */
+  sortDirection?: SortDirection;
+  /** Stat-card filter key (e.g. "running", "needsAttention"). */
+  statFilter?: string | null;
+  /** Selected row uids (ephemeral — not persisted across sessions). */
+  selectedRows?: Set<string>;
+  /** Keyboard-focused row index; -1 = no focus. */
+  selectedRowIndex?: number;
 }
+
+const EMPTY_SELECTED_ROWS: Set<string> = new Set();
 
 let _tabCounter = 0;
 function nextTabId(): string {
@@ -32,6 +72,15 @@ function nextTabId(): string {
 /** Reset the tab counter (useful in tests) */
 export function resetTabCounter(): void {
   _tabCounter = 0;
+}
+
+/**
+ * Bump the tab counter so the next generated id is strictly greater than
+ * any already in use. Called after hydrating tabs from storage to prevent
+ * collisions with restored ids like "tab-7".
+ */
+export function ensureTabCounterAbove(n: number): void {
+  if (n > _tabCounter) _tabCounter = n;
 }
 
 /** View types that should only have one tab open at a time */
@@ -74,31 +123,81 @@ function mkOverviewTab(): Tab {
 export class UiStoreLogic {
   sidebarCollapsed = false;
   commandPaletteOpen = false;
-  filter = "";
-  protected _debouncedFilter = "";
-  protected _debounceTimer: ReturnType<typeof setTimeout> | null = null;
-  sortColumn = "name";
-  sortDirection: SortDirection = "asc";
   activeView: ActiveView = "overview";
   previousView: ActiveView | null = null;
-  selectedRowIndex = -1;
-  selectedRows = new Set<string>();
-  statFilter: string | null = null;
 
   // Tab system
   tabs: Tab[] = [mkOverviewTab()];
   activeTabId = "tab-overview";
+
+  // Debounce timer lives on the store (single shared handle), but each
+  // setFilter call captures its target tab in the closure so a fast
+  // tab-switch doesn't misroute the deferred write.
+  protected _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  protected _debounceTarget: Tab | null = null;
+
+  get activeTab(): Tab | undefined {
+    return this.tabs.find((t) => t.id === this.activeTabId);
+  }
+
+  // ── Per-tab UI state (getter/setter over `this.activeTab`) ──
+  // Defaults mirror the pre-refactor globals so consumers that never touched
+  // a tab behave identically.
+
+  get filter(): string {
+    return this.activeTab?.filter ?? "";
+  }
+  set filter(v: string) {
+    const t = this.activeTab;
+    if (t) t.filter = v;
+  }
 
   get filterLower(): string {
     return this.filter.toLowerCase();
   }
 
   get debouncedFilterLower(): string {
-    return this._debouncedFilter.toLowerCase();
+    return (this.activeTab?._debouncedFilter ?? "").toLowerCase();
   }
 
-  get activeTab(): Tab | undefined {
-    return this.tabs.find((t) => t.id === this.activeTabId);
+  get sortColumn(): string {
+    return this.activeTab?.sortColumn ?? "name";
+  }
+  set sortColumn(v: string) {
+    const t = this.activeTab;
+    if (t) t.sortColumn = v;
+  }
+
+  get sortDirection(): SortDirection {
+    return this.activeTab?.sortDirection ?? "asc";
+  }
+  set sortDirection(v: SortDirection) {
+    const t = this.activeTab;
+    if (t) t.sortDirection = v;
+  }
+
+  get statFilter(): string | null {
+    return this.activeTab?.statFilter ?? null;
+  }
+  set statFilter(v: string | null) {
+    const t = this.activeTab;
+    if (t) t.statFilter = v;
+  }
+
+  get selectedRows(): Set<string> {
+    return this.activeTab?.selectedRows ?? EMPTY_SELECTED_ROWS;
+  }
+  set selectedRows(v: Set<string>) {
+    const t = this.activeTab;
+    if (t) t.selectedRows = v;
+  }
+
+  get selectedRowIndex(): number {
+    return this.activeTab?.selectedRowIndex ?? -1;
+  }
+  set selectedRowIndex(v: number) {
+    const t = this.activeTab;
+    if (t) t.selectedRowIndex = v;
   }
 
   openTab(type: ActiveView, opts?: { label?: string; resourceName?: string; resourceType?: string; namespace?: string }): void {
@@ -145,13 +244,14 @@ export class UiStoreLogic {
     const from = this.activeTab;
     // Restore data BEFORE changing the view — prevents empty state flash
     if (from?.id !== tab.id) {
+      // Flush pending debounce against the OUTGOING tab so its filter and
+      // _debouncedFilter stay consistent when we come back to it.
+      this._flushDebounce();
       this.onBeforeTabSwitch?.(from, tab);
     }
     this.activeTabId = tabId;
     this.activeView = tab.type;
-    this.filter = "";
-    this._clearDebounce();
-    this.statFilter = null;
+    // No reset of filter/sort/statFilter/selectedRows — each tab owns its state.
   }
 
   closeTab(tabId: string): void {
@@ -215,25 +315,29 @@ export class UiStoreLogic {
   }
 
   toggleRowSelection(uid: string): void {
-    const next = new Set(this.selectedRows);
-    if (next.has(uid)) {
-      next.delete(uid);
-    } else {
-      next.add(uid);
-    }
-    this.selectedRows = next;
+    const t = this.activeTab;
+    if (!t) return;
+    const current = t.selectedRows ?? new Set<string>();
+    const next = new Set(current);
+    if (next.has(uid)) next.delete(uid);
+    else next.add(uid);
+    t.selectedRows = next;
   }
 
   selectAllRows(uids: string[]): void {
-    this.selectedRows = new Set(uids);
+    const t = this.activeTab;
+    if (!t) return;
+    t.selectedRows = new Set(uids);
   }
 
   clearSelection(): void {
-    this.selectedRows = new Set();
+    const t = this.activeTab;
+    if (!t) return;
+    t.selectedRows = new Set();
   }
 
   get selectedCount(): number {
-    return this.selectedRows.size;
+    return this.activeTab?.selectedRows?.size ?? 0;
   }
 
   toggleSidebar(): void {
@@ -333,40 +437,63 @@ export class UiStoreLogic {
   }
 
   setSort(column: string): void {
-    if (this.sortColumn === column) {
-      this.sortDirection = this.sortDirection === "asc" ? "desc" : "asc";
+    const t = this.activeTab;
+    if (!t) return;
+    const currentCol = t.sortColumn ?? "name";
+    const currentDir = t.sortDirection ?? "asc";
+    if (currentCol === column) {
+      t.sortDirection = currentDir === "asc" ? "desc" : "asc";
     } else {
-      this.sortColumn = column;
-      this.sortDirection = "asc";
+      t.sortColumn = column;
+      t.sortDirection = "asc";
     }
   }
 
   setFilter(value: string): void {
-    this.filter = value;
+    const tab = this.activeTab;
+    if (!tab || tab.filter === value) return;
+    tab.filter = value;
     if (this._debounceTimer) clearTimeout(this._debounceTimer);
+    this._debounceTarget = tab;
     this._debounceTimer = setTimeout(() => {
-      this._debouncedFilter = value;
+      tab._debouncedFilter = value;
+      this._debounceTimer = null;
+      this._debounceTarget = null;
     }, 150);
   }
 
   toggleStatFilter(key: string): void {
-    this.statFilter = this.statFilter === key ? null : key;
+    const t = this.activeTab;
+    if (!t) return;
+    t.statFilter = t.statFilter === key ? null : key;
   }
 
   clearStatFilter(): void {
-    this.statFilter = null;
+    const t = this.activeTab;
+    if (!t) return;
+    t.statFilter = null;
   }
 
   resetSelection(): void {
-    this.selectedRowIndex = -1;
+    const t = this.activeTab;
+    if (!t) return;
+    t.selectedRowIndex = -1;
   }
 
-  protected _clearDebounce(): void {
+  /**
+   * Cancel any pending debounce timer and commit its value to the target tab
+   * synchronously. Keeps `filter` and `_debouncedFilter` consistent on the
+   * outgoing tab when the user switches tabs mid-typing.
+   */
+  protected _flushDebounce(): void {
     if (this._debounceTimer) {
       clearTimeout(this._debounceTimer);
       this._debounceTimer = null;
     }
-    this._debouncedFilter = this.filter;
+    if (this._debounceTarget) {
+      this._debounceTarget._debouncedFilter = this._debounceTarget.filter ?? "";
+      this._debounceTarget = null;
+    }
   }
 
   /** Override in subclass to add side effects (e.g., contextMenuStore.close()) */
@@ -376,17 +503,153 @@ export class UiStoreLogic {
 
   resetForContextChange(): void {
     this.commandPaletteOpen = false;
-    this.filter = "";
-    this._clearDebounce();
-    this.sortColumn = "name";
-    this.sortDirection = "asc";
+    this._flushDebounce();
+    // Per-tab state is implicitly cleared by recreating the tabs array —
+    // no need to touch filter/sort/statFilter/selectedRows individually.
     this.tabs = [mkOverviewTab()];
     this.activeTabId = "tab-overview";
     this.activeView = "overview";
     this.previousView = null;
-    this.selectedRowIndex = -1;
-    this.selectedRows = new Set();
-    this.statFilter = null;
     this._onResetContextChange();
   }
+}
+
+// ── Tab persistence (serialization) ──────────────────────────────────────
+// Saved to storage (survives restart):
+//   id, type, label, closable, resourceName, resourceType, namespace,
+//   filter, sortColumn, sortDirection, statFilter
+// NOT saved (ephemeral — reloaded fresh from cluster or recomputed):
+//   cachedItems, cachedResource, cacheReady, count, _debouncedFilter,
+//   selectedRows, selectedRowIndex
+// Rationale: cached resource lists become stale in seconds. Selected rows
+// and keyboard focus are session-local UX that shouldn't cross restarts.
+
+export const TABS_STORAGE_KEY = "kdashboard-tabs-v1";
+export const TABS_STORAGE_VERSION = 1;
+
+const VALID_VIEW_TYPES = new Set<ActiveView>([
+  "overview", "table", "details", "logs", "terminal", "portforwards",
+  "yaml", "settings", "topology", "cost", "security", "crd-table",
+]);
+
+interface SerializableTab {
+  id: string;
+  type: ActiveView;
+  label: string;
+  closable: boolean;
+  resourceName?: string;
+  resourceType?: string;
+  namespace?: string;
+  filter?: string;
+  sortColumn?: string;
+  sortDirection?: SortDirection;
+  statFilter?: string | null;
+}
+
+interface SerializedTabsState {
+  version: number;
+  tabs: SerializableTab[];
+  activeTabId: string;
+}
+
+export function serializeTabs(tabs: Tab[], activeTabId: string): SerializedTabsState {
+  const serialized: SerializableTab[] = tabs.map((t) => {
+    const st: SerializableTab = {
+      id: t.id,
+      type: t.type,
+      label: t.label,
+      closable: t.closable,
+    };
+    if (t.resourceName !== undefined) st.resourceName = t.resourceName;
+    if (t.resourceType !== undefined) st.resourceType = t.resourceType;
+    if (t.namespace !== undefined) st.namespace = t.namespace;
+    if (t.filter !== undefined && t.filter !== "") st.filter = t.filter;
+    if (t.sortColumn !== undefined && t.sortColumn !== "name") st.sortColumn = t.sortColumn;
+    if (t.sortDirection !== undefined && t.sortDirection !== "asc") st.sortDirection = t.sortDirection;
+    if (t.statFilter !== undefined && t.statFilter !== null) st.statFilter = t.statFilter;
+    return st;
+  });
+  return { version: TABS_STORAGE_VERSION, tabs: serialized, activeTabId };
+}
+
+/**
+ * Parse and validate a persisted tabs payload. Returns `null` if the payload
+ * is corrupt, from a future version, or would leave no tabs — the caller
+ * should fall back to defaults in that case.
+ */
+export function deserializeTabs(raw: string | null): SerializedTabsState | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.version !== TABS_STORAGE_VERSION) return null;
+  if (!Array.isArray(obj.tabs) || obj.tabs.length === 0) return null;
+  if (typeof obj.activeTabId !== "string") return null;
+
+  const tabs: SerializableTab[] = [];
+  for (const item of obj.tabs as unknown[]) {
+    if (!item || typeof item !== "object") return null;
+    const r = item as Record<string, unknown>;
+    if (typeof r.id !== "string" || typeof r.type !== "string" ||
+        typeof r.label !== "string" || typeof r.closable !== "boolean") return null;
+    if (!VALID_VIEW_TYPES.has(r.type as ActiveView)) return null;
+    const st: SerializableTab = {
+      id: r.id, type: r.type as ActiveView, label: r.label, closable: r.closable,
+    };
+    if (typeof r.resourceName === "string") st.resourceName = r.resourceName;
+    if (typeof r.resourceType === "string") st.resourceType = r.resourceType;
+    if (typeof r.namespace === "string") st.namespace = r.namespace;
+    if (typeof r.filter === "string") st.filter = r.filter;
+    if (typeof r.sortColumn === "string") st.sortColumn = r.sortColumn;
+    if (r.sortDirection === "asc" || r.sortDirection === "desc") st.sortDirection = r.sortDirection;
+    if (typeof r.statFilter === "string" || r.statFilter === null) st.statFilter = r.statFilter as string | null;
+    tabs.push(st);
+  }
+
+  // activeTabId must reference an existing tab
+  if (!tabs.some((t) => t.id === obj.activeTabId)) return null;
+
+  return { version: TABS_STORAGE_VERSION, tabs, activeTabId: obj.activeTabId };
+}
+
+/**
+ * Convert a SerializableTab back to a runtime Tab. Ephemeral fields stay
+ * undefined — data will be fetched fresh; selection/focus reset.
+ */
+export function restoreTab(st: SerializableTab): Tab {
+  return {
+    id: st.id,
+    type: st.type,
+    label: st.label,
+    closable: st.closable,
+    resourceName: st.resourceName,
+    resourceType: st.resourceType,
+    namespace: st.namespace,
+    filter: st.filter,
+    sortColumn: st.sortColumn,
+    sortDirection: st.sortDirection,
+    statFilter: st.statFilter,
+  };
+}
+
+/**
+ * Highest numeric suffix in a set of tab ids like "tab-7". Ignores the
+ * fixed "tab-overview" id. Used to bump the module-level counter so newly
+ * opened tabs never collide with restored ones.
+ */
+export function maxTabIdSuffix(tabs: { id: string }[]): number {
+  let max = 0;
+  for (const t of tabs) {
+    const m = /^tab-(\d+)$/.exec(t.id);
+    if (m) {
+      const n = Number(m[1]);
+      if (n > max) max = n;
+    }
+  }
+  return max;
 }

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -7,36 +7,96 @@ import {
   RESOURCE_TAB_TYPES,
   VIEW_LABELS,
   viewShowsTitleBar,
+  serializeTabs,
+  deserializeTabs,
+  restoreTab,
+  maxTabIdSuffix,
+  ensureTabCounterAbove,
+  TABS_STORAGE_KEY,
 } from "./ui.logic.js";
 
 export type { ActiveView, Tab };
 export { RESOURCE_TAB_TYPES, VIEW_LABELS, viewShowsTitleBar };
 
+const SAVE_DEBOUNCE_MS = 250;
+
 class UiStore extends UiStoreLogic {
+  // Store-level reactive state. Per-tab UI state (filter, sort, statFilter,
+  // selectedRows, selectedRowIndex, _debouncedFilter) lives on `Tab` and is
+  // accessed via inherited getters on `UiStoreLogic` — the deep $state proxy
+  // on `tabs` makes nested tab fields reactive automatically.
   override sidebarCollapsed = $state<boolean>(false);
   override commandPaletteOpen = $state<boolean>(false);
-  override filter = $state<string>("");
-  // @ts-expect-error -- $derived compiles to accessor; TS cannot see that
-  override filterLower = $derived(this.filter.toLowerCase());
-  override _debouncedFilter = $state<string>("");
-  // @ts-expect-error -- $derived compiles to accessor; TS cannot see that
-  override debouncedFilterLower = $derived(this._debouncedFilter.toLowerCase());
-  override sortColumn = $state<string>("name");
-  override sortDirection = $state<import("../types/index.js").SortDirection>("asc");
   override activeView = $state<ActiveView>("overview");
   override previousView = $state<ActiveView | null>(null);
-  override selectedRowIndex = $state<number>(-1);
-  override selectedRows = $state<Set<string>>(new Set());
-  override statFilter = $state<string | null>(null);
 
   // Tab system
   override tabs = $state<Tab[]>([{ id: "tab-overview", type: "overview", label: "Overview", closable: true }]);
   override activeTabId = $state<string>("tab-overview");
 
+  private _saveTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     super();
     unshadowState(this);
+    // Hydrate AFTER unshadow so writes go through the reactive setters.
+    this._hydrateFromStorage();
+    this._installAutosave();
+  }
+
+  /**
+   * Restore tabs and active-tab selection from localStorage. Silent on any
+   * failure — corrupt/missing data falls back to the default overview tab
+   * already seeded by the $state declaration.
+   */
+  private _hydrateFromStorage(): void {
+    if (typeof localStorage === "undefined") return;
+    let raw: string | null = null;
+    try {
+      raw = localStorage.getItem(TABS_STORAGE_KEY);
+    } catch {
+      return;
+    }
+    const state = deserializeTabs(raw);
+    if (!state) return;
+    this.tabs = state.tabs.map(restoreTab);
+    this.activeTabId = state.activeTabId;
+    const activeTab = this.tabs.find((t) => t.id === state.activeTabId);
+    if (activeTab) this.activeView = activeTab.type;
+    // Prevent id collisions with newly opened tabs.
+    ensureTabCounterAbove(maxTabIdSuffix(this.tabs));
+  }
+
+  /**
+   * Watch tabs + activeTabId and persist on change, debounced so a burst of
+   * mutations (typing in the filter input) doesn't thrash localStorage.
+   * $effect.root gives the effect a scope tied to the store's lifetime.
+   */
+  private _installAutosave(): void {
+    if (typeof localStorage === "undefined") return;
+    $effect.root(() => {
+      $effect(() => {
+        // Touch reactive deps; defer the actual serialize + write until the
+        // debounce fires so a burst of keystrokes doesn't rebuild snapshots
+        // we'd only discard.
+        void this.activeTabId;
+        for (const t of this.tabs) {
+          void t.filter; void t.sortColumn; void t.sortDirection;
+          void t.statFilter; void t.label; void t.resourceName;
+          void t.resourceType; void t.namespace;
+        }
+        if (this._saveTimer) clearTimeout(this._saveTimer);
+        this._saveTimer = setTimeout(() => {
+          try {
+            const snapshot = serializeTabs(this.tabs, this.activeTabId);
+            localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(snapshot));
+          } catch {
+            // Quota exceeded or storage disabled — session restore is best-effort.
+          }
+          this._saveTimer = null;
+        }, SAVE_DEBOUNCE_MS);
+      });
+    });
   }
 
   protected override _onResetContextChange(): void {

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -3,7 +3,13 @@ import {
   UiStoreLogic,
   resetTabCounter,
   viewShowsTitleBar,
+  serializeTabs,
+  deserializeTabs,
+  restoreTab,
+  maxTabIdSuffix,
+  TABS_STORAGE_VERSION,
   type ActiveView,
+  type Tab,
 } from "./ui.logic.js";
 
 describe("UiStore", () => {
@@ -123,9 +129,10 @@ describe("UiStore", () => {
       expect(store.previousView).toBe("overview");
     });
 
-    test("_switchView clears filter on tab activation", () => {
+    test("new tab starts with empty filter (per-tab state)", () => {
       store.setFilter("some-filter");
       expect(store.filter).toBe("some-filter");
+      // Opening a new tab switches activeTab; the new tab has its own empty filter
       store.showDetails();
       expect(store.filter).toBe("");
     });
@@ -146,10 +153,12 @@ describe("UiStore", () => {
       expect(store.activeView).toBe("overview");
     });
 
-    test("backToPrevious clears filter", () => {
+    test("backToPrevious goes to nearest tab (filter is per-tab)", () => {
       store.showDetails();
       store.setFilter("test");
+      expect(store.filter).toBe("test");
       store.backToPrevious();
+      // details tab closed; activeTab is now the overview tab, which never had a filter set
       expect(store.filter).toBe("");
     });
 
@@ -316,6 +325,9 @@ describe("UiStore", () => {
       store.resetForContextChange();
 
       expect(store.commandPaletteOpen).toBe(false);
+      // Per-tab state is implicitly reset: resetForContextChange() recreates
+      // the tabs array with a fresh overview tab, so all per-tab fields
+      // fall back to their getter defaults.
       expect(store.filter).toBe("");
       expect(store.sortColumn).toBe("name");
       expect(store.sortDirection as "asc" | "desc").toBe("asc");
@@ -324,6 +336,307 @@ describe("UiStore", () => {
       expect(store.selectedRowIndex).toBe(-1);
       expect(store.selectedCount).toBe(0);
       expect(store.statFilter).toBeNull();
+    });
+  });
+
+  describe("per-tab state", () => {
+    test("filter persists across tab switches", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.setFilter("nginx");
+      expect(store.filter).toBe("nginx");
+
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      const servicesId = store.activeTabId;
+      expect(store.filter).toBe("");
+
+      store.setFilter("api");
+      expect(store.filter).toBe("api");
+
+      store.activateTab(podsId);
+      expect(store.filter).toBe("nginx");
+
+      store.activateTab(servicesId);
+      expect(store.filter).toBe("api");
+    });
+
+    test("sortColumn and sortDirection persist per-tab", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.setSort("cpu");
+      expect(store.sortColumn).toBe("cpu");
+      expect(store.sortDirection).toBe("asc");
+
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      // new tab: defaults
+      expect(store.sortColumn).toBe("name");
+      expect(store.sortDirection).toBe("asc");
+
+      store.activateTab(podsId);
+      expect(store.sortColumn).toBe("cpu");
+    });
+
+    test("statFilter persists per-tab", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.toggleStatFilter("running");
+      expect(store.statFilter).toBe("running");
+
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      expect(store.statFilter).toBeNull();
+
+      store.activateTab(podsId);
+      expect(store.statFilter).toBe("running");
+    });
+
+    test("selectedRows do not leak across tabs", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.selectAllRows(["pod-uid-1", "pod-uid-2"]);
+      expect(store.selectedCount).toBe(2);
+
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      expect(store.selectedCount).toBe(0);
+      expect(store.selectedRows.has("pod-uid-1")).toBe(false);
+
+      store.toggleRowSelection("svc-uid-1");
+      expect(store.selectedCount).toBe(1);
+
+      store.activateTab(podsId);
+      expect(store.selectedCount).toBe(2);
+      expect(store.selectedRows.has("pod-uid-1")).toBe(true);
+      expect(store.selectedRows.has("svc-uid-1")).toBe(false);
+    });
+
+    test("selectedRowIndex is per-tab", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.selectedRowIndex = 5;
+      expect(store.selectedRowIndex).toBe(5);
+
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      expect(store.selectedRowIndex).toBe(-1);
+
+      store.activateTab(podsId);
+      expect(store.selectedRowIndex).toBe(5);
+    });
+
+    test("filter round-trips through detail view", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.setFilter("nginx");
+
+      // open detail (new tab, inherits nothing)
+      store.showDetails("nginx-abc123", "pods");
+      expect(store.filter).toBe("");
+
+      // back to pods — filter must still be there
+      store.activateTab(podsId);
+      expect(store.filter).toBe("nginx");
+    });
+
+    test("closing a tab discards its filter (no leak to remaining tabs)", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      store.setFilter("nginx");
+      const podsId = store.activeTabId;
+
+      store.closeTab(podsId);
+      // now on overview, which has no filter
+      expect(store.filter).toBe("");
+    });
+
+    test("debounced filter writes to the correct tab after switch", async () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.setFilter("nginx");
+      expect(store.filter).toBe("nginx");
+      // debounced not yet fired
+      expect(store.debouncedFilterLower).toBe("");
+
+      // Switch before debounce fires — _flushDebounce commits the value
+      // to the outgoing (pods) tab synchronously.
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      expect(store.debouncedFilterLower).toBe(""); // services tab, no filter
+
+      store.activateTab(podsId);
+      expect(store.filter).toBe("nginx");
+      expect(store.debouncedFilterLower).toBe("nginx");
+    });
+
+    test("setFilter debounce fires on the captured tab even after switch", async () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      const podsId = store.activeTabId;
+      store.setFilter("nginx");
+
+      // Switch tabs. _flushDebounce commits "nginx" to pods tab synchronously.
+      store.openTab("table", { label: "Services", resourceType: "services" });
+      store.setFilter("api");
+
+      // Wait beyond debounce
+      await new Promise((r) => setTimeout(r, 200));
+
+      // Services debounced should now be "api"
+      expect(store.debouncedFilterLower).toBe("api");
+
+      // Pods debounced should be "nginx" (flushed at switch, not overwritten)
+      store.activateTab(podsId);
+      expect(store.debouncedFilterLower).toBe("nginx");
+    });
+
+    test("tab without per-tab fields falls back to defaults (backwards compat)", () => {
+      // Simulate a tab constructed without optional fields (e.g., by legacy
+      // code or future deserialization).
+      const legacyTab: Tab = {
+        id: "tab-legacy",
+        type: "table",
+        label: "Legacy",
+        closable: true,
+      };
+      store.tabs = [...store.tabs, legacyTab];
+      store.activateTab("tab-legacy");
+
+      expect(store.filter).toBe("");
+      expect(store.sortColumn).toBe("name");
+      expect(store.sortDirection).toBe("asc");
+      expect(store.statFilter).toBeNull();
+      expect(store.selectedCount).toBe(0);
+      expect(store.selectedRowIndex).toBe(-1);
+    });
+  });
+
+  describe("tab persistence (serialization)", () => {
+    test("serializeTabs strips ephemeral fields", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods" });
+      store.setFilter("nginx");
+      store.setSort("cpu");
+      store.selectAllRows(["uid-1", "uid-2"]);
+      store.selectedRowIndex = 3;
+      // Simulate cache population
+      const tab = store.activeTab!;
+      tab.cachedItems = [];
+      tab.cacheReady = true;
+      tab.count = 42;
+
+      const snap = serializeTabs(store.tabs, store.activeTabId);
+      const persistedPods = snap.tabs.find((t) => t.label === "Pods")!;
+
+      // Saved:
+      expect(persistedPods.filter).toBe("nginx");
+      expect(persistedPods.sortColumn).toBe("cpu");
+      expect(persistedPods.resourceType).toBe("pods");
+
+      // NOT saved (not present on SerializableTab at all):
+      expect("cachedItems" in persistedPods).toBe(false);
+      expect("cachedResource" in persistedPods).toBe(false);
+      expect("cacheReady" in persistedPods).toBe(false);
+      expect("count" in persistedPods).toBe(false);
+      expect("selectedRows" in persistedPods).toBe(false);
+      expect("selectedRowIndex" in persistedPods).toBe(false);
+      expect("_debouncedFilter" in persistedPods).toBe(false);
+    });
+
+    test("serializeTabs omits defaults to keep payload small", () => {
+      // overview tab with no filter/sort/statFilter set
+      const snap = serializeTabs(store.tabs, store.activeTabId);
+      const overview = snap.tabs[0];
+      expect("filter" in overview).toBe(false);
+      expect("sortColumn" in overview).toBe(false);
+      expect("sortDirection" in overview).toBe(false);
+      expect("statFilter" in overview).toBe(false);
+    });
+
+    test("serialize + deserialize round-trip", () => {
+      store.openTab("table", { label: "Pods", resourceType: "pods", namespace: "default" });
+      store.setFilter("nginx");
+      store.setSort("cpu");
+      store.setSort("cpu"); // toggle to desc
+      store.toggleStatFilter("running");
+
+      const snap = serializeTabs(store.tabs, store.activeTabId);
+      const json = JSON.stringify(snap);
+      const parsed = deserializeTabs(json);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.version).toBe(TABS_STORAGE_VERSION);
+      expect(parsed!.activeTabId).toBe(store.activeTabId);
+      expect(parsed!.tabs.length).toBe(store.tabs.length);
+
+      const restored = parsed!.tabs.map(restoreTab);
+      const podsRestored = restored.find((t) => t.label === "Pods")!;
+      expect(podsRestored.filter).toBe("nginx");
+      expect(podsRestored.sortColumn).toBe("cpu");
+      expect(podsRestored.sortDirection).toBe("desc");
+      expect(podsRestored.statFilter).toBe("running");
+      expect(podsRestored.resourceType).toBe("pods");
+      expect(podsRestored.namespace).toBe("default");
+    });
+
+    test("deserializeTabs rejects null / empty / invalid JSON", () => {
+      expect(deserializeTabs(null)).toBeNull();
+      expect(deserializeTabs("")).toBeNull();
+      expect(deserializeTabs("{not json")).toBeNull();
+      expect(deserializeTabs("[]")).toBeNull();
+    });
+
+    test("deserializeTabs rejects wrong version", () => {
+      const bad = JSON.stringify({
+        version: 999,
+        tabs: [{ id: "tab-overview", type: "overview", label: "Overview", closable: true }],
+        activeTabId: "tab-overview",
+      });
+      expect(deserializeTabs(bad)).toBeNull();
+    });
+
+    test("deserializeTabs rejects unknown tab type", () => {
+      const bad = JSON.stringify({
+        version: TABS_STORAGE_VERSION,
+        tabs: [{ id: "tab-1", type: "does-not-exist", label: "?", closable: true }],
+        activeTabId: "tab-1",
+      });
+      expect(deserializeTabs(bad)).toBeNull();
+    });
+
+    test("deserializeTabs rejects payload with dangling activeTabId", () => {
+      const bad = JSON.stringify({
+        version: TABS_STORAGE_VERSION,
+        tabs: [{ id: "tab-overview", type: "overview", label: "Overview", closable: true }],
+        activeTabId: "tab-missing",
+      });
+      expect(deserializeTabs(bad)).toBeNull();
+    });
+
+    test("deserializeTabs rejects empty tabs array", () => {
+      const bad = JSON.stringify({
+        version: TABS_STORAGE_VERSION,
+        tabs: [],
+        activeTabId: "tab-overview",
+      });
+      expect(deserializeTabs(bad)).toBeNull();
+    });
+
+    test("maxTabIdSuffix finds highest numeric suffix", () => {
+      expect(maxTabIdSuffix([])).toBe(0);
+      expect(maxTabIdSuffix([{ id: "tab-overview" }])).toBe(0);
+      expect(maxTabIdSuffix([
+        { id: "tab-overview" },
+        { id: "tab-1" },
+        { id: "tab-7" },
+        { id: "tab-3" },
+      ])).toBe(7);
+      // mixed / malformed ids — ignored
+      expect(maxTabIdSuffix([{ id: "weird-5" }, { id: "tab-2" }])).toBe(2);
+    });
+
+    test("restoreTab discards ephemeral fields by construction", () => {
+      // The SerializableTab type has no cache/selection fields, so restoreTab
+      // produces a runtime Tab with those undefined — verified by shape check.
+      const restored = restoreTab({
+        id: "tab-1", type: "table", label: "Pods", closable: true,
+        resourceType: "pods", filter: "nginx",
+      });
+      expect(restored.filter).toBe("nginx");
+      expect(restored.cachedItems).toBeUndefined();
+      expect(restored.selectedRows).toBeUndefined();
+      expect(restored.selectedRowIndex).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Each tab now owns its own filter, sort, stat filter, row selection, and keyboard focus — switching tabs no longer wipes the search or column sort you had.
- Tabs (including filter / sort / stat filter) persist to localStorage debounced at 250ms and rehydrate on startup, so the workspace survives a restart.
- Fixes a desync where the TitleBar search input was bound to a local \`\$state\` instead of \`uiStore.filter\`, so the visible value didn't follow the active tab.

## Implementation notes
- \`UiStoreLogic\` exposes per-tab state via getters/setters over \`this.activeTab.*\`. Ephemeral fields (\`cachedItems\`, \`cachedResource\`, \`selectedRows\`, \`selectedRowIndex\`, debounce scratch) are excluded from persistence.
- Debounced autosave serializes inside the timeout so bursts of keystrokes don't rebuild snapshots we'd discard.
- \`setFilter\` short-circuits on no-op writes; \`selectedRows\` getter returns a shared \`EMPTY_SELECTED_ROWS\` singleton to keep identity stable across reads.

## Test plan
- [x] \`bun test src/lib/stores/ui.test.ts\` — 61/61 pass (includes new persistence + per-tab state coverage)
- [x] \`svelte-check\` — 0 errors
- [ ] Manual: type in tab A's search, switch tab, come back — filter restored
- [ ] Manual: set sort/stat filter in tab A, switch and return — preserved
- [ ] Manual: restart app — tabs and their filters/sorts rehydrate from localStorage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabs now maintain their own filter, sorting, stat-filter, and selection state and are persisted/restored across sessions.

* **Bug Fixes**
  * Pending search/filter input is correctly committed when switching tabs, preventing lost or mixed-up edits.

* **Tests**
  * Expanded tests for per-tab state isolation, debounce/flush behavior, and persistence serialization/restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->