### PR TITLE
fix(macos): themed scrollbars and titlebar in production build via color-scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>kdashboard</title>
   </head>
   <body>

--- a/splashscreen.html
+++ b/splashscreen.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <title>kdashboard</title>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/src/app.css
+++ b/src/app.css
@@ -11,6 +11,11 @@ html, body {
   margin: 0;
   background: var(--bg-primary, #0C0C0C);
   color: var(--text-primary, #E5E5E5);
+  /* Make the packaged macOS WKWebView paint native scrollbars and window
+     chrome in dark mode by default. Without this, the production build
+     defaults to light and renders white scrollbars/titlebar. Overridden
+     per-theme below for the light presets. */
+  color-scheme: dark;
 }
 
 /* Layout tokens (theme-agnostic) */
@@ -404,6 +409,30 @@ html, body {
 [data-theme] {
   --border-color: color-mix(in srgb, var(--text-primary) 14%, var(--bg-primary));
   --border-hover: color-mix(in srgb, var(--text-primary) 22%, var(--bg-primary));
+}
+
+/* ========================================
+   Native color-scheme per theme
+   Drives macOS WKWebView native scrollbars + window chrome so they match
+   the active theme in the production build (not just in dev).
+   ======================================== */
+
+:root,
+[data-theme="kdashboard"],
+[data-theme="gruvbox-dark"],
+[data-theme="solarized-dark"],
+[data-theme="everforest-dark"],
+[data-theme="dracula-dark"],
+[data-theme="monokai-dark"] {
+  color-scheme: dark;
+}
+
+[data-theme="gruvbox-light"],
+[data-theme="solarized-light"],
+[data-theme="everforest-light"],
+[data-theme="rosepine-dawn"],
+[data-theme="github-light"] {
+  color-scheme: light;
 }
 
 /* ========================================


### PR DESCRIPTION
## Problem

In production builds on macOS, the scrollbars and the topbar/window chrome rendered with **white backgrounds** that did not match the app's design. The same UI looked correct in `dev` (`vite` / `tauri dev`).

## Root cause

The app never declared a `color-scheme`. In the packaged macOS `WKWebView`, `color-scheme` defaults to `light`, so WebKit paints its **native** (white) scrollbars and light window chrome *behind* the app's custom styling — which is intentionally transparent until hover. In dev the WebView inherits the system appearance, which masked the issue.

The themed CSS variables and `::-webkit-scrollbar` rules were already correct and fully bundled; the only missing piece was `color-scheme`.

## Fix

- **`src/app.css`**
  - Add `color-scheme: dark` to the base `html, body` rule (covers the default first paint).
  - Map `color-scheme` per theme: `dark` for the dark presets (kdashboard, gruvbox-dark, solarized-dark, everforest-dark, dracula-dark, monokai-dark) and `light` for the light presets (gruvbox-light, solarized-light, everforest-light, rosepine-dawn, github-light), so native scrollbars and the titlebar follow the active theme.
- **`index.html`** — add `<meta name="color-scheme" content="dark light" />`.
- **`splashscreen.html`** — add `<meta name="color-scheme" content="dark" />` to avoid a light first paint before CSS loads.

CSS-only change — no Rust or `tauri.conf.json` changes.

## Verification

- `npm run tauri build` completes successfully and the bundled CSS (`dist/assets/index-*.css`) contains both `color-scheme:dark` and `color-scheme:light`.
- The packaged `kdashboard.app` launches; scrollbars and chrome now render against the dark theme instead of white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added color scheme metadata to HTML documents enabling support for dark and light theme modes.
  * Updated global CSS with explicit theme-specific color scheme rules for each available theme preset, ensuring consistent rendering behavior across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/folio-pro/kdashboard/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->