### PR TITLE
feat(pricing): daily cloud pricing dataset job

### DIFF
--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -1,0 +1,59 @@
+name: Update pricing dataset
+
+on:
+  schedule:
+    # Daily at 03:17 UTC (off-peak, jittered to avoid GH cron pile-up).
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-pricing
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Fetch and normalise pricing
+        run: bun scripts/fetch-pricing.ts
+
+      - name: Verify outputs
+        run: |
+          set -euo pipefail
+          for f in pricing-out/aws.json pricing-out/azure.json pricing-out/gcp.json pricing-out/index.json; do
+            test -s "$f" || { echo "missing or empty: $f" >&2; exit 1; }
+          done
+          ls -lh pricing-out/
+
+      - name: Publish to release tag pricing-data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="pricing-data"
+          NOTES="Daily pricing snapshot from instances.vantage.sh.\nGenerated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')\n\nNormalised cloud instance pricing for AWS, Azure, GCP. Replaced daily."
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG exists, replacing assets"
+            gh release upload "$TAG" pricing-out/aws.json pricing-out/azure.json pricing-out/gcp.json pricing-out/index.json --clobber
+            gh release edit "$TAG" --notes "$(printf '%b' "$NOTES")"
+          else
+            echo "release $TAG does not exist, creating"
+            gh release create "$TAG" \
+              --title "Pricing dataset (rolling)" \
+              --notes "$(printf '%b' "$NOTES")" \
+              --latest=false \
+              pricing-out/aws.json pricing-out/azure.json pricing-out/gcp.json pricing-out/index.json
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src-tauri/gen/
 *.log
 .env
 .gstack/
+pricing-out/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e:debug": "playwright test --debug",
     "benchmark": "tsx scripts/run-playwright-benchmarks.ts",
     "benchmark:ci": "tsx scripts/run-playwright-benchmarks.ts ./benchmark-results.json",
+    "fetch-pricing": "bun scripts/fetch-pricing.ts",
     "test": "bun test && cargo test --manifest-path src-tauri/Cargo.toml"
   },
   "dependencies": {

--- a/scripts/fetch-pricing.ts
+++ b/scripts/fetch-pricing.ts
@@ -1,0 +1,263 @@
+#!/usr/bin/env bun
+// Fetches cloud instance pricing from instances.vantage.sh for AWS, Azure, GCP.
+// Normalises into a compact, kdashboard-shaped JSON keyed by region/instance_type.
+// Output goes to ./pricing-out/ to be uploaded as release assets by CI.
+//
+// Source attribution: instances.vantage.sh / vantage-sh/ec2instances.info (AGPL data).
+// We only redistribute pricing facts (not the dataset code), normalised into our schema.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type NormalisedInstance = {
+  vcpu: number;
+  memory_gb: number;
+  ondemand_usd_hour: number | null;
+  spot_usd_hour: number | null;
+};
+
+type NormalisedDataset = {
+  version: string;
+  generated_at: string;
+  source: string;
+  provider: "aws" | "azure" | "gcp";
+  region_count: number;
+  instance_count: number;
+  // region -> instance_type -> price entry
+  instances: Record<string, Record<string, NormalisedInstance>>;
+};
+
+const VANTAGE = {
+  aws: "https://instances.vantage.sh/instances.json",
+  azure: "https://instances.vantage.sh/azure/instances.json",
+  gcp: "https://instances.vantage.sh/gcp/instances.json",
+} as const;
+
+const OUT_DIR = join(import.meta.dir, "..", "pricing-out");
+
+function parsePrice(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === "string" ? parseFloat(value) : Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { "user-agent": "kdashboard-pricing-fetcher/1.0" },
+  });
+  if (!res.ok) {
+    throw new Error(`fetch ${url} failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+type AwsInstance = {
+  instance_type: string;
+  vCPU: number;
+  memory: number;
+  pricing: Record<
+    string,
+    Partial<{
+      linux: { ondemand?: string; spot_min?: string };
+    }>
+  >;
+};
+
+function normaliseAws(raw: AwsInstance[]): NormalisedDataset {
+  const instances: NormalisedDataset["instances"] = {};
+  let count = 0;
+
+  for (const it of raw) {
+    if (!it.instance_type || !it.pricing) continue;
+
+    for (const [region, price] of Object.entries(it.pricing)) {
+      const linux = price?.linux;
+      if (!linux) continue;
+      const ondemand = parsePrice(linux.ondemand);
+      const spot = parsePrice(linux.spot_min);
+      if (ondemand === null && spot === null) continue;
+
+      instances[region] ??= {};
+      instances[region][it.instance_type] = {
+        vcpu: it.vCPU,
+        memory_gb: it.memory,
+        ondemand_usd_hour: ondemand,
+        spot_usd_hour: spot,
+      };
+      count++;
+    }
+  }
+
+  return {
+    version: new Date().toISOString().slice(0, 10),
+    generated_at: new Date().toISOString(),
+    source: VANTAGE.aws,
+    provider: "aws",
+    region_count: Object.keys(instances).length,
+    instance_count: count,
+    instances,
+  };
+}
+
+type AzureInstance = {
+  pretty_name: string;
+  vcpu: number;
+  memory: number;
+  pricing: Record<
+    string,
+    Partial<{
+      linux: { ondemand?: number | string; spot_min?: number | string };
+    }>
+  >;
+};
+
+function normaliseAzure(raw: AzureInstance[]): NormalisedDataset {
+  const instances: NormalisedDataset["instances"] = {};
+  let count = 0;
+
+  for (const it of raw) {
+    if (!it.pretty_name || !it.pricing) continue;
+
+    for (const [region, price] of Object.entries(it.pricing)) {
+      const linux = price?.linux;
+      if (!linux) continue;
+      const ondemand = parsePrice(linux.ondemand);
+      const spot = parsePrice(linux.spot_min);
+      if (ondemand === null && spot === null) continue;
+
+      instances[region] ??= {};
+      instances[region][it.pretty_name] = {
+        vcpu: it.vcpu,
+        memory_gb: it.memory,
+        ondemand_usd_hour: ondemand,
+        spot_usd_hour: spot,
+      };
+      count++;
+    }
+  }
+
+  return {
+    version: new Date().toISOString().slice(0, 10),
+    generated_at: new Date().toISOString(),
+    source: VANTAGE.azure,
+    provider: "azure",
+    region_count: Object.keys(instances).length,
+    instance_count: count,
+    instances,
+  };
+}
+
+type GcpInstance = {
+  instance_type: string;
+  vCPU: number;
+  memory: number;
+  pricing: Record<
+    string,
+    Partial<{
+      linux: { ondemand?: string; spot?: string };
+    }>
+  >;
+};
+
+function normaliseGcp(raw: GcpInstance[]): NormalisedDataset {
+  const instances: NormalisedDataset["instances"] = {};
+  let count = 0;
+
+  for (const it of raw) {
+    if (!it.instance_type || !it.pricing) continue;
+
+    for (const [region, price] of Object.entries(it.pricing)) {
+      const linux = price?.linux;
+      if (!linux) continue;
+      const ondemand = parsePrice(linux.ondemand);
+      const spot = parsePrice(linux.spot);
+      if (ondemand === null && spot === null) continue;
+
+      instances[region] ??= {};
+      instances[region][it.instance_type] = {
+        vcpu: it.vCPU,
+        memory_gb: it.memory,
+        ondemand_usd_hour: ondemand,
+        spot_usd_hour: spot,
+      };
+      count++;
+    }
+  }
+
+  return {
+    version: new Date().toISOString().slice(0, 10),
+    generated_at: new Date().toISOString(),
+    source: VANTAGE.gcp,
+    provider: "gcp",
+    region_count: Object.keys(instances).length,
+    instance_count: count,
+    instances,
+  };
+}
+
+async function run(): Promise<void> {
+  await mkdir(OUT_DIR, { recursive: true });
+
+  const tasks = [
+    {
+      name: "aws",
+      url: VANTAGE.aws,
+      normalise: (d: unknown) => normaliseAws(d as AwsInstance[]),
+    },
+    {
+      name: "azure",
+      url: VANTAGE.azure,
+      normalise: (d: unknown) => normaliseAzure(d as AzureInstance[]),
+    },
+    {
+      name: "gcp",
+      url: VANTAGE.gcp,
+      normalise: (d: unknown) => normaliseGcp(d as GcpInstance[]),
+    },
+  ] as const;
+
+  const summaries: Array<{
+    provider: string;
+    file: string;
+    bytes: number;
+    regions: number;
+    instances: number;
+  }> = [];
+
+  for (const t of tasks) {
+    process.stdout.write(`[${t.name}] fetching ${t.url}...\n`);
+    const raw = await fetchJson<unknown>(t.url);
+    const normalised = t.normalise(raw);
+    if (normalised.instance_count === 0) {
+      throw new Error(`[${t.name}] zero instances after normalisation — refusing to write`);
+    }
+    const json = JSON.stringify(normalised);
+    const file = `${t.name}.json`;
+    await writeFile(join(OUT_DIR, file), json);
+    summaries.push({
+      provider: t.name,
+      file,
+      bytes: json.length,
+      regions: normalised.region_count,
+      instances: normalised.instance_count,
+    });
+    process.stdout.write(
+      `[${t.name}] ${normalised.instance_count} prices across ${normalised.region_count} regions, ${(json.length / 1024).toFixed(1)} KB\n`,
+    );
+  }
+
+  const index = {
+    version: new Date().toISOString().slice(0, 10),
+    generated_at: new Date().toISOString(),
+    schema_version: 1,
+    source: "https://instances.vantage.sh",
+    providers: summaries,
+  };
+  await writeFile(join(OUT_DIR, "index.json"), JSON.stringify(index, null, 2));
+  process.stdout.write(`\nwrote index.json with ${summaries.length} providers\n`);
+}
+
+run().catch((err: unknown) => {
+  process.stderr.write(`fetch-pricing failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a daily GitHub Actions cron that fetches cloud instance pricing from `instances.vantage.sh` for AWS, Azure, and GCP, normalises it, and publishes the JSON dataset as assets on a rolling release with the fixed tag `pricing-data`.

This unblocks node cost lookup in `src-tauri/src/k8s/cost/` without requiring any in-cluster agent — kdashboard will fetch the dataset on startup and cache it locally (Rust client lands in a follow-up PR).

## What

- **`scripts/fetch-pricing.ts`** — bun script that calls Vantage, strips reserved/dedicated/spot-window noise, and outputs:
  ```
  region -> instance_type -> { vcpu, memory_gb, ondemand_usd_hour, spot_usd_hour }
  ```
  Fails fast if any provider returns 0 entries (defends against upstream breakage).

- **`.github/workflows/update-pricing.yml`** — runs daily at 03:17 UTC (jittered, off-peak) plus `workflow_dispatch`. Uses `gh release upload --clobber` against the `pricing-data` tag so the git history stays flat.

- **`.gitignore`** — adds `pricing-out/` so generated JSONs never get committed by mistake.

- **`package.json`** — adds `bun run fetch-pricing` for manual local runs.

## Local run output

```
[aws]   22,288 prices · 103 regions · 1.9 MB
[azure] 47,363 prices ·  60 regions · 4.0 MB
[gcp]   15,686 prices ·  47 regions · 1.6 MB
                                     ─────────
                                 ~7.5 MB total
```

## Public URLs (once first run completes)

- `https://github.com/folio-pro/kdashboard/releases/download/pricing-data/aws.json`
- `https://github.com/folio-pro/kdashboard/releases/download/pricing-data/azure.json`
- `https://github.com/folio-pro/kdashboard/releases/download/pricing-data/gcp.json`
- `https://github.com/folio-pro/kdashboard/releases/download/pricing-data/index.json`

## Test plan

- [x] Run `bun run fetch-pricing` locally — produces 4 files in `pricing-out/`, all non-empty.
- [x] Validate JSON shape with sample lookups (`aws.json` → `us-east-1` → `m5.large`).
- [ ] Trigger workflow manually with `gh workflow run "Update pricing dataset"` after merge — verify the release `pricing-data` is created with the 4 assets.
- [ ] Re-trigger the workflow and verify assets are replaced (not duplicated) thanks to `--clobber`.
- [ ] Wait for the first scheduled run (03:17 UTC) and confirm the cron fires.

## Out of scope

- Rust client that consumes the dataset (separate PR in `src-tauri/src/k8s/cost/pricing.rs`).
- Provider/region detection from Node labels.
- GCP via official Billing API (would need an API key as a repo secret).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated daily pricing data updates for AWS, Azure, and GCP now available and on-demand.

* **Chores**
  * Implemented automated workflow for collecting, validating, and publishing cloud provider pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->