### PR TITLE
feat(cost): resolve node pricing from GitHub release dataset

### DIFF
--- a/src-tauri/src/commands/app_commands.rs
+++ b/src-tauri/src/commands/app_commands.rs
@@ -41,6 +41,7 @@ pub async fn save_settings(
         if old.kubeconfig_path != settings.kubeconfig_path {
             k8s::client::set_kubeconfig_path(settings.kubeconfig_path.clone());
             k8s::client::reset_client();
+            k8s::cost::reset_metrics_availability();
         }
     }
 

--- a/src-tauri/src/k8s/context.rs
+++ b/src-tauri/src/k8s/context.rs
@@ -55,6 +55,8 @@ pub fn set_context(context: &str) -> Result<()> {
 
     // Force the client to reconnect with the new context.
     reset_client();
+    // Clear cached metrics-server availability so the new cluster is probed fresh.
+    super::cost::reset_metrics_availability();
 
     Ok(())
 }

--- a/src-tauri/src/k8s/cost/metrics.rs
+++ b/src-tauri/src/k8s/cost/metrics.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 
+use super::metrics_availability::{self, MetricsKind};
 use super::types::{
     ContainerMetrics, PodMetrics, PodMetricsList, PodMetricsMetadata, ResourceUsage,
 };
@@ -12,14 +13,31 @@ pub(super) async fn fetch_pod_metrics(
     client: &kube::Client,
     namespace: Option<&str>,
 ) -> Result<Vec<PodMetrics>> {
+    if !metrics_availability::is_available(MetricsKind::Pods) {
+        anyhow::bail!("metrics-server pods endpoint marked unavailable; using fallback");
+    }
+
     let url = match namespace {
         Some(ns) => format!("/apis/metrics.k8s.io/v1beta1/namespaces/{}/pods", ns),
         None => "/apis/metrics.k8s.io/v1beta1/pods".to_string(),
     };
 
     let request = kube::api::Request::new(&url).list(&Default::default())?;
-    let response: PodMetricsList = client.request(request).await?;
-    Ok(response.items)
+    match client.request::<PodMetricsList>(request).await {
+        Ok(response) => {
+            metrics_availability::mark_available(MetricsKind::Pods);
+            Ok(response.items)
+        }
+        Err(err) => {
+            let backoff = metrics_availability::mark_unavailable(MetricsKind::Pods);
+            tracing::warn!(
+                backoff_secs = backoff.as_secs(),
+                error = %err,
+                "metrics-server pods endpoint failed; backing off",
+            );
+            Err(err.into())
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/k8s/cost/metrics_availability.rs
+++ b/src-tauri/src/k8s/cost/metrics_availability.rs
@@ -1,0 +1,115 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MetricsKind {
+    Pods,
+    Nodes,
+}
+
+struct State {
+    unavailable_until: Option<Instant>,
+    consecutive_failures: u32,
+}
+
+const fn empty_state() -> State {
+    State {
+        unavailable_until: None,
+        consecutive_failures: 0,
+    }
+}
+
+static PODS_STATE: Mutex<State> = Mutex::new(empty_state());
+static NODES_STATE: Mutex<State> = Mutex::new(empty_state());
+
+const BACKOFF_STEPS_SECS: &[u64] = &[30, 60, 120, 300];
+
+fn slot(kind: MetricsKind) -> &'static Mutex<State> {
+    match kind {
+        MetricsKind::Pods => &PODS_STATE,
+        MetricsKind::Nodes => &NODES_STATE,
+    }
+}
+
+pub(super) fn is_available(kind: MetricsKind) -> bool {
+    let guard = slot(kind).lock().unwrap_or_else(|e| e.into_inner());
+    match guard.unavailable_until {
+        Some(until) => Instant::now() >= until,
+        None => true,
+    }
+}
+
+pub(super) fn mark_available(kind: MetricsKind) {
+    let mut guard = slot(kind).lock().unwrap_or_else(|e| e.into_inner());
+    if guard.consecutive_failures > 0 {
+        tracing::info!(endpoint = ?kind, "metrics-server endpoint recovered");
+    }
+    guard.unavailable_until = None;
+    guard.consecutive_failures = 0;
+}
+
+pub(super) fn mark_unavailable(kind: MetricsKind) -> Duration {
+    let mut guard = slot(kind).lock().unwrap_or_else(|e| e.into_inner());
+    let step = (guard.consecutive_failures as usize).min(BACKOFF_STEPS_SECS.len() - 1);
+    let secs = BACKOFF_STEPS_SECS[step];
+    guard.consecutive_failures = guard.consecutive_failures.saturating_add(1);
+    let dur = Duration::from_secs(secs);
+    guard.unavailable_until = Some(Instant::now() + dur);
+    dur
+}
+
+/// Call on context switch / kubeconfig change so a new cluster is probed fresh
+/// instead of inheriting the previous cluster's availability state.
+pub fn reset() {
+    for s in [&PODS_STATE, &NODES_STATE] {
+        let mut g = s.lock().unwrap_or_else(|e| e.into_inner());
+        g.unavailable_until = None;
+        g.consecutive_failures = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    // Tests share global state — run them sequentially.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn clear() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        reset();
+        guard
+    }
+
+    #[test]
+    fn starts_available() {
+        let _g = clear();
+        assert!(is_available(MetricsKind::Pods));
+        assert!(is_available(MetricsKind::Nodes));
+    }
+
+    #[test]
+    fn marks_unavailable_with_growing_backoff() {
+        let _g = clear();
+        let first = mark_unavailable(MetricsKind::Pods);
+        let second = mark_unavailable(MetricsKind::Pods);
+        let third = mark_unavailable(MetricsKind::Pods);
+        assert_eq!(first, Duration::from_secs(30));
+        assert_eq!(second, Duration::from_secs(60));
+        assert_eq!(third, Duration::from_secs(120));
+        assert!(!is_available(MetricsKind::Pods));
+        assert!(is_available(MetricsKind::Nodes));
+    }
+
+    #[test]
+    fn recovery_resets_backoff() {
+        let _g = clear();
+        mark_unavailable(MetricsKind::Nodes);
+        mark_unavailable(MetricsKind::Nodes);
+        mark_available(MetricsKind::Nodes);
+        // After recovery, the next failure should restart at the first backoff step.
+        let next = mark_unavailable(MetricsKind::Nodes);
+        assert_eq!(next, Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/k8s/cost/mod.rs
+++ b/src-tauri/src/k8s/cost/mod.rs
@@ -1,9 +1,12 @@
 mod calculations;
 mod metrics;
+mod metrics_availability;
 mod node_metrics;
 mod nodes;
 mod pricing;
 mod types;
+
+pub use metrics_availability::reset as reset_metrics_availability;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/k8s/cost/mod.rs
+++ b/src-tauri/src/k8s/cost/mod.rs
@@ -15,4 +15,4 @@ pub use types::{CostOverview, NamespaceCostSummary, NodeCostInfo, NodeMetricsInf
 // Re-export public functions
 pub use calculations::get_cost_overview;
 pub use node_metrics::{get_node_costs, get_node_metrics};
-pub use pricing::refresh_pricing;
+pub use pricing::{refresh_pricing, spawn_periodic_refresh};

--- a/src-tauri/src/k8s/cost/node_metrics.rs
+++ b/src-tauri/src/k8s/cost/node_metrics.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 use super::calculations::HOURS_PER_MONTH;
 use super::metrics::{parse_cpu, parse_memory};
+use super::metrics_availability::{self, MetricsKind};
 use super::nodes::get_node_info;
 use super::pricing::resolve_pricing;
 use super::types::{NodeCostInfo, NodeMetricsInfo, NodeMetricsList};
@@ -15,12 +16,34 @@ use crate::k8s::client::get_client;
 pub async fn get_node_metrics() -> Result<Vec<NodeMetricsInfo>> {
     let client = get_client().await?;
 
+    if !metrics_availability::is_available(MetricsKind::Nodes) {
+        anyhow::bail!("metrics-server nodes endpoint marked unavailable; skipping");
+    }
+
     let url = "/apis/metrics.k8s.io/v1beta1/nodes";
     let request = kube::api::Request::new(url).list(&Default::default())?;
-    let response: NodeMetricsList = client.request(request).await?;
 
-    // Reuse get_node_info to avoid a duplicate node list API call
-    let nodes = get_node_info(&client).await.unwrap_or_default();
+    let (metrics_result, nodes) = tokio::join!(
+        client.request::<NodeMetricsList>(request),
+        async { get_node_info(&client).await.unwrap_or_default() },
+    );
+
+    let response: NodeMetricsList = match metrics_result {
+        Ok(resp) => {
+            metrics_availability::mark_available(MetricsKind::Nodes);
+            resp
+        }
+        Err(err) => {
+            let backoff = metrics_availability::mark_unavailable(MetricsKind::Nodes);
+            tracing::warn!(
+                backoff_secs = backoff.as_secs(),
+                error = %err,
+                "metrics-server nodes endpoint failed; backing off",
+            );
+            return Err(err.into());
+        }
+    };
+
     let capacity_map: HashMap<String, (f64, f64)> = nodes
         .into_iter()
         .map(|n| (n.name, (n.cpu_capacity, n.memory_capacity_bytes)))

--- a/src-tauri/src/k8s/cost/pricing.rs
+++ b/src-tauri/src/k8s/cost/pricing.rs
@@ -415,18 +415,72 @@ pub(super) async fn resolve_pricing(nodes: &[NodeInfo]) -> Option<HashMap<String
         return None;
     }
 
+    // Track which providers we successfully (re)loaded. A `false` here means
+    // both network and stale-disk fallback failed — DATASET_CACHE may still
+    // hold a pre-existing entry from a previous run, but we have no way to
+    // confirm its freshness, so we MUST NOT serve from it.
+    let mut loaded_ok: Vec<&str> = Vec::with_capacity(providers.len());
     for provider in &providers {
-        ensure_dataset_loaded(provider).await;
+        if ensure_dataset_loaded(provider).await {
+            loaded_ok.push(*provider);
+        } else {
+            tracing::warn!(
+                provider = %provider,
+                "pricing dataset unavailable (network + disk fallback both failed); \
+                 skipping this provider"
+            );
+        }
+    }
+
+    if loaded_ok.is_empty() {
+        return None;
     }
 
     let cache = DATASET_CACHE.lock().await;
     let map = cache.as_ref()?;
+    let prices = lookup_prices(nodes, &loaded_ok, map, Instant::now());
 
+    if prices.is_empty() {
+        tracing::info!(
+            providers_loaded = loaded_ok.len(),
+            "pricing dataset loaded but no nodes matched any region/instance_type"
+        );
+        None
+    } else {
+        Some(prices)
+    }
+}
+
+/// Pure lookup over a previously-loaded cache map. Two guards layered for
+/// defence-in-depth:
+///   1. Skip any provider not in `loaded_ok` — its presence in `cache` may be
+///      a stale leftover from a previous run that we couldn't refresh.
+///   2. Skip any entry whose `expires_at` is in the past. By construction
+///      `ensure_dataset_loaded` only installs entries with a future
+///      `expires_at`, so this should never fire in practice — but it
+///      protects against future refactors that decouple "loaded ok" from
+///      "freshly installed".
+fn lookup_prices(
+    nodes: &[NodeInfo],
+    loaded_ok: &[&str],
+    cache: &HashMap<String, ProviderDataset>,
+    now: Instant,
+) -> HashMap<String, f64> {
     let mut prices: HashMap<String, f64> = HashMap::new();
     for node in nodes {
-        let Some(ds) = map.get(&node.provider) else {
+        if !loaded_ok.contains(&node.provider.as_str()) {
+            continue;
+        }
+        let Some(ds) = cache.get(&node.provider) else {
             continue;
         };
+        if ds.expires_at <= now {
+            tracing::warn!(
+                provider = %node.provider,
+                "pricing dataset unexpectedly expired between load and read; skipping"
+            );
+            continue;
+        }
         let Some(by_region) = ds.prices.get(&node.region) else {
             continue;
         };
@@ -436,16 +490,7 @@ pub(super) async fn resolve_pricing(nodes: &[NodeInfo]) -> Option<HashMap<String
         let key = format!("{}/{}/{}", node.provider, node.region, node.instance_type);
         prices.insert(key, *price);
     }
-
-    if prices.is_empty() {
-        tracing::info!(
-            providers_loaded = providers.len(),
-            "pricing dataset loaded but no nodes matched any region/instance_type"
-        );
-        None
-    } else {
-        Some(prices)
-    }
+    prices
 }
 
 /// Force-clear the in-memory pricing cache and the cost overview cache. Disk
@@ -655,6 +700,94 @@ mod tests {
     #[tokio::test]
     async fn resolve_pricing_returns_none_for_empty_input() {
         assert!(resolve_pricing(&[]).await.is_none());
+    }
+
+    fn fake_node(provider: &str, region: &str, itype: &str) -> NodeInfo {
+        NodeInfo {
+            name: format!("{provider}-node"),
+            instance_type: itype.into(),
+            provider: provider.into(),
+            region: region.into(),
+            cpu_capacity: 2.0,
+            memory_capacity_bytes: 8.0 * 1024.0 * 1024.0 * 1024.0,
+        }
+    }
+
+    fn cache_with(provider: &str, region: &str, itype: &str, price: f64, ttl: Duration) -> HashMap<String, ProviderDataset> {
+        let mut by_type = HashMap::new();
+        by_type.insert(itype.to_string(), price);
+        let mut by_region = HashMap::new();
+        by_region.insert(region.to_string(), by_type);
+        let mut map = HashMap::new();
+        map.insert(
+            provider.to_string(),
+            ProviderDataset {
+                prices: by_region,
+                expires_at: Instant::now() + ttl,
+            },
+        );
+        map
+    }
+
+    #[test]
+    fn lookup_prices_returns_match_for_loaded_provider() {
+        let nodes = vec![fake_node("aws", "us-east-1", "m5.large")];
+        let cache = cache_with("aws", "us-east-1", "m5.large", 0.096, DATASET_TTL);
+        let out = lookup_prices(&nodes, &["aws"], &cache, Instant::now());
+        assert_eq!(out.get("aws/us-east-1/m5.large").copied(), Some(0.096));
+    }
+
+    #[test]
+    fn lookup_prices_skips_provider_not_in_loaded_ok() {
+        // Cache has aws but the loader didn't OK it (e.g. previous-run leftover
+        // that we couldn't refresh). Must not be served.
+        let nodes = vec![fake_node("aws", "us-east-1", "m5.large")];
+        let cache = cache_with("aws", "us-east-1", "m5.large", 0.096, DATASET_TTL);
+        let out = lookup_prices(&nodes, &[], &cache, Instant::now());
+        assert!(out.is_empty(), "expected no match without loaded_ok, got {out:?}");
+    }
+
+    #[test]
+    fn lookup_prices_skips_expired_dataset_even_when_loaded_ok() {
+        // Defensive: even if loaded_ok lists the provider, an expires_at in the
+        // past means the entry is stale and must not be served.
+        let nodes = vec![fake_node("aws", "us-east-1", "m5.large")];
+        let mut cache = cache_with("aws", "us-east-1", "m5.large", 0.096, DATASET_TTL);
+        // Force expiry into the past.
+        if let Some(ds) = cache.get_mut("aws") {
+            ds.expires_at = Instant::now() - Duration::from_secs(1);
+        }
+        let out = lookup_prices(&nodes, &["aws"], &cache, Instant::now());
+        assert!(out.is_empty(), "expired dataset must be skipped, got {out:?}");
+    }
+
+    #[test]
+    fn lookup_prices_partial_when_one_provider_fails() {
+        // aws loaded ok, gcp not: aws node resolves, gcp node doesn't.
+        let nodes = vec![
+            fake_node("aws", "us-east-1", "m5.large"),
+            fake_node("gcp", "us-central1", "e2-standard-4"),
+        ];
+        let mut cache = cache_with("aws", "us-east-1", "m5.large", 0.096, DATASET_TTL);
+        // Pre-existing stale gcp entry — exactly the leftover scenario.
+        let mut by_type = HashMap::new();
+        by_type.insert("e2-standard-4".to_string(), 0.13);
+        let mut by_region = HashMap::new();
+        by_region.insert("us-central1".to_string(), by_type);
+        cache.insert(
+            "gcp".to_string(),
+            ProviderDataset {
+                prices: by_region,
+                expires_at: Instant::now() + DATASET_TTL,
+            },
+        );
+
+        let out = lookup_prices(&nodes, &["aws"], &cache, Instant::now());
+        assert_eq!(out.get("aws/us-east-1/m5.large").copied(), Some(0.096));
+        assert!(
+            !out.contains_key("gcp/us-central1/e2-standard-4"),
+            "gcp not in loaded_ok must be skipped despite being in cache"
+        );
     }
 
     fn unique_tmp_dir(label: &str) -> PathBuf {

--- a/src-tauri/src/k8s/cost/pricing.rs
+++ b/src-tauri/src/k8s/cost/pricing.rs
@@ -42,6 +42,11 @@ const PRICING_BASE_URL: &str =
 const SUPPORTED_PROVIDERS: &[&str] = &["aws", "azure", "gcp"];
 
 const DATASET_TTL: Duration = Duration::from_secs(86400); // 24h
+/// TTL applied when we install a dataset whose freshness we could NOT validate
+/// (network down + only a stale disk cache available). Short so the next
+/// `resolve_pricing` call retries the network instead of serving the
+/// unvalidated bytes for a full day.
+const STALE_RETRY_TTL: Duration = Duration::from_secs(300); // 5 minutes
 const DISK_CACHE_DIR: &str = ".kdashboard/pricing";
 
 // ---------------------------------------------------------------------------
@@ -345,10 +350,18 @@ async fn ensure_dataset_loaded(provider: &str) -> bool {
         }
     }
 
-    // Last resort: stale disk body.
+    // Last resort: stale disk body. We could not validate freshness against
+    // either the meta TTL or the network, so apply a short TTL — the next
+    // resolve_pricing call (5 minutes from now) will retry the network instead
+    // of serving these unvalidated bytes for a full day.
     if let Some(body) = read_disk_body(provider).await {
-        if let Ok(ds) = parse_dataset(&body) {
-            tracing::info!(provider, "using stale disk cache (network unreachable)");
+        if let Ok(mut ds) = parse_dataset(&body) {
+            ds.expires_at = Instant::now() + STALE_RETRY_TTL;
+            tracing::info!(
+                provider,
+                retry_in_secs = STALE_RETRY_TTL.as_secs(),
+                "using stale disk cache (network unreachable), short TTL"
+            );
             install_dataset(provider, ds).await;
             return true;
         }
@@ -566,6 +579,20 @@ mod tests {
             fetched_at: now_epoch_seconds() - DATASET_TTL.as_secs() - 60,
         };
         assert!(!meta_is_fresh(&meta));
+    }
+
+    #[test]
+    fn stale_retry_ttl_is_much_shorter_than_dataset_ttl() {
+        // Guards against a future change that accidentally equates the two —
+        // which would re-introduce the bug where unvalidated stale-disk loads
+        // are kept for a full day after a transient network failure.
+        assert!(STALE_RETRY_TTL > Duration::ZERO);
+        assert!(
+            STALE_RETRY_TTL * 10 < DATASET_TTL,
+            "STALE_RETRY_TTL ({:?}) must be << DATASET_TTL ({:?})",
+            STALE_RETRY_TTL,
+            DATASET_TTL,
+        );
     }
 
     #[test]

--- a/src-tauri/src/k8s/cost/pricing.rs
+++ b/src-tauri/src/k8s/cost/pricing.rs
@@ -1,124 +1,307 @@
-use anyhow::Result;
+//! Pricing resolver backed by the daily-refreshed dataset published as
+//! GitHub release assets (see `.github/workflows/update-pricing.yml`).
+//!
+//! Strategy:
+//! 1. For each unique provider in the requested nodes, ensure the provider's
+//!    dataset is loaded (memory → disk cache → network fetch, in that order).
+//! 2. Resolve `(provider, region, instance_type) -> $/hour` purely in-memory.
+//!
+//! Cache layers:
+//! - In-memory `HashMap<provider, ProviderDataset>` with 24h TTL — survives the
+//!   process lifetime, refreshed lazily.
+//! - Disk cache at `~/.kdashboard/pricing/<provider>.json` with the same TTL —
+//!   survives restarts and offline boots.
+//!
+//! Failure mode: if both network and disk fail, returns `None` and the caller
+//! falls back to hardcoded rates. If the network fails but a stale disk cache
+//! exists, we use the stale cache rather than nothing.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
 use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::Mutex;
 
-use super::types::{NodeInfo, PricingResolveRequest, PricingResolveResponse, ResolvedPricing};
+use super::types::NodeInfo;
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const PRICING_RESOLVE_URL: &str = "https://www.kdashboard.app/api/pricing/resolve";
+const PRICING_BASE_URL: &str =
+    "https://github.com/folio-pro/kdashboard/releases/download/pricing-data";
 
-pub(super) static RESOLVED_PRICING: Mutex<Option<ResolvedPricing>> =
+const SUPPORTED_PROVIDERS: &[&str] = &["aws", "azure", "gcp"];
+
+const DATASET_TTL: Duration = Duration::from_secs(86400); // 24 hours
+
+const DISK_CACHE_DIR: &str = ".kdashboard/pricing";
+
+// ---------------------------------------------------------------------------
+// Dataset shape (matches scripts/fetch-pricing.ts output)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct InstancePrice {
+    #[allow(dead_code)]
+    vcpu: f64,
+    #[allow(dead_code)]
+    memory_gb: f64,
+    ondemand_usd_hour: Option<f64>,
+    #[allow(dead_code)]
+    spot_usd_hour: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawDataset {
+    #[allow(dead_code)]
+    version: String,
+    #[allow(dead_code)]
+    generated_at: String,
+    /// region -> instance_type -> price entry
+    instances: HashMap<String, HashMap<String, InstancePrice>>,
+}
+
+struct ProviderDataset {
+    /// region -> instance_type -> on-demand $/hour
+    prices: HashMap<String, HashMap<String, f64>>,
+    expires_at: Instant,
+}
+
+// ---------------------------------------------------------------------------
+// Caches
+// ---------------------------------------------------------------------------
+
+static DATASET_CACHE: Mutex<Option<HashMap<String, ProviderDataset>>> =
     tokio::sync::Mutex::const_new(None);
-
-const RESOLVED_PRICING_TTL: Duration = Duration::from_secs(86400); // 24 hours
-
-// ---------------------------------------------------------------------------
-// HTTP client singleton
-// ---------------------------------------------------------------------------
 
 fn http_client() -> &'static reqwest::Client {
     use std::sync::OnceLock;
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
         reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_else(|e| {
-                tracing::error!(
-                    "Failed to create HTTP client with timeout: {}, falling back to default",
-                    e
-                );
+                tracing::error!(error = %e, "pricing http client init failed, using default");
                 reqwest::Client::new()
             })
     })
 }
 
+fn pricing_base_url() -> String {
+    std::env::var("KDASHBOARD_PRICING_URL").unwrap_or_else(|_| PRICING_BASE_URL.to_string())
+}
+
+fn disk_cache_path(provider: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(home.join(DISK_CACHE_DIR).join(format!("{provider}.json")))
+}
+
 // ---------------------------------------------------------------------------
-// Resolve pricing via server API
+// Disk cache helpers
 // ---------------------------------------------------------------------------
 
-/// Resolve pricing for a set of nodes by calling the server API.
-/// Only sends the unique instance types — response is < 1 KB typically.
-pub(super) async fn resolve_pricing(nodes: &[NodeInfo]) -> Option<HashMap<String, f64>> {
-    // Check cache
-    {
-        let cache = RESOLVED_PRICING.lock().await;
-        if let Some(ref cached) = *cache {
-            if cached.expires_at > Instant::now() {
-                return Some(cached.prices.clone());
-            }
-        }
+async fn read_disk_cache(provider: &str) -> Option<(String, bool)> {
+    let path = disk_cache_path(provider)?;
+    let metadata = tokio::fs::metadata(&path).await.ok()?;
+    let modified = metadata.modified().ok()?;
+    let age = SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or(Duration::ZERO);
+    let fresh = age < DATASET_TTL;
+
+    let contents = tokio::fs::read_to_string(&path).await.ok()?;
+    Some((contents, fresh))
+}
+
+async fn write_disk_cache(provider: &str, contents: &str) -> Result<()> {
+    let path = disk_cache_path(provider).context("home dir unavailable")?;
+    if let Some(dir) = path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("create_dir_all {dir:?}"))?;
     }
+    tokio::fs::write(&path, contents)
+        .await
+        .with_context(|| format!("write {path:?}"))?;
+    Ok(())
+}
 
-    // Build unique node specs
-    let mut seen = std::collections::HashSet::new();
-    let mut specs = Vec::new();
-    for node in nodes {
-        let key = format!("{}/{}/{}", node.provider, node.region, node.instance_type);
-        if seen.insert(key) {
-            specs.push(PricingResolveRequest {
-                provider: node.provider.clone(),
-                region: node.region.clone(),
-                instance_type: node.instance_type.clone(),
-            });
-        }
-    }
+// ---------------------------------------------------------------------------
+// Network fetch
+// ---------------------------------------------------------------------------
 
-    if specs.is_empty() {
-        return None;
-    }
-
-    let http = http_client();
-
-    let resp = match http.post(PRICING_RESOLVE_URL).json(&specs).send().await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!("Failed to resolve pricing: {}", e);
-            return None;
-        }
-    };
-
+async fn fetch_dataset_from_network(provider: &str) -> Result<String> {
+    let url = format!("{}/{}.json", pricing_base_url(), provider);
+    let resp = http_client()
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
     if !resp.status().is_success() {
-        tracing::warn!("Pricing resolve API returned {}", resp.status());
+        anyhow::bail!("pricing fetch returned {}", resp.status());
+    }
+    let body = resp.text().await.context("read pricing body")?;
+    Ok(body)
+}
+
+fn parse_dataset(json: &str) -> Result<ProviderDataset> {
+    let raw: RawDataset = serde_json::from_str(json).context("parse pricing dataset")?;
+    let mut prices: HashMap<String, HashMap<String, f64>> = HashMap::new();
+    for (region, types) in raw.instances {
+        let mut region_prices: HashMap<String, f64> = HashMap::new();
+        for (instance_type, price) in types {
+            if let Some(p) = price.ondemand_usd_hour {
+                if p > 0.0 {
+                    region_prices.insert(instance_type, p);
+                }
+            }
+        }
+        if !region_prices.is_empty() {
+            prices.insert(region, region_prices);
+        }
+    }
+    Ok(ProviderDataset {
+        prices,
+        expires_at: Instant::now() + DATASET_TTL,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Ensure a dataset is available for a provider.
+// Order: memory cache → fresh disk → network → stale disk fallback.
+// ---------------------------------------------------------------------------
+
+async fn ensure_dataset_loaded(provider: &str) -> bool {
+    {
+        let cache = DATASET_CACHE.lock().await;
+        if let Some(map) = cache.as_ref() {
+            if let Some(ds) = map.get(provider) {
+                if ds.expires_at > Instant::now() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    // Try fresh disk cache
+    if let Some((contents, fresh)) = read_disk_cache(provider).await {
+        if fresh {
+            match parse_dataset(&contents) {
+                Ok(ds) => {
+                    install_dataset(provider, ds).await;
+                    return true;
+                }
+                Err(e) => {
+                    tracing::warn!(provider, error = %e, "disk cache corrupt, will refetch");
+                }
+            }
+        }
+    }
+
+    // Network fetch
+    match fetch_dataset_from_network(provider).await {
+        Ok(body) => match parse_dataset(&body) {
+            Ok(ds) => {
+                if let Err(e) = write_disk_cache(provider, &body).await {
+                    tracing::warn!(provider, error = %e, "disk cache write failed");
+                }
+                install_dataset(provider, ds).await;
+                return true;
+            }
+            Err(e) => {
+                tracing::warn!(provider, error = %e, "pricing dataset parse failed");
+            }
+        },
+        Err(e) => {
+            tracing::warn!(provider, error = %e, "pricing dataset fetch failed");
+        }
+    }
+
+    // Last resort: stale disk cache
+    if let Some((contents, _)) = read_disk_cache(provider).await {
+        match parse_dataset(&contents) {
+            Ok(ds) => {
+                tracing::info!(provider, "using stale disk cache (network unreachable)");
+                install_dataset(provider, ds).await;
+                return true;
+            }
+            Err(e) => {
+                tracing::warn!(provider, error = %e, "stale disk cache also unreadable");
+            }
+        }
+    }
+
+    false
+}
+
+async fn install_dataset(provider: &str, ds: ProviderDataset) {
+    let mut cache = DATASET_CACHE.lock().await;
+    let map = cache.get_or_insert_with(HashMap::new);
+    map.insert(provider.to_string(), ds);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: same signature as before — keys are "provider/region/instance_type".
+// ---------------------------------------------------------------------------
+
+pub(super) async fn resolve_pricing(nodes: &[NodeInfo]) -> Option<HashMap<String, f64>> {
+    if nodes.is_empty() {
         return None;
     }
 
-    match resp.json::<PricingResolveResponse>().await {
-        Ok(data) => {
-            let mut prices = HashMap::new();
-            for item in &data.results {
-                prices.insert(item.key.clone(), item.price_per_hour);
-            }
-            tracing::info!(
-                resolved = data.resolved,
-                total = data.total,
-                "pricing_resolved"
-            );
+    let mut providers: Vec<&str> = nodes
+        .iter()
+        .map(|n| n.provider.as_str())
+        .filter(|p| SUPPORTED_PROVIDERS.contains(p))
+        .collect();
+    providers.sort_unstable();
+    providers.dedup();
 
-            // Cache results
-            let mut cache = RESOLVED_PRICING.lock().await;
-            *cache = Some(ResolvedPricing {
-                prices: prices.clone(),
-                expires_at: Instant::now() + RESOLVED_PRICING_TTL,
-            });
+    if providers.is_empty() {
+        return None;
+    }
 
-            Some(prices)
-        }
-        Err(e) => {
-            tracing::warn!("Failed to parse pricing response: {}", e);
-            None
-        }
+    for provider in &providers {
+        ensure_dataset_loaded(provider).await;
+    }
+
+    let cache = DATASET_CACHE.lock().await;
+    let map = cache.as_ref()?;
+
+    let mut prices: HashMap<String, f64> = HashMap::new();
+    for node in nodes {
+        let Some(ds) = map.get(&node.provider) else {
+            continue;
+        };
+        let Some(by_region) = ds.prices.get(&node.region) else {
+            continue;
+        };
+        let Some(price) = by_region.get(&node.instance_type) else {
+            continue;
+        };
+        let key = format!("{}/{}/{}", node.provider, node.region, node.instance_type);
+        prices.insert(key, *price);
+    }
+
+    if prices.is_empty() {
+        tracing::info!(
+            providers_loaded = providers.len(),
+            "pricing dataset loaded but no nodes matched any region/instance_type"
+        );
+        None
+    } else {
+        Some(prices)
     }
 }
 
-/// Force-refresh pricing by clearing cache and re-resolving.
+/// Force-refresh pricing by clearing in-memory caches. Disk cache is left in
+/// place — next call will refetch from network and overwrite it.
 pub async fn refresh_pricing() -> Result<()> {
     {
-        let mut cache = RESOLVED_PRICING.lock().await;
+        let mut cache = DATASET_CACHE.lock().await;
         *cache = None;
     }
     {
@@ -126,4 +309,114 @@ pub async fn refresh_pricing() -> Result<()> {
         *cache = None;
     }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_JSON: &str = r#"{
+        "version": "2026-04-25",
+        "generated_at": "2026-04-25T20:17:18Z",
+        "source": "https://example.test",
+        "provider": "aws",
+        "region_count": 1,
+        "instance_count": 2,
+        "instances": {
+            "us-east-1": {
+                "m5.large": { "vcpu": 2, "memory_gb": 8, "ondemand_usd_hour": 0.096, "spot_usd_hour": 0.04 },
+                "broken": { "vcpu": 1, "memory_gb": 1, "ondemand_usd_hour": null, "spot_usd_hour": null }
+            }
+        }
+    }"#;
+
+    #[test]
+    fn parse_dataset_skips_null_prices() {
+        let ds = parse_dataset(SAMPLE_JSON).expect("parses");
+        let region = ds.prices.get("us-east-1").expect("region");
+        assert_eq!(region.get("m5.large").copied(), Some(0.096));
+        assert!(region.get("broken").is_none(), "null prices must be filtered");
+    }
+
+    #[test]
+    fn parse_dataset_drops_zero_priced_entries() {
+        let json = r#"{
+            "version": "x", "generated_at": "x", "source": "x", "provider": "aws",
+            "region_count": 1, "instance_count": 1,
+            "instances": { "r": { "i": { "vcpu": 1, "memory_gb": 1, "ondemand_usd_hour": 0, "spot_usd_hour": null } } }
+        }"#;
+        let ds = parse_dataset(json).expect("parses");
+        assert!(
+            ds.prices.get("r").is_none(),
+            "regions with zero-priced entries become empty and are dropped"
+        );
+    }
+
+    #[test]
+    fn parse_dataset_rejects_invalid_json() {
+        match parse_dataset("{ not json") {
+            Ok(_) => panic!("expected parse error"),
+            Err(e) => assert!(e.to_string().contains("parse"), "unexpected error: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_pricing_returns_none_when_unsupported_provider() {
+        let nodes = vec![NodeInfo {
+            name: "n1".into(),
+            instance_type: "x".into(),
+            provider: "openstack".into(),
+            region: "r".into(),
+            cpu_capacity: 1.0,
+            memory_capacity_bytes: 1.0,
+        }];
+        assert!(resolve_pricing(&nodes).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_pricing_returns_none_for_empty_input() {
+        assert!(resolve_pricing(&[]).await.is_none());
+    }
+
+    /// Live network test against the actual GitHub release. Ignored by default —
+    /// run with `cargo test --lib cost::pricing -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn resolve_pricing_against_real_release() {
+        let nodes = vec![
+            NodeInfo {
+                name: "aws-1".into(),
+                instance_type: "m5.large".into(),
+                provider: "aws".into(),
+                region: "us-east-1".into(),
+                cpu_capacity: 2.0,
+                memory_capacity_bytes: 8.0 * 1024.0 * 1024.0 * 1024.0,
+            },
+            NodeInfo {
+                name: "gcp-1".into(),
+                instance_type: "e2-standard-4".into(),
+                provider: "gcp".into(),
+                region: "us-central1".into(),
+                cpu_capacity: 4.0,
+                memory_capacity_bytes: 16.0 * 1024.0 * 1024.0 * 1024.0,
+            },
+        ];
+
+        let prices = resolve_pricing(&nodes).await.expect("got prices");
+        assert!(
+            prices.contains_key("aws/us-east-1/m5.large"),
+            "missing aws m5.large: {prices:?}"
+        );
+        assert!(
+            prices.contains_key("gcp/us-central1/e2-standard-4"),
+            "missing gcp e2-standard-4: {prices:?}"
+        );
+        for (k, v) in &prices {
+            assert!(*v > 0.0 && *v < 100.0, "implausible price for {k}: {v}");
+        }
+    }
 }

--- a/src-tauri/src/k8s/cost/pricing.rs
+++ b/src-tauri/src/k8s/cost/pricing.rs
@@ -26,7 +26,8 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
@@ -149,16 +150,8 @@ async fn read_disk_meta(provider: &str) -> Option<DatasetMeta> {
 
 async fn write_disk_meta(provider: &str, meta: &DatasetMeta) -> Result<()> {
     let path = meta_path(provider).context("home dir unavailable")?;
-    if let Some(dir) = path.parent() {
-        tokio::fs::create_dir_all(dir)
-            .await
-            .with_context(|| format!("create_dir_all {dir:?}"))?;
-    }
     let body = serde_json::to_string(meta).context("serialise meta")?;
-    tokio::fs::write(&path, body)
-        .await
-        .with_context(|| format!("write {path:?}"))?;
-    Ok(())
+    atomic_write(&path, body.as_bytes()).await
 }
 
 async fn read_disk_body(provider: &str) -> Option<String> {
@@ -167,14 +160,46 @@ async fn read_disk_body(provider: &str) -> Option<String> {
 
 async fn write_disk_body(provider: &str, body: &str) -> Result<()> {
     let path = dataset_path(provider).context("home dir unavailable")?;
+    atomic_write(&path, body.as_bytes()).await
+}
+
+/// Crash-safe replacement of `path` with `contents`. Writes to a uniquely-named
+/// temp sibling first, then atomically renames it onto the target. If the
+/// process dies mid-write, the previous file at `path` is untouched and the
+/// orphaned temp file can be ignored or cleaned up later — it never partially
+/// replaces real cache content. Multiple concurrent callers writing to the
+/// same `path` get distinct temp names (process id + monotonic counter), so
+/// they don't clobber each other's intermediate writes.
+async fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
     if let Some(dir) = path.parent() {
         tokio::fs::create_dir_all(dir)
             .await
             .with_context(|| format!("create_dir_all {dir:?}"))?;
     }
-    tokio::fs::write(&path, body)
-        .await
-        .with_context(|| format!("write {path:?}"))?;
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let tmp_path = {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(format!(
+            ".tmp.{}.{}",
+            std::process::id(),
+            TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        PathBuf::from(name)
+    };
+
+    if let Err(e) = tokio::fs::write(&tmp_path, contents).await {
+        return Err(anyhow::Error::from(e))
+            .with_context(|| format!("write temp {tmp_path:?} for {path:?}"));
+    }
+
+    if let Err(e) = tokio::fs::rename(&tmp_path, path).await {
+        // Best-effort cleanup; the orphan temp is harmless if this also fails.
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(anyhow::Error::from(e))
+            .with_context(|| format!("rename {tmp_path:?} -> {path:?}"));
+    }
+
     Ok(())
 }
 
@@ -630,6 +655,82 @@ mod tests {
     #[tokio::test]
     async fn resolve_pricing_returns_none_for_empty_input() {
         assert!(resolve_pricing(&[]).await.is_none());
+    }
+
+    fn unique_tmp_dir(label: &str) -> PathBuf {
+        let unique = format!(
+            "kdashboard-pricing-{}-{}-{}",
+            label,
+            std::process::id(),
+            TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[tokio::test]
+    async fn atomic_write_creates_file_and_parent_dirs() {
+        let dir = unique_tmp_dir("create");
+        let path = dir.join("nested").join("a.json");
+        atomic_write(&path, b"hello").await.expect("write ok");
+        let got = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(got, "hello");
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn atomic_write_replaces_existing_content() {
+        let dir = unique_tmp_dir("replace");
+        let path = dir.join("a.json");
+        atomic_write(&path, b"first").await.expect("first write");
+        atomic_write(&path, b"second").await.expect("second write");
+        let got = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(got, "second");
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn atomic_write_leaves_no_temp_files_behind() {
+        let dir = unique_tmp_dir("notemp");
+        let path = dir.join("a.json");
+        atomic_write(&path, b"x").await.expect("write");
+
+        let mut entries = tokio::fs::read_dir(&dir).await.expect("read_dir");
+        let mut names = Vec::new();
+        while let Some(entry) = entries.next_entry().await.expect("next_entry") {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["a.json".to_string()],
+            "expected only the target file, found {names:?}"
+        );
+        tokio::fs::remove_dir_all(&dir).await.ok();
+    }
+
+    #[tokio::test]
+    async fn atomic_write_concurrent_callers_do_not_clobber_temp() {
+        // Many concurrent writes to the same path must each succeed (each gets
+        // its own temp name) and the final content must be one of the inputs.
+        let dir = unique_tmp_dir("concurrent");
+        let path = dir.join("a.json");
+        let mut handles = Vec::new();
+        for i in 0..16u8 {
+            let p = path.clone();
+            handles.push(tokio::spawn(async move {
+                let payload = vec![i; 64];
+                atomic_write(&p, &payload).await.map(|_| payload)
+            }));
+        }
+        let mut payloads = Vec::new();
+        for h in handles {
+            payloads.push(h.await.unwrap().expect("write ok"));
+        }
+        let final_bytes = tokio::fs::read(&path).await.unwrap();
+        assert!(payloads.contains(&final_bytes), "final content must be one of the writes");
+        tokio::fs::remove_dir_all(&dir).await.ok();
     }
 
     /// Live network test against the actual GitHub release. Ignored by default —

--- a/src-tauri/src/k8s/cost/pricing.rs
+++ b/src-tauri/src/k8s/cost/pricing.rs
@@ -3,24 +3,31 @@
 //!
 //! Strategy:
 //! 1. For each unique provider in the requested nodes, ensure the provider's
-//!    dataset is loaded (memory → disk cache → network fetch, in that order).
+//!    dataset is loaded (memory → fresh disk → conditional fetch → stale disk).
 //! 2. Resolve `(provider, region, instance_type) -> $/hour` purely in-memory.
 //!
 //! Cache layers:
-//! - In-memory `HashMap<provider, ProviderDataset>` with 24h TTL — survives the
-//!   process lifetime, refreshed lazily.
-//! - Disk cache at `~/.kdashboard/pricing/<provider>.json` with the same TTL —
-//!   survives restarts and offline boots.
+//! - In-memory `HashMap<provider, ProviderDataset>` with 24h TTL.
+//! - Disk: `~/.kdashboard/pricing/<provider>.json` (the body) plus
+//!   `~/.kdashboard/pricing/<provider>.meta.json` (`{ etag, fetched_at }`).
+//!
+//! Bandwidth optimisation: every network refresh sends `If-None-Match: <etag>`.
+//! GitHub release assets honour this and return 304 when the file is unchanged,
+//! so a daily revalidation of an unchanged dataset costs ~0 bytes of body.
+//!
+//! A background task started via [`spawn_periodic_refresh`] revalidates every
+//! provider currently in the memory cache once every 24h, so a long-running
+//! app never goes more than a day without a freshness check.
 //!
 //! Failure mode: if both network and disk fail, returns `None` and the caller
 //! falls back to hardcoded rates. If the network fails but a stale disk cache
 //! exists, we use the stale cache rather than nothing.
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
 use super::types::NodeInfo;
@@ -34,8 +41,7 @@ const PRICING_BASE_URL: &str =
 
 const SUPPORTED_PROVIDERS: &[&str] = &["aws", "azure", "gcp"];
 
-const DATASET_TTL: Duration = Duration::from_secs(86400); // 24 hours
-
+const DATASET_TTL: Duration = Duration::from_secs(86400); // 24h
 const DISK_CACHE_DIR: &str = ".kdashboard/pricing";
 
 // ---------------------------------------------------------------------------
@@ -69,6 +75,13 @@ struct ProviderDataset {
     expires_at: Instant,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DatasetMeta {
+    etag: Option<String>,
+    /// epoch seconds — used to compute disk cache freshness.
+    fetched_at: u64,
+}
+
 // ---------------------------------------------------------------------------
 // Caches
 // ---------------------------------------------------------------------------
@@ -94,58 +107,114 @@ fn pricing_base_url() -> String {
     std::env::var("KDASHBOARD_PRICING_URL").unwrap_or_else(|_| PRICING_BASE_URL.to_string())
 }
 
-fn disk_cache_path(provider: &str) -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    Some(home.join(DISK_CACHE_DIR).join(format!("{provider}.json")))
+fn cache_root() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(DISK_CACHE_DIR))
+}
+
+fn dataset_path(provider: &str) -> Option<PathBuf> {
+    Some(cache_root()?.join(format!("{provider}.json")))
+}
+
+fn meta_path(provider: &str) -> Option<PathBuf> {
+    Some(cache_root()?.join(format!("{provider}.meta.json")))
+}
+
+fn now_epoch_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn meta_is_fresh(meta: &DatasetMeta) -> bool {
+    let now = now_epoch_seconds();
+    let age = now.saturating_sub(meta.fetched_at);
+    age < DATASET_TTL.as_secs()
 }
 
 // ---------------------------------------------------------------------------
-// Disk cache helpers
+// Disk I/O
 // ---------------------------------------------------------------------------
 
-async fn read_disk_cache(provider: &str) -> Option<(String, bool)> {
-    let path = disk_cache_path(provider)?;
-    let metadata = tokio::fs::metadata(&path).await.ok()?;
-    let modified = metadata.modified().ok()?;
-    let age = SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or(Duration::ZERO);
-    let fresh = age < DATASET_TTL;
-
-    let contents = tokio::fs::read_to_string(&path).await.ok()?;
-    Some((contents, fresh))
+async fn read_disk_meta(provider: &str) -> Option<DatasetMeta> {
+    let path = meta_path(provider)?;
+    let raw = tokio::fs::read_to_string(&path).await.ok()?;
+    serde_json::from_str(&raw).ok()
 }
 
-async fn write_disk_cache(provider: &str, contents: &str) -> Result<()> {
-    let path = disk_cache_path(provider).context("home dir unavailable")?;
+async fn write_disk_meta(provider: &str, meta: &DatasetMeta) -> Result<()> {
+    let path = meta_path(provider).context("home dir unavailable")?;
     if let Some(dir) = path.parent() {
         tokio::fs::create_dir_all(dir)
             .await
             .with_context(|| format!("create_dir_all {dir:?}"))?;
     }
-    tokio::fs::write(&path, contents)
+    let body = serde_json::to_string(meta).context("serialise meta")?;
+    tokio::fs::write(&path, body)
+        .await
+        .with_context(|| format!("write {path:?}"))?;
+    Ok(())
+}
+
+async fn read_disk_body(provider: &str) -> Option<String> {
+    tokio::fs::read_to_string(dataset_path(provider)?).await.ok()
+}
+
+async fn write_disk_body(provider: &str, body: &str) -> Result<()> {
+    let path = dataset_path(provider).context("home dir unavailable")?;
+    if let Some(dir) = path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .with_context(|| format!("create_dir_all {dir:?}"))?;
+    }
+    tokio::fs::write(&path, body)
         .await
         .with_context(|| format!("write {path:?}"))?;
     Ok(())
 }
 
 // ---------------------------------------------------------------------------
-// Network fetch
+// Network: conditional fetch with If-None-Match.
+// Returns Ok(None) when the server replies 304 Not Modified.
 // ---------------------------------------------------------------------------
 
-async fn fetch_dataset_from_network(provider: &str) -> Result<String> {
-    let url = format!("{}/{}.json", pricing_base_url(), provider);
-    let resp = http_client()
-        .get(&url)
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?;
-    if !resp.status().is_success() {
-        anyhow::bail!("pricing fetch returned {}", resp.status());
-    }
-    let body = resp.text().await.context("read pricing body")?;
-    Ok(body)
+struct FetchedDataset {
+    body: String,
+    etag: Option<String>,
 }
+
+async fn fetch_dataset_conditional(
+    provider: &str,
+    prev_etag: Option<&str>,
+) -> Result<Option<FetchedDataset>> {
+    let url = format!("{}/{}.json", pricing_base_url(), provider);
+    let mut req = http_client().get(&url);
+    if let Some(etag) = prev_etag {
+        req = req.header(reqwest::header::IF_NONE_MATCH, etag);
+    }
+
+    let resp = req.send().await.with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+
+    if status == reqwest::StatusCode::NOT_MODIFIED {
+        return Ok(None);
+    }
+    if !status.is_success() {
+        anyhow::bail!("pricing fetch returned {status}");
+    }
+
+    let etag = resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body = resp.text().await.context("read pricing body")?;
+    Ok(Some(FetchedDataset { body, etag }))
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
 
 fn parse_dataset(json: &str) -> Result<ProviderDataset> {
     let raw: RawDataset = serde_json::from_str(json).context("parse pricing dataset")?;
@@ -170,77 +239,121 @@ fn parse_dataset(json: &str) -> Result<ProviderDataset> {
 }
 
 // ---------------------------------------------------------------------------
-// Ensure a dataset is available for a provider.
-// Order: memory cache → fresh disk → network → stale disk fallback.
+// Memory cache helpers
 // ---------------------------------------------------------------------------
-
-async fn ensure_dataset_loaded(provider: &str) -> bool {
-    {
-        let cache = DATASET_CACHE.lock().await;
-        if let Some(map) = cache.as_ref() {
-            if let Some(ds) = map.get(provider) {
-                if ds.expires_at > Instant::now() {
-                    return true;
-                }
-            }
-        }
-    }
-
-    // Try fresh disk cache
-    if let Some((contents, fresh)) = read_disk_cache(provider).await {
-        if fresh {
-            match parse_dataset(&contents) {
-                Ok(ds) => {
-                    install_dataset(provider, ds).await;
-                    return true;
-                }
-                Err(e) => {
-                    tracing::warn!(provider, error = %e, "disk cache corrupt, will refetch");
-                }
-            }
-        }
-    }
-
-    // Network fetch
-    match fetch_dataset_from_network(provider).await {
-        Ok(body) => match parse_dataset(&body) {
-            Ok(ds) => {
-                if let Err(e) = write_disk_cache(provider, &body).await {
-                    tracing::warn!(provider, error = %e, "disk cache write failed");
-                }
-                install_dataset(provider, ds).await;
-                return true;
-            }
-            Err(e) => {
-                tracing::warn!(provider, error = %e, "pricing dataset parse failed");
-            }
-        },
-        Err(e) => {
-            tracing::warn!(provider, error = %e, "pricing dataset fetch failed");
-        }
-    }
-
-    // Last resort: stale disk cache
-    if let Some((contents, _)) = read_disk_cache(provider).await {
-        match parse_dataset(&contents) {
-            Ok(ds) => {
-                tracing::info!(provider, "using stale disk cache (network unreachable)");
-                install_dataset(provider, ds).await;
-                return true;
-            }
-            Err(e) => {
-                tracing::warn!(provider, error = %e, "stale disk cache also unreadable");
-            }
-        }
-    }
-
-    false
-}
 
 async fn install_dataset(provider: &str, ds: ProviderDataset) {
     let mut cache = DATASET_CACHE.lock().await;
     let map = cache.get_or_insert_with(HashMap::new);
     map.insert(provider.to_string(), ds);
+}
+
+async fn extend_memory_expiry(provider: &str) {
+    let mut cache = DATASET_CACHE.lock().await;
+    if let Some(map) = cache.as_mut() {
+        if let Some(ds) = map.get_mut(provider) {
+            ds.expires_at = Instant::now() + DATASET_TTL;
+        }
+    }
+}
+
+async fn memory_has_fresh(provider: &str) -> bool {
+    let cache = DATASET_CACHE.lock().await;
+    cache
+        .as_ref()
+        .and_then(|m| m.get(provider))
+        .map(|ds| ds.expires_at > Instant::now())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// ensure_dataset_loaded — main path
+// ---------------------------------------------------------------------------
+
+async fn ensure_dataset_loaded(provider: &str) -> bool {
+    if memory_has_fresh(provider).await {
+        return true;
+    }
+
+    let meta = read_disk_meta(provider).await.unwrap_or_default();
+
+    // Fresh disk cache → load directly, no network.
+    if meta_is_fresh(&meta) {
+        if let Some(body) = read_disk_body(provider).await {
+            match parse_dataset(&body) {
+                Ok(ds) => {
+                    install_dataset(provider, ds).await;
+                    return true;
+                }
+                Err(e) => {
+                    tracing::warn!(provider, error = %e, "fresh disk cache corrupt, will refetch");
+                }
+            }
+        }
+    }
+
+    // Stale or missing disk → conditional fetch.
+    match fetch_dataset_conditional(provider, meta.etag.as_deref()).await {
+        Ok(Some(fetched)) => {
+            // 200 — body changed (or first fetch). Persist new body + meta.
+            if let Err(e) = write_disk_body(provider, &fetched.body).await {
+                tracing::warn!(provider, error = %e, "disk body write failed");
+            }
+            let new_meta = DatasetMeta {
+                etag: fetched.etag.clone(),
+                fetched_at: now_epoch_seconds(),
+            };
+            if let Err(e) = write_disk_meta(provider, &new_meta).await {
+                tracing::warn!(provider, error = %e, "disk meta write failed");
+            }
+            match parse_dataset(&fetched.body) {
+                Ok(ds) => {
+                    tracing::info!(provider, etag = ?new_meta.etag, "pricing dataset updated");
+                    install_dataset(provider, ds).await;
+                    return true;
+                }
+                Err(e) => {
+                    tracing::warn!(provider, error = %e, "downloaded dataset failed to parse");
+                }
+            }
+        }
+        Ok(None) => {
+            // 304 — body unchanged. Touch the meta so we don't revalidate again
+            // for another 24h, and reload from disk.
+            tracing::debug!(provider, "pricing dataset unchanged (304)");
+            let touched = DatasetMeta {
+                etag: meta.etag.clone(),
+                fetched_at: now_epoch_seconds(),
+            };
+            if let Err(e) = write_disk_meta(provider, &touched).await {
+                tracing::warn!(provider, error = %e, "touch disk meta failed");
+            }
+            if let Some(body) = read_disk_body(provider).await {
+                match parse_dataset(&body) {
+                    Ok(ds) => {
+                        install_dataset(provider, ds).await;
+                        return true;
+                    }
+                    Err(e) => {
+                        tracing::warn!(provider, error = %e, "disk body unreadable after 304");
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(provider, error = %e, "pricing dataset fetch failed");
+        }
+    }
+
+    // Last resort: stale disk body.
+    if let Some(body) = read_disk_body(provider).await {
+        if let Ok(ds) = parse_dataset(&body) {
+            tracing::info!(provider, "using stale disk cache (network unreachable)");
+            install_dataset(provider, ds).await;
+            return true;
+        }
+    }
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -297,8 +410,9 @@ pub(super) async fn resolve_pricing(nodes: &[NodeInfo]) -> Option<HashMap<String
     }
 }
 
-/// Force-refresh pricing by clearing in-memory caches. Disk cache is left in
-/// place — next call will refetch from network and overwrite it.
+/// Force-clear the in-memory pricing cache and the cost overview cache. Disk
+/// state is left in place — the next call refetches conditionally and a 304 is
+/// usually free.
 pub async fn refresh_pricing() -> Result<()> {
     {
         let mut cache = DATASET_CACHE.lock().await;
@@ -309,6 +423,75 @@ pub async fn refresh_pricing() -> Result<()> {
         *cache = None;
     }
     Ok(())
+}
+
+/// Revalidate one provider's dataset against the network (uses ETag — usually a
+/// 304 once a day). Returns `Ok(true)` when the body changed, `Ok(false)` on
+/// 304. Errors propagate so the periodic loop can log them.
+async fn revalidate_provider(provider: &str) -> Result<bool> {
+    let meta = read_disk_meta(provider).await.unwrap_or_default();
+    match fetch_dataset_conditional(provider, meta.etag.as_deref()).await? {
+        Some(fetched) => {
+            write_disk_body(provider, &fetched.body).await?;
+            let new_meta = DatasetMeta {
+                etag: fetched.etag.clone(),
+                fetched_at: now_epoch_seconds(),
+            };
+            write_disk_meta(provider, &new_meta).await?;
+            let ds = parse_dataset(&fetched.body)?;
+            install_dataset(provider, ds).await;
+            tracing::info!(provider, etag = ?new_meta.etag, "pricing dataset refreshed");
+            Ok(true)
+        }
+        None => {
+            let touched = DatasetMeta {
+                etag: meta.etag.clone(),
+                fetched_at: now_epoch_seconds(),
+            };
+            write_disk_meta(provider, &touched).await?;
+            extend_memory_expiry(provider).await;
+            tracing::debug!(provider, "pricing dataset unchanged on revalidation");
+            Ok(false)
+        }
+    }
+}
+
+async fn known_providers() -> Vec<String> {
+    let cache = DATASET_CACHE.lock().await;
+    match cache.as_ref() {
+        Some(map) => map.keys().cloned().collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Spawn a background task that revalidates every provider in the in-memory
+/// cache once every 24h. Cheap on the wire because each revalidation is a
+/// conditional GET — typical case is 304 with no body. Idempotent: calling
+/// twice spawns two loops; the cost is one extra HTTP request per day.
+pub fn spawn_periodic_refresh() {
+    tauri::async_runtime::spawn(async {
+        let mut interval = tokio::time::interval(DATASET_TTL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // Consume the immediate first tick — startup path already loads via
+        // `ensure_dataset_loaded`. The next tick fires after 24h.
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+            let providers = known_providers().await;
+            if providers.is_empty() {
+                tracing::debug!("periodic pricing refresh: nothing cached, skipping");
+                continue;
+            }
+            for provider in providers {
+                match revalidate_provider(&provider).await {
+                    Ok(true) => tracing::info!(provider, "periodic refresh: updated"),
+                    Ok(false) => tracing::debug!(provider, "periodic refresh: 304 unchanged"),
+                    Err(e) => tracing::warn!(provider, error = %e, "periodic refresh failed"),
+                }
+            }
+        }
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -339,7 +522,10 @@ mod tests {
         let ds = parse_dataset(SAMPLE_JSON).expect("parses");
         let region = ds.prices.get("us-east-1").expect("region");
         assert_eq!(region.get("m5.large").copied(), Some(0.096));
-        assert!(region.get("broken").is_none(), "null prices must be filtered");
+        assert!(
+            region.get("broken").is_none(),
+            "null prices must be filtered"
+        );
     }
 
     #[test]
@@ -364,6 +550,43 @@ mod tests {
         }
     }
 
+    #[test]
+    fn meta_is_fresh_within_ttl() {
+        let meta = DatasetMeta {
+            etag: Some("abc".into()),
+            fetched_at: now_epoch_seconds() - 60, // 1 min ago
+        };
+        assert!(meta_is_fresh(&meta));
+    }
+
+    #[test]
+    fn meta_is_stale_past_ttl() {
+        let meta = DatasetMeta {
+            etag: Some("abc".into()),
+            fetched_at: now_epoch_seconds() - DATASET_TTL.as_secs() - 60,
+        };
+        assert!(!meta_is_fresh(&meta));
+    }
+
+    #[test]
+    fn meta_default_is_stale() {
+        let meta = DatasetMeta::default();
+        assert_eq!(meta.fetched_at, 0);
+        assert!(!meta_is_fresh(&meta), "epoch-zero meta must be treated as stale");
+    }
+
+    #[test]
+    fn meta_roundtrips_json() {
+        let meta = DatasetMeta {
+            etag: Some("\"0xABCDEF\"".into()),
+            fetched_at: 1_700_000_000,
+        };
+        let s = serde_json::to_string(&meta).unwrap();
+        let back: DatasetMeta = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.etag, meta.etag);
+        assert_eq!(back.fetched_at, meta.fetched_at);
+    }
+
     #[tokio::test]
     async fn resolve_pricing_returns_none_when_unsupported_provider() {
         let nodes = vec![NodeInfo {
@@ -384,39 +607,28 @@ mod tests {
 
     /// Live network test against the actual GitHub release. Ignored by default —
     /// run with `cargo test --lib cost::pricing -- --ignored --nocapture`.
+    /// Verifies both the initial 200 fetch and the conditional 304 path.
     #[tokio::test]
     #[ignore]
-    async fn resolve_pricing_against_real_release() {
-        let nodes = vec![
-            NodeInfo {
-                name: "aws-1".into(),
-                instance_type: "m5.large".into(),
-                provider: "aws".into(),
-                region: "us-east-1".into(),
-                cpu_capacity: 2.0,
-                memory_capacity_bytes: 8.0 * 1024.0 * 1024.0 * 1024.0,
-            },
-            NodeInfo {
-                name: "gcp-1".into(),
-                instance_type: "e2-standard-4".into(),
-                provider: "gcp".into(),
-                region: "us-central1".into(),
-                cpu_capacity: 4.0,
-                memory_capacity_bytes: 16.0 * 1024.0 * 1024.0 * 1024.0,
-            },
-        ];
-
+    async fn revalidate_uses_etag_for_304() {
+        // First call: loads via ensure_dataset_loaded (probably 200 if cache empty).
+        let nodes = vec![NodeInfo {
+            name: "aws-1".into(),
+            instance_type: "m5.large".into(),
+            provider: "aws".into(),
+            region: "us-east-1".into(),
+            cpu_capacity: 2.0,
+            memory_capacity_bytes: 8.0 * 1024.0 * 1024.0 * 1024.0,
+        }];
         let prices = resolve_pricing(&nodes).await.expect("got prices");
-        assert!(
-            prices.contains_key("aws/us-east-1/m5.large"),
-            "missing aws m5.large: {prices:?}"
-        );
-        assert!(
-            prices.contains_key("gcp/us-central1/e2-standard-4"),
-            "missing gcp e2-standard-4: {prices:?}"
-        );
-        for (k, v) in &prices {
-            assert!(*v > 0.0 && *v < 100.0, "implausible price for {k}: {v}");
-        }
+        assert!(prices.contains_key("aws/us-east-1/m5.large"));
+
+        // Now revalidate — meta on disk has a fresh etag, so this MUST come back
+        // as Ok(false) (304). If GitHub regenerated the asset between our two
+        // calls we'd get Ok(true), but in a same-second test that's impossible.
+        let changed = revalidate_provider("aws")
+            .await
+            .expect("revalidate succeeds");
+        assert!(!changed, "second call should be 304 not modified");
     }
 }

--- a/src-tauri/src/k8s/cost/types.rs
+++ b/src-tauri/src/k8s/cost/types.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::time::Instant;
 
 // ---------------------------------------------------------------------------
@@ -71,36 +70,6 @@ pub struct NodeCostInfo {
 pub(super) struct CostCache {
     pub data: Option<CostOverview>,
     pub expires_at: Instant,
-}
-
-pub(super) struct ResolvedPricing {
-    pub prices: HashMap<String, f64>,
-    pub expires_at: Instant,
-}
-
-#[derive(Debug, Serialize)]
-pub(super) struct PricingResolveRequest {
-    pub provider: String,
-    pub region: String,
-    #[serde(rename = "instanceType")]
-    pub instance_type: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub(super) struct PricingResolveItem {
-    pub key: String,
-    #[serde(rename = "pricePerHour")]
-    pub price_per_hour: f64,
-    #[serde(rename = "pricePerMonth")]
-    #[allow(dead_code)]
-    pub price_per_month: f64,
-}
-
-#[derive(Debug, Deserialize)]
-pub(super) struct PricingResolveResponse {
-    pub results: Vec<PricingResolveItem>,
-    pub resolved: u32,
-    pub total: u32,
 }
 
 // Pod / node metrics types used by the metrics-server integration

--- a/src-tauri/src/k8s/crd/discovery.rs
+++ b/src-tauri/src/k8s/crd/discovery.rs
@@ -73,6 +73,12 @@ pub async fn discover_crds() -> Result<Vec<CrdGroup>> {
         "authentication.k8s.io",
         "authorization.k8s.io",
         "internal.apiserver.k8s.io",
+        // Aggregated metrics APIs — served by metrics-server / custom adapters,
+        // not user CRDs. Listing them often returns 403/404/500 on managed
+        // clusters (GKE etc.) and floods the logs on every sidebar refresh.
+        "metrics.k8s.io",
+        "external.metrics.k8s.io",
+        "custom.metrics.k8s.io",
     ];
 
     let mut groups_map: HashMap<String, Vec<CrdInfo>> = HashMap::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,7 +118,8 @@ pub(crate) fn get_os_version() -> &'static str {
 // Tracing infrastructure
 // ===========================================================================
 
-const DEFAULT_LOG_FILTER: &str = "kdashboard_lib=info,kube=warn";
+const DEFAULT_LOG_FILTER: &str =
+    "kdashboard_lib=info,kube_client=warn,kube=warn,tower::buffer=warn,hyper=warn,rustls=warn";
 
 fn build_env_filter() -> tracing_subscriber::EnvFilter {
     tracing_subscriber::EnvFilter::try_from_default_env()
@@ -162,8 +163,11 @@ pub fn run() {
     let _ = dotenvy::dotenv();
     fix_path_env();
 
+    use std::io::IsTerminal;
     tracing_subscriber::fmt()
         .with_env_filter(build_env_filter())
+        .with_target(true)
+        .with_ansi(std::io::stderr().is_terminal())
         .init();
 
     tracing::info!("Starting kdashboard v2");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,6 +198,11 @@ pub fn run() {
             // Check for updates in background after startup settles.
             update::check_and_notify(app.handle().clone());
 
+            // Revalidate cloud pricing datasets in the background once a day.
+            // Cheap on the wire — uses If-None-Match, so 99% of revalidations
+            // are 304 with no body.
+            k8s::cost::spawn_periodic_refresh();
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Summary

Wires the cost view to the daily pricing dataset published by [#16](https://github.com/folio-pro/kdashboard/pull/16). The Rust resolver fetches the dataset directly from the `pricing-data` GitHub release, **uses ETag for conditional fetches** (so daily revalidations are ~0 bytes when nothing changed), caches everything on disk, and runs a **background refresh once every 24h**. No more dependency on `www.kdashboard.app/api/pricing/resolve`.

## What changes

- **`src-tauri/src/k8s/cost/pricing.rs`** — full rewrite. Public signature `resolve_pricing(&[NodeInfo]) -> Option<HashMap<String, f64>>` is preserved (key `provider/region/instance_type`), so `calculations.rs` and `node_metrics.rs` need zero changes.
- **`src-tauri/src/k8s/cost/types.rs`** — removed obsolete request/response structs (`PricingResolveRequest`, `PricingResolveResponse`, `PricingResolveItem`, `ResolvedPricing`).
- **`src-tauri/src/k8s/cost/mod.rs`** — exports new `spawn_periodic_refresh`.
- **`src-tauri/src/lib.rs`** — calls `spawn_periodic_refresh()` from the Tauri `setup` callback so the daily revalidation runs even if the cost view is never opened after launch.

## How it works

```
resolve_pricing(nodes)
  └─ for each unique provider:
       memory cache fresh? (24h)
         └─ no → meta.fetched_at fresh? (24h)
              └─ yes → load body from disk, install in memory
              └─ no  → conditional GET with If-None-Match
                   ├─ 304 → touch meta (new fetched_at), reload disk body
                   ├─ 200 → write new body + new etag, install in memory
                   └─ network err → fall back to stale disk body
```

`spawn_periodic_refresh()` ticks every 24h and revalidates every provider already in the memory cache. Each tick is a conditional GET — typically 304 with no body — so daily refresh of an unchanged dataset is essentially free on the wire.

## Disk layout

```
~/.kdashboard/pricing/
├── aws.json         (~2 MB — raw dataset body)
├── aws.meta.json    ({ etag, fetched_at })
├── azure.json
├── azure.meta.json
├── gcp.json
└── gcp.meta.json
```

Freshness is driven by `meta.fetched_at` rather than file mtime, so a 304 just rewrites the meta and leaves the body untouched.

## Knobs

- `KDASHBOARD_PRICING_URL` env var overrides the base URL (testing, self-hosted mirror).

## Test plan

- [x] `cargo check` clean.
- [x] `cargo test --lib cost::pricing` — 9 tests pass, 1 `--ignored`.
- [x] **Live test against the real release**:
  ```
  cargo test --lib cost::pricing -- --ignored --nocapture
  ```
  - First call hits the network (200) and persists `aws.json` + `aws.meta.json`.
  - Second call sends `If-None-Match: <etag>` and gets back 304, asserted via `revalidate_provider("aws") == Ok(false)`.
- [ ] Manual: `bun run tauri dev`, open cost view, confirm `source: cloud-pricing` on the overview. Inspect `~/.kdashboard/pricing/` for body + meta sidecars.
- [ ] Manual: leave the app open >24h and confirm a `pricing dataset unchanged on revalidation` log line appears (`RUST_LOG=kdashboard_lib=debug`).

## Out of scope

- UI surfacing of "last refreshed at" or "stale data" hints in the cost view.
- GCP zone-vs-region nuances (`us-central1` vs `us-central1-a`) — node label parsing in `nodes.rs` was already handling this and is untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily background refresh of cloud pricing datasets for up-to-date rates.
  * Pricing resolves from local provider datasets for faster, offline-capable lookups.
  * Metrics availability tracking to avoid repeated failing probes and reduce noise.

* **Bug Fixes / Reliability**
  * Multi-layer caching with conditional validation and atomic disk writes to reduce downloads and tolerate network failures.
  * Metrics endpoint gating and reset on context/settings changes to force fresh probing and improve stability.
* **Other**
  * Broader logging for networking and Kubernetes client components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->