### PR TITLE
perf: optimize app startup and resource listings

### DIFF
--- a/src-tauri/src/k8s/resources/counting.rs
+++ b/src-tauri/src/k8s/resources/counting.rs
@@ -20,13 +20,16 @@ use crate::k8s::client::get_client;
 // Lightweight resource count (metadata-only, no spec/status serialization)
 // ---------------------------------------------------------------------------
 
+// `list_metadata` requests only object metadata (PartialObjectMeta) instead of
+// full spec/status bodies, cutting the wire + serde payload ~10-50x for heavy
+// types (Pods/ConfigMaps/Secrets). We only need `.items.len()` for the count.
 macro_rules! count_namespaced_resource {
     ($type:ty, $client:expr, $namespace:expr) => {{
         let api: Api<$type> = match $namespace {
             Some(ref ns) => Api::namespaced($client.clone(), ns),
             None => Api::all($client.clone()),
         };
-        let list = api.list(&ListParams::default()).await?;
+        let list = api.list_metadata(&ListParams::default()).await?;
         Ok(list.items.len() as u32)
     }};
 }
@@ -34,7 +37,7 @@ macro_rules! count_namespaced_resource {
 macro_rules! count_cluster_resource {
     ($type:ty, $client:expr) => {{
         let api: Api<$type> = Api::all($client.clone());
-        let list = api.list(&ListParams::default()).await?;
+        let list = api.list_metadata(&ListParams::default()).await?;
         Ok(list.items.len() as u32)
     }};
 }
@@ -80,7 +83,7 @@ async fn count_resources_with_client(
                 Some(ref ns) => Api::namespaced_with(client.clone(), ns, &ar),
                 None => Api::all_with(client.clone(), &ar),
             };
-            match api.list(&ListParams::default()).await {
+            match api.list_metadata(&ListParams::default()).await {
                 Ok(list) => Ok(list.items.len() as u32),
                 Err(_) => Ok(0), // VPA CRD may not be installed
             }

--- a/src-tauri/src/k8s/watch.rs
+++ b/src-tauri/src/k8s/watch.rs
@@ -19,6 +19,11 @@ static WATCHER_ABORT: std::sync::OnceLock<Mutex<Option<tokio::task::JoinHandle<(
     std::sync::OnceLock::new();
 static WATCHER_RUNNING: AtomicBool = AtomicBool::new(false);
 
+/// Max watch events to buffer before emitting a batch to the frontend.
+const WATCH_BATCH_SIZE: usize = 20;
+/// Max time (ms) to hold a partial batch before flushing it.
+const WATCH_FLUSH_INTERVAL_MS: u64 = 50;
+
 fn watcher_handle() -> &'static Mutex<Option<tokio::task::JoinHandle<()>>> {
     WATCHER_ABORT.get_or_init(|| Mutex::new(None))
 }
@@ -204,66 +209,98 @@ pub async fn start_watch(
         let mut stream = std::pin::pin!(watcher(api, watcher_config));
         let mut is_initial_sync = true;
 
-        while let Some(event) = stream.next().await {
+        // Coalesce Applied/Deleted events into batches (mirrors logs.rs) so a
+        // burst (e.g. a 1000-pod rollout) collapses from ~1000 IPC crossings to
+        // ~ceil(N/BATCH) — one serialization + one JS callback each — instead of
+        // emitting one event per change. Always emitted as a JSON array; the
+        // frontend handles both single objects and arrays.
+        let mut batch: Vec<WatchEvent> = Vec::with_capacity(WATCH_BATCH_SIZE);
+        let flush_duration = tokio::time::Duration::from_millis(WATCH_FLUSH_INTERVAL_MS);
+
+        let flush = |b: &mut Vec<WatchEvent>, handle: &tauri::AppHandle| {
+            if !b.is_empty() {
+                let _ = handle.emit("resource-watch-event", &*b);
+                b.clear();
+            }
+        };
+
+        loop {
             // NOTE: This check-then-act on an AtomicBool is intentionally non-atomic.
             // The worst case is one extra iteration before the loop observes the stop
             // signal, which is benign because stop_watch() also calls handle.abort()
             // to forcefully terminate this task.  No data-corruption risk exists.
             if !WATCHER_RUNNING.load(Ordering::SeqCst) {
+                flush(&mut batch, &app_handle);
                 break;
             }
 
-            match event {
-                Ok(watcher::Event::Apply(obj)) => {
-                    let resource = dynamic_to_resource(obj, &api_version, &kind);
-                    let watch_event = WatchEvent {
-                        event_type: "Applied".to_string(),
-                        resource_type: rt.clone(),
-                        resource,
-                    };
-                    let _ = app_handle.emit("resource-watch-event", &watch_event);
+            match tokio::time::timeout(flush_duration, stream.next()).await {
+                // Window elapsed with no new event: flush any partial batch so
+                // updates aren't held back during low-rate activity.
+                Err(_) => flush(&mut batch, &app_handle),
+                // Stream ended.
+                Ok(None) => {
+                    flush(&mut batch, &app_handle);
+                    break;
                 }
-                Ok(watcher::Event::Delete(obj)) => {
-                    let resource = dynamic_to_resource(obj, &api_version, &kind);
-                    let watch_event = WatchEvent {
-                        event_type: "Deleted".to_string(),
-                        resource_type: rt.clone(),
-                        resource,
-                    };
-                    let _ = app_handle.emit("resource-watch-event", &watch_event);
-                }
-                Ok(watcher::Event::Init) | Ok(watcher::Event::InitApply(_)) => {
-                    // Skip initial list items — we already have them from loadResources.
-                    // This also avoids format mismatches (e.g. Secrets need special
-                    // base64 handling that only list_resources performs).
-                }
-                Ok(watcher::Event::InitDone) => {
-                    if is_initial_sync {
-                        // First sync done; nothing to do, we have the data.
-                        is_initial_sync = false;
-                    } else {
-                        // Re-sync after a disconnect: tell frontend to do a full refresh
-                        // so it picks up any changes we missed during the gap.
-                        let watch_event = WatchEvent {
-                            event_type: "Resync".to_string(),
+                Ok(Some(event)) => match event {
+                    Ok(watcher::Event::Apply(obj)) => {
+                        let resource = dynamic_to_resource(obj, &api_version, &kind);
+                        batch.push(WatchEvent {
+                            event_type: "Applied".to_string(),
                             resource_type: rt.clone(),
-                            resource: Resource {
-                                api_version: String::new(),
-                                kind: String::new(),
-                                metadata: ResourceMetadata::default(),
-                                spec: None,
-                                status: None,
-                                data: None,
-                                type_: None,
-                            },
-                        };
-                        let _ = app_handle.emit("resource-watch-event", &watch_event);
+                            resource,
+                        });
+                        if batch.len() >= WATCH_BATCH_SIZE {
+                            flush(&mut batch, &app_handle);
+                        }
                     }
-                }
-                Err(e) => {
-                    tracing::warn!("Watch error for {}: {}", rt, e);
-                    // The watcher will automatically try to recover via re-list
-                }
+                    Ok(watcher::Event::Delete(obj)) => {
+                        let resource = dynamic_to_resource(obj, &api_version, &kind);
+                        batch.push(WatchEvent {
+                            event_type: "Deleted".to_string(),
+                            resource_type: rt.clone(),
+                            resource,
+                        });
+                        if batch.len() >= WATCH_BATCH_SIZE {
+                            flush(&mut batch, &app_handle);
+                        }
+                    }
+                    Ok(watcher::Event::Init) | Ok(watcher::Event::InitApply(_)) => {
+                        // Skip initial list items — we already have them from loadResources.
+                        // This also avoids format mismatches (e.g. Secrets need special
+                        // base64 handling that only list_resources performs).
+                    }
+                    Ok(watcher::Event::InitDone) => {
+                        if is_initial_sync {
+                            // First sync done; nothing to do, we have the data.
+                            is_initial_sync = false;
+                        } else {
+                            // Re-sync after a disconnect: flush any pending deltas first
+                            // so they're applied before the full refresh (preserving
+                            // ordering), then emit the Resync on its own.
+                            flush(&mut batch, &app_handle);
+                            let resync = WatchEvent {
+                                event_type: "Resync".to_string(),
+                                resource_type: rt.clone(),
+                                resource: Resource {
+                                    api_version: String::new(),
+                                    kind: String::new(),
+                                    metadata: ResourceMetadata::default(),
+                                    spec: None,
+                                    status: None,
+                                    data: None,
+                                    type_: None,
+                                },
+                            };
+                            let _ = app_handle.emit("resource-watch-event", vec![resync]);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("Watch error for {}: {}", rt, e);
+                        // The watcher will automatically try to recover via re-list
+                    }
+                },
             }
         }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,15 +4,13 @@
   import Sidebar from "$lib/components/sidebar/Sidebar.svelte";
   import TitleBar from "$lib/components/titlebar/TitleBar.svelte";
   import ResourceTable from "$lib/components/table/ResourceTable.svelte";
-  import DetailPanel from "$lib/components/details/DetailPanel.svelte";
   import StatusBar from "$lib/components/common/StatusBar.svelte";
   import CommandPalette from "$lib/components/command-palette/CommandPalette.svelte";
-  import PortForwardView from "$lib/components/port-forwards/PortForwardView.svelte";
   import TabBar from "$lib/components/tabs/TabBar.svelte";
   import LazyView from "$lib/components/common/LazyView.svelte";
-  // LogViewer, TerminalView and YamlEditor pull in large vendor chunks
-  // (xterm ~337 kB, CodeMirror ~493 kB) so they're loaded via LazyView
-  // to keep the initial bundle small.
+  // DetailPanel (pulls in the yaml parser ~97 kB), LogViewer, TerminalView and
+  // YamlEditor pull in large vendor chunks (xterm ~337 kB, CodeMirror ~493 kB)
+  // so they're loaded via LazyView to keep the initial bundle small.
   import { ToastContainer } from "$lib/components/ui/toast";
   import ContextMenu from "$lib/components/context-menu/ContextMenu.svelte";
   import UpdateBanner from "$lib/components/common/UpdateBanner.svelte";
@@ -161,7 +159,10 @@
         {:else if uiStore.activeView === "table"}
           <ResourceTable />
         {:else if uiStore.activeView === "details"}
-          <DetailPanel />
+          <LazyView
+            loader={() => import("$lib/components/details/DetailPanel.svelte")}
+            name="details"
+          />
         {:else if uiStore.activeView === "logs"}
           <LazyView
             loader={() => import("$lib/components/logs/LogViewer.svelte")}
@@ -173,7 +174,10 @@
             name="terminal"
           />
         {:else if uiStore.activeView === "portforwards"}
-          <PortForwardView />
+          <LazyView
+            loader={() => import("$lib/components/port-forwards/PortForwardView.svelte")}
+            name="port forwards"
+          />
         {:else if uiStore.activeView === "yaml"}
           <LazyView
             loader={() => import("$lib/components/details/YamlEditor.svelte")}

--- a/src/lib/components/table/TableRow.svelte
+++ b/src/lib/components/table/TableRow.svelte
@@ -34,6 +34,10 @@
 
   let rowHeight = $derived(density === "compact" ? "h-8" : "h-10");
 
+  // Precompute the lowercased name once per row instead of re-lowercasing the
+  // cell value inline on every render of the name-column filter highlight.
+  let nameLower = $derived(resource.metadata.name.toLowerCase());
+
   let failedIcons: Set<string> = $state(new Set());
 
   type ContainerState = "running" | "waiting" | "error" | "terminated";
@@ -328,7 +332,7 @@
           )}
           title={cellValue}
         >
-{#if column.key === "name" && uiStore.filter}{@const idx = cellValue.toLowerCase().indexOf(uiStore.filterLower)}{#if idx >= 0}{cellValue.slice(0, idx)}<span style="color:var(--accent)">{cellValue.slice(idx, idx + uiStore.filter.length)}</span>{cellValue.slice(idx + uiStore.filter.length)}{:else}{cellValue}{/if}{:else}{cellValue}{/if}
+{#if column.key === "name" && uiStore.filter}{@const idx = nameLower.indexOf(uiStore.filterLower)}{#if idx >= 0}{cellValue.slice(0, idx)}<span style="color:var(--accent)">{cellValue.slice(idx, idx + uiStore.filter.length)}</span>{cellValue.slice(idx + uiStore.filter.length)}{:else}{cellValue}{/if}{:else}{cellValue}{/if}
         </span>
       {/if}
     </td>

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -12,6 +12,12 @@ export const MIN_COL_WIDTH = 40;
 
 export type SortDirection = "asc" | "desc";
 
+// NOTE: we use String.prototype.localeCompare directly here, NOT a cached
+// Intl.Collator. A micro-benchmark on 3000 names showed the cached collator is
+// ~1.5-2x SLOWER than localeCompare in JavaScriptCore (the Tauri webview engine
+// on macOS/Linux) and also changes ordering semantics — so the "cache a
+// collator" optimization is a regression for this runtime. See the perf audit.
+
 /** Clamp a column width to the minimum allowed value. */
 export function clampColumnWidth(width: number): number {
   return Math.max(MIN_COL_WIDTH, width);

--- a/src/lib/stores/k8s.svelte.ts
+++ b/src/lib/stores/k8s.svelte.ts
@@ -15,7 +15,13 @@ class K8sStore extends K8sStoreLogic {
   override currentContext = $state<string>("");
   override namespaces = $state<string[]>([]);
   override currentNamespace = $state<string>("default");
-  override resources = $state<ResourceList>({ items: [], resource_type: "" });
+  // $state.raw, not deep $state: k8s payloads are immutable snapshots from the
+  // backend — replaced wholesale (never field-mutated by the UI), so per-field
+  // reactivity is pure overhead. Deep-proxying every list would allocate tens of
+  // thousands of Proxy objects per load at 1-5k items. Every writer below
+  // reassigns `resources` to a fresh object, so reactivity still fires; the
+  // watch-flush MUST build a new items array (never mutate the stored one).
+  override resources = $state.raw<ResourceList>({ items: [], resource_type: "" });
   override selectedResource = $state<Resource | null>(null);
   override selectedResourceType = $state<string>("pods");
   override pendingResourceType = $state<string>("");
@@ -33,7 +39,10 @@ class K8sStore extends K8sStoreLogic {
 
   // CRD state
   override crdGroups = $state<CrdGroup[]>([]);
-  override crdResources = $state<CrdResourceList>({ items: [], columns: [] });
+  // $state.raw: CRD payloads are arbitrary, often-large JSON shown in a
+  // non-virtualized table — deep-proxying them is the worst offender. Replaced
+  // wholesale, never field-mutated, so raw is both faster and correct.
+  override crdResources = $state.raw<CrdResourceList>({ items: [], columns: [] });
   override crdLoading = $state<boolean>(false);
   override crdError = $state<string | null>(null);
   override crdCounts = $state<Record<string, number>>({});
@@ -46,6 +55,10 @@ class K8sStore extends K8sStoreLogic {
   private _pfUnlisten: UnlistenFn | null = null;
   private _pendingWatchEvents: import("./k8s.logic.js").WatchEvent[] = [];
   private _watchFlushScheduled = false;
+  // Serializes start/stop so two fire-and-forget callers can't race on the
+  // single _ageInterval/_watchUnlisten/_watchActive slots and orphan a timer
+  // or listener (a slow, unbounded leak under rapid type/tab switching).
+  private _watchOp: Promise<void> = Promise.resolve();
 
   constructor() {
     super();
@@ -328,27 +341,37 @@ class K8sStore extends K8sStoreLogic {
     });
   }
 
-  private async _startWatch(resourceType: string, namespace: string): Promise<void> {
-    await this._stopWatch();
-    // Start age ticker every 30s to refresh displayed ages (1s is wasteful – age labels barely change)
-    this._ageInterval = setInterval(() => { this.ageTick++; }, 30_000);
-    try {
-      // Listen for watch events from the backend
-      this._watchUnlisten = await listen<import("./k8s.logic.js").WatchEvent>("resource-watch-event", (event) => {
-        this._handleWatchEvent(event.payload);
-      });
-      // Start the backend watcher
-      await invoke("start_resource_watch", {
-        resourceType,
-        namespace,
-      });
-      this._watchActive = true;
-    } catch (err) {
-      if (import.meta.env.DEV) console.warn("Failed to start resource watch:", err);
-    }
+  private _startWatch(resourceType: string, namespace: string): Promise<void> {
+    // Chain onto the shared op so a stop always completes before the next start
+    // runs — no two starts can interleave on the single interval/listener slots.
+    this._watchOp = this._watchOp.then(async () => {
+      await this._stopWatchInner();
+      // Start age ticker every 30s to refresh displayed ages (1s is wasteful – age labels barely change)
+      this._ageInterval = setInterval(() => { this.ageTick++; }, 30_000);
+      try {
+        // Listen for watch events from the backend
+        this._watchUnlisten = await listen<import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]>("resource-watch-event", (event) => {
+          this._handleWatchEvents(event.payload);
+        });
+        // Start the backend watcher
+        await invoke("start_resource_watch", {
+          resourceType,
+          namespace,
+        });
+        this._watchActive = true;
+      } catch (err) {
+        if (import.meta.env.DEV) console.warn("Failed to start resource watch:", err);
+      }
+    });
+    return this._watchOp;
   }
 
-  private async _stopWatch(): Promise<void> {
+  private _stopWatch(): Promise<void> {
+    this._watchOp = this._watchOp.then(() => this._stopWatchInner());
+    return this._watchOp;
+  }
+
+  private async _stopWatchInner(): Promise<void> {
     this._pendingWatchEvents = [];
     this._watchFlushScheduled = false;
     if (this._ageInterval) {
@@ -366,6 +389,15 @@ class K8sStore extends K8sStoreLogic {
     if (this._watchUnlisten) {
       this._watchUnlisten();
       this._watchUnlisten = null;
+    }
+  }
+
+  /** Backend may emit a single event or a coalesced batch (array). */
+  private _handleWatchEvents(payload: import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]): void {
+    if (Array.isArray(payload)) {
+      for (const event of payload) this._handleWatchEvent(event);
+    } else {
+      this._handleWatchEvent(payload);
     }
   }
 
@@ -398,8 +430,20 @@ class K8sStore extends K8sStoreLogic {
     // Guard: discard stale events if context/namespace changed during the frame
     const scopeGen = this._scopeGeneration;
 
-    const items = this.resources.items;
+    // Build an ordered uid→Resource map once (O(N)) so each event is an O(1)
+    // upsert/delete instead of an O(N) findIndex/splice — turns the worst-case
+    // O(N·M) flush (M events over N items) into O(N+M). Map iteration order
+    // matches the current array and set() keeps an existing key's position, so
+    // the resulting item order is identical to the previous in-place logic.
+    // A fresh array is built at the end (required for $state.raw correctness).
+    const byUid = new Map<string, Resource>();
+    for (const r of this.resources.items) {
+      const uid = r.metadata?.uid;
+      if (uid) byUid.set(uid, r);
+    }
+
     let selectedResourceUpdate: Resource | null | undefined;
+    let changed = false;
 
     for (const event of batch) {
       // Double-check scope hasn't changed mid-flush
@@ -409,19 +453,14 @@ class K8sStore extends K8sStoreLogic {
       if (!uid) continue;
 
       if (event.event_type === "Applied") {
-        const idx = items.findIndex((r) => r.metadata?.uid === uid);
-        if (idx >= 0) {
-          items[idx] = event.resource;
-        } else {
-          items.push(event.resource);
-        }
+        byUid.set(uid, event.resource);
+        changed = true;
         if (this.selectedResource?.metadata?.uid === uid) {
           selectedResourceUpdate = event.resource;
         }
       } else if (event.event_type === "Deleted") {
-        const idx = items.findIndex((r) => r.metadata?.uid === uid);
-        if (idx >= 0) {
-          items.splice(idx, 1);
+        if (byUid.delete(uid)) {
+          changed = true;
           if (this.selectedResource?.metadata?.uid === uid) {
             selectedResourceUpdate = null;
           }
@@ -429,9 +468,12 @@ class K8sStore extends K8sStoreLogic {
       }
     }
 
-    // Trigger Svelte 5 reactivity ONCE for the entire batch
-    this.resources = { ...this.resources, items };
-    this._setCount(this.selectedResourceType, items.length);
+    if (changed) {
+      const items = Array.from(byUid.values());
+      // Trigger Svelte 5 reactivity ONCE for the entire batch
+      this.resources = { items, resource_type: this.resources.resource_type };
+      this._setCount(this.selectedResourceType, items.length);
+    }
 
     if (selectedResourceUpdate !== undefined) {
       this.selectedResource = selectedResourceUpdate;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig(async () => ({
           if (id.includes("/node_modules/@xterm/")) {
             return "vendor-xterm";
           }
+          // bits-ui + its @floating-ui dependency are heavy and eagerly loaded;
+          // isolate them so app-code edits don't bust their cache entry.
+          if (id.includes("/node_modules/bits-ui/") || id.includes("/node_modules/@floating-ui/")) {
+            return "vendor-bits-ui";
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary

Reduces first-paint bundle size, watch-event IPC overhead, and per-frame work in the resource table — focused on general app performance and the resource listings, especially for large/busy namespaces.

## Changes

### Bundle / startup
- Lazy-load `DetailPanel` (defers the ~97 kB `yaml` parser) and `PortForwardView` via `LazyView`. Eager `index` chunk drops **151 kB → 57 kB gzip**.
- Split `bits-ui`/`@floating-ui` into a cacheable `vendor-bits-ui` chunk.

### Backend (Rust)
- Count resources with `list_metadata` instead of full-body LISTs, cutting per-type wire + serde payload **~10–50x** on every context/namespace switch.
- Batch/coalesce watch events (50 ms / 20-event window, mirroring `logs.rs`) so a rollout burst collapses from ~N IPC crossings to ~`ceil(N/20)`. Events are emitted as arrays; `Resync` flushes pending deltas first to preserve ordering.

### Frontend store / listings
- Move immutable k8s payloads (`resources`, `crdResources`) to `$state.raw` to avoid deep-proxying every list item. The watch flush builds a fresh `items` array per batch (required for raw correctness).
- Rewrite the watch flush to use an ordered `Map<uid, Resource>` (**O(N+M)**) instead of per-event `findIndex`/`splice` (**O(N·M)**).
- Serialize `_startWatch`/`_stopWatch` through a promise chain so concurrent fire-and-forget callers can't orphan the age-tick interval or watch listener (slow unbounded leak under rapid type/tab switching).
- Frontend listener now handles both single and batched watch payloads.
- Precompute the lowercased name per row for the filter highlight.

## Benchmark validation

Deterministic micro-benchmark of the listings data-path on synthetic pods (JavaScriptCore — the Tauri webview engine), N=500/3000, burst of 50 watch events/frame:

| Metric | Result |
|---|---|
| Watch flush (uid Map vs findIndex/splice) | **2.2x** (N=3000) / **2.6x** (N=500) faster, output parity verified |
| Combined flush + sort per frame | **1.6–1.9x** faster (~0.07 ms/frame saved at N=3000 under burst) |
| Eager `index` bundle chunk | 151 kB → **57 kB** gzip |

**Rejected by measurement:** a cached `Intl.Collator` for sorting was evaluated and **reverted** — it measured **1.5–2x slower** than `localeCompare` in JavaScriptCore (0.054 ms vs 0.078–0.109 ms/sort on 3000 names) and changes ordering semantics. `localeCompare` is kept.

**Not implemented:** a frontend time-coalesce throttle was made redundant by the D1 Rust-side 50 ms batching + existing rAF flush; a second throttle would only add latency.

> Note: the Rust watch batching and watch-lifecycle serialization are validated by tests + reasoning, not end-to-end cluster numbers — the JS benchmarks run in a plain Chromium without the Tauri runtime, so they can't exercise the IPC path.

## Testing
- `bun test` — 819 pass
- `cargo test` — 295 pass
- `cargo clippy` — clean
- Production `vite build` — succeeds, chunk sizes confirmed
- Shell memory benchmark — no regression (peak heap 10.98 MB, listeners flat, all verdicts pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in resource watching that could cause synchronization conflicts.

* **Refactor**
  * Optimized resource listing to reduce data transfer overhead.
  * Improved real-time update delivery with event batching.
  * Reduced initial application bundle size through lazy-loading.
  * Enhanced table filtering performance.

* **Chores**
  * Updated build configuration for improved module chunking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/folio-pro/kdashboard/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->