### PR TITLE
fix(macos): native titlebar uses the active theme colour

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,9 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-set-theme",
+    "core:window:allow-set-background-color",
+    "core:webview:allow-set-webview-background-color",
     "shell:allow-open",
     "updater:default",
     "process:allow-restart",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,7 @@
         "minHeight": 600,
         "decorations": true,
         "transparent": false,
+        "backgroundColor": "#0C0C0C",
         "visible": false
       },
       {

--- a/src/lib/components/settings/settings-constants.ts
+++ b/src/lib/components/settings/settings-constants.ts
@@ -43,6 +43,12 @@ export const DARK_THEMES: ThemeOption[] = [
   { id: "monokai-dark", name: "Monokai" },
 ];
 
+/** Whether a theme id is a light preset. Anything not in LIGHT_THEMES is dark
+ *  (mirrors the `color-scheme` mapping in app.css). Used to drive the native
+ *  window appearance so the macOS titlebar matches the active theme. */
+export const isLightTheme = (id: string): boolean =>
+  LIGHT_THEMES.some((t) => t.id === id);
+
 export const TABS = [
   { id: "general", label: "General", icon: Palette },
   { id: "kubernetes", label: "Kubernetes", icon: Container },

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -40,6 +40,40 @@ class SettingsStore extends SettingsStoreLogic {
 
   protected override applyTheme(theme: string): void {
     document.documentElement.setAttribute("data-theme", theme);
+    // The native macOS titlebar shows through to the webview background. In the
+    // packaged build the WKWebView paints that background WHITE (in dev it stays
+    // themed), so the titlebar looked white regardless of theme. Paint the
+    // webview/window background with the theme's own colour so the titlebar
+    // matches the theme exactly — not just generic dark/light.
+    void this.syncNativeWindowTheme(theme);
+  }
+
+  private async syncNativeWindowTheme(theme: string): Promise<void> {
+    try {
+      const { isLightTheme, THEME_COLORS } = await import(
+        "$lib/components/settings/settings-constants"
+      );
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const win = getCurrentWindow();
+      const bg = THEME_COLORS[theme]?.bg;
+      if (bg) {
+        // Paint both the window and the webview background: the packaged WKWebView
+        // is the surface that defaults to white, while the window background backs
+        // the transparent titlebar region. Theming both makes the titlebar match.
+        await win.setBackgroundColor(bg);
+        try {
+          const { getCurrentWebview } = await import("@tauri-apps/api/webview");
+          await getCurrentWebview().setBackgroundColor(bg);
+        } catch {
+          // Older runtime without webview background support — window bg is enough.
+        }
+      }
+      // Keep native control glyphs (traffic lights, scrollbars) legible against
+      // the themed background.
+      await win.setTheme(isLightTheme(theme) ? "light" : "dark");
+    } catch {
+      // Non-Tauri context (browser/tests) or unsupported platform — ignore.
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

In the packaged macOS build the native window **titlebar shows white regardless of the app theme**. In dev it correctly shows the exact theme colour.

The titlebar is transparent and backed by the webview/window background. In dev that background stays themed, so the titlebar picks up the theme colour; the packaged WKWebView instead paints that background **white**. The earlier `color-scheme` fix (3ed8b49) only themed the webview's *own* controls (scrollbars/form controls), not this background — so it didn't help, and #22 didn't touch any of it.

## Fix

Drive the native background from the active theme whenever it's applied (`SettingsStore.applyTheme`):

- `settings-constants.ts`: `isLightTheme(id)` — mirrors the `color-scheme` dark/light mapping in `app.css`.
- `settings.svelte.ts`: set **both** the window and the webview background to the theme's own colour (`THEME_COLORS[theme].bg`), and `setTheme(dark|light)` so the traffic-light glyphs / native scrollbars stay legible. Dynamic imports, wrapped so it no-ops outside Tauri (browser/tests).
- `tauri.conf.json`: default window `backgroundColor` `#0C0C0C` to avoid a white flash before the theme is applied.
- `capabilities/default.json`: allow `set-theme`, `set-background-color`, `set-webview-background-color`.

Result: the titlebar shows the **exact theme colour** (e.g. kdashboard black, Gruvbox brown) in both dev and the packaged build, and updates live when the theme changes — rather than generic system dark/light.

## Why not a transparent/overlay titlebar redesign

Not needed: dev already renders the theme colour with the current `decorations: true` setup, so the only gap is the packaged background going white. Theming that background is the minimal fix and matches how other Tauri apps handle the production white-background issue.

## Verification

- `svelte-check`: no new errors.
- `cargo check`: passes (validates the new config field + capabilities).
- `setBackgroundColor`/`setTheme` take effect in dev too, so it's checkable with `npm run tauri dev`; final confirmation of the packaged behaviour lands in the next release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selection now automatically synchronizes native window and webview background colors for improved visual consistency
  * Window appearance dynamically adapts based on selected theme (light or dark mode)
  * Enhanced native platform support for seamless theme synchronization across desktop environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/folio-pro/kdashboard/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->