### PR TITLE
refactor(k8s): KubeIo seam + testable orchestration; fix skeleton-on-return

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,7 +24,7 @@
   import { dialogStore } from "$lib/stores/dialogs.svelte";
   import { deleteResource } from "$lib/actions/registry";
   import { initKeyboardShortcuts } from "$lib/utils/keyboard";
-  import { handleTabSwitch } from "$lib/utils/tabLifecycle";
+  import { handleTabSwitch, invalidateTabCacheForNamespace } from "$lib/utils/tabLifecycle";
 
   // Synchronous hook: restore cached data BEFORE the view changes
   // (prevents empty state flash). Implementation lives in tabLifecycle
@@ -33,22 +33,12 @@
     handleTabSwitch(fromTab, toTab, k8sStore);
   };
 
-  // When namespace changes, save it to the active tab and invalidate cache.
-  // Writes to tab.* are wrapped in untrack so they don't retrigger this effect
-  // via Svelte 5's deep $state proxy on the tabs array.
+  // When the namespace changes, drop the active table tab's stale cache.
+  // The mutation lives in tabLifecycle (tested); untrack keeps the tab.* writes
+  // from retriggering this effect via Svelte 5's deep $state proxy.
   $effect(() => {
     const ns = k8sStore.currentNamespace;
-    untrack(() => {
-      const tab = uiStore.activeTab;
-      if (tab && (tab.type === "table" || tab.type === "crd-table")) {
-        if (tab.namespace !== ns) {
-          tab.namespace = ns;
-          tab.cachedItems = undefined;
-          tab.count = undefined;
-          tab.cacheReady = false;
-        }
-      }
-    });
+    untrack(() => invalidateTabCacheForNamespace(uiStore.activeTab, ns));
   });
 
   async function confirmGlobalDelete() {

--- a/src/lib/stores/k8s.io.fake.ts
+++ b/src/lib/stores/k8s.io.fake.ts
@@ -1,0 +1,121 @@
+import type { ResourceList, CrdGroup, CrdInfo, CrdResourceList } from "../types/index.js";
+import type {
+  KubeIo,
+  Unsubscribe,
+  WatchEventPayload,
+  PortForwardStartArgs,
+  PortForwardStartResult,
+  CrdListArgs,
+} from "./k8s.io.js";
+
+/**
+ * In-memory KubeIo for tests. The second adapter that makes the seam real:
+ * it lets bun test drive the full load → cache → watch → reconcile state
+ * machine of K8sStoreLogic without a cluster.
+ *
+ * Tests control what `listResources` returns (set `listResult` / `listError`)
+ * and push watch traffic through `emitWatch(...)` — the store's live watcher
+ * would deliver exactly the same payloads.
+ */
+export class FakeKubeIo implements KubeIo {
+  // ── Test-controllable resource surface ──
+  listResult: ResourceList = { items: [], resource_type: "" };
+  listError: unknown = null;
+  counts: Record<string, number> = {};
+
+  // ── Observability for assertions ──
+  listCalls: Array<{ resourceType: string; namespace: string }> = [];
+  watchStarted: { resourceType: string; namespace: string } | null = null;
+  watchStopCount = 0;
+  currentContext: string | null = null;
+
+  private _watchCb: ((payload: WatchEventPayload) => void) | null = null;
+
+  /** Set what the next listResources call resolves to. */
+  setList(items: ResourceList["items"], resourceType: string): void {
+    this.listResult = { items, resource_type: resourceType };
+  }
+
+  /** Push a watch event (or batch) as the backend would deliver it. */
+  emitWatch(payload: WatchEventPayload): void {
+    this._watchCb?.(payload);
+  }
+
+  /** Whether a watch subscription is currently attached. */
+  get isWatching(): boolean {
+    return this._watchCb !== null;
+  }
+
+  listResources(resourceType: string, namespace: string): Promise<ResourceList> {
+    this.listCalls.push({ resourceType, namespace });
+    if (this.listError) return Promise.reject(this.listError);
+    return Promise.resolve(this.listResult);
+  }
+
+  getResourceCounts(): Promise<Record<string, number>> {
+    return Promise.resolve(this.counts);
+  }
+
+  startResourceWatch(resourceType: string, namespace: string): Promise<void> {
+    this.watchStarted = { resourceType, namespace };
+    return Promise.resolve();
+  }
+
+  stopResourceWatch(): Promise<void> {
+    this.watchStopCount++;
+    this.watchStarted = null;
+    return Promise.resolve();
+  }
+
+  onWatchEvent(cb: (payload: WatchEventPayload) => void): Promise<Unsubscribe> {
+    this._watchCb = cb;
+    return Promise.resolve(() => {
+      this._watchCb = null;
+    });
+  }
+
+  // ── Cluster / contexts ──
+  getContexts(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+  getCurrentContext(): Promise<string> {
+    return Promise.resolve(this.currentContext ?? "");
+  }
+  switchContext(context: string): Promise<void> {
+    this.currentContext = context;
+    return Promise.resolve();
+  }
+  getNamespaces(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  // ── Transient teardown ──
+  stopLogStream(): Promise<void> {
+    return Promise.resolve();
+  }
+  stopTerminalExec(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  // ── Port forwards ──
+  startPortForward(args: PortForwardStartArgs): Promise<PortForwardStartResult> {
+    return Promise.resolve({ session_id: args.sessionId, local_port: args.localPort });
+  }
+  stopPortForward(): Promise<void> {
+    return Promise.resolve();
+  }
+  onPortForwardClosed(): Promise<Unsubscribe> {
+    return Promise.resolve(() => {});
+  }
+
+  // ── CRDs ──
+  discoverCrds(): Promise<CrdGroup[]> {
+    return Promise.resolve([]);
+  }
+  listCrdResources(_args: CrdListArgs): Promise<CrdResourceList> {
+    return Promise.resolve({ items: [], columns: [] });
+  }
+  getCrdCounts(_crds: CrdInfo[]): Promise<Record<string, number>> {
+    return Promise.resolve({});
+  }
+}

--- a/src/lib/stores/k8s.io.tauri.ts
+++ b/src/lib/stores/k8s.io.tauri.ts
@@ -1,0 +1,106 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { ResourceList, CrdGroup, CrdInfo, CrdResourceList } from "../types/index.js";
+import type {
+  KubeIo,
+  Unsubscribe,
+  WatchEventPayload,
+  PortForwardStartArgs,
+  PortForwardStartResult,
+  CrdListArgs,
+} from "./k8s.io.js";
+
+/**
+ * The real KubeIo adapter: maps the store's Kubernetes-domain calls onto Tauri
+ * `invoke` command strings and `listen` event channels. This is the ONLY place
+ * that knows the backend command names — the orchestration above the seam
+ * never sees them.
+ */
+export class TauriKubeIo implements KubeIo {
+  getContexts(): Promise<string[]> {
+    return invoke<string[]>("get_contexts");
+  }
+
+  getCurrentContext(): Promise<string> {
+    return invoke<string>("get_current_context");
+  }
+
+  switchContext(context: string): Promise<void> {
+    return invoke("switch_context", { context });
+  }
+
+  getNamespaces(): Promise<string[]> {
+    return invoke<string[]>("get_namespaces");
+  }
+
+  listResources(resourceType: string, namespace: string): Promise<ResourceList> {
+    return invoke<ResourceList>("list_resources", { resourceType, namespace });
+  }
+
+  getResourceCounts(
+    resourceTypes: readonly string[],
+    namespace: string,
+  ): Promise<Record<string, number>> {
+    return invoke<Record<string, number>>("get_resource_counts", {
+      resourceTypes: [...resourceTypes],
+      namespace,
+    });
+  }
+
+  startResourceWatch(resourceType: string, namespace: string): Promise<void> {
+    return invoke("start_resource_watch", { resourceType, namespace });
+  }
+
+  stopResourceWatch(): Promise<void> {
+    return invoke("stop_resource_watch");
+  }
+
+  async onWatchEvent(cb: (payload: WatchEventPayload) => void): Promise<Unsubscribe> {
+    return listen<WatchEventPayload>("resource-watch-event", (event) => cb(event.payload));
+  }
+
+  stopLogStream(): Promise<void> {
+    return invoke("stop_log_stream");
+  }
+
+  stopTerminalExec(): Promise<void> {
+    return invoke("stop_terminal_exec");
+  }
+
+  startPortForward(args: PortForwardStartArgs): Promise<PortForwardStartResult> {
+    return invoke<PortForwardStartResult>("start_port_forward", {
+      podName: args.podName,
+      namespace: args.namespace,
+      containerPort: args.containerPort,
+      localPort: args.localPort,
+      sessionId: args.sessionId,
+    });
+  }
+
+  stopPortForward(sessionId: string): Promise<void> {
+    return invoke("stop_port_forward", { sessionId });
+  }
+
+  async onPortForwardClosed(cb: (sessionId: string) => void): Promise<Unsubscribe> {
+    return listen<string>("port-forward-closed", (event) => cb(event.payload));
+  }
+
+  discoverCrds(): Promise<CrdGroup[]> {
+    return invoke<CrdGroup[]>("discover_crds");
+  }
+
+  listCrdResources(args: CrdListArgs): Promise<CrdResourceList> {
+    return invoke<CrdResourceList>("list_crd_resources", {
+      group: args.group,
+      version: args.version,
+      kind: args.kind,
+      plural: args.plural,
+      scope: args.scope,
+      namespace: args.namespace,
+    });
+  }
+
+  getCrdCounts(crds: CrdInfo[], namespace: string): Promise<Record<string, number>> {
+    return invoke<Record<string, number>>("get_crd_counts", { crds, namespace });
+  }
+}

--- a/src/lib/stores/k8s.io.ts
+++ b/src/lib/stores/k8s.io.ts
@@ -1,0 +1,87 @@
+import type {
+  Resource,
+  ResourceList,
+  CrdGroup,
+  CrdInfo,
+  CrdResourceList,
+} from "../types/index.js";
+import type { WatchEvent } from "./k8s.logic.js";
+
+/**
+ * The seam between the k8s store's orchestration and the Kubernetes backend.
+ *
+ * The store speaks Kubernetes (list these resources, watch that type) — never
+ * Tauri IPC command strings. TauriKubeIo maps this domain surface onto
+ * `invoke`/`listen`; a fake implementation lets the whole load → cache → watch
+ * → reconcile state machine be exercised in bun test without a real cluster.
+ *
+ * Two adapters (real + fake) make this a real seam, not a hypothetical one.
+ */
+
+/** Undo a subscription made via onWatchEvent / onPortForwardClosed. */
+export type Unsubscribe = () => void;
+
+/** The backend may deliver a single watch event or a coalesced batch. */
+export type WatchEventPayload = WatchEvent | WatchEvent[];
+
+export interface PortForwardStartArgs {
+  podName: string;
+  namespace: string;
+  containerPort: number;
+  localPort: number;
+  sessionId: string;
+}
+
+export interface PortForwardStartResult {
+  session_id: string;
+  local_port: number;
+}
+
+export interface CrdListArgs {
+  group: string;
+  version: string;
+  kind: string;
+  plural: string;
+  scope: string;
+  /** null for cluster-scoped CRDs. */
+  namespace: string | null;
+}
+
+export interface KubeIo {
+  // ── Cluster / contexts ──
+  getContexts(): Promise<string[]>;
+  getCurrentContext(): Promise<string>;
+  switchContext(context: string): Promise<void>;
+  getNamespaces(): Promise<string[]>;
+
+  // ── Resources ──
+  listResources(resourceType: string, namespace: string): Promise<ResourceList>;
+  getResourceCounts(
+    resourceTypes: readonly string[],
+    namespace: string,
+  ): Promise<Record<string, number>>;
+
+  // ── Watch ──
+  startResourceWatch(resourceType: string, namespace: string): Promise<void>;
+  stopResourceWatch(): Promise<void>;
+  onWatchEvent(cb: (payload: WatchEventPayload) => void): Promise<Unsubscribe>;
+
+  // ── Transient session teardown ──
+  stopLogStream(): Promise<void>;
+  stopTerminalExec(): Promise<void>;
+
+  // ── Port forwards ──
+  startPortForward(args: PortForwardStartArgs): Promise<PortForwardStartResult>;
+  stopPortForward(sessionId: string): Promise<void>;
+  onPortForwardClosed(cb: (sessionId: string) => void): Promise<Unsubscribe>;
+
+  // ── CRDs ──
+  discoverCrds(): Promise<CrdGroup[]>;
+  listCrdResources(args: CrdListArgs): Promise<CrdResourceList>;
+  getCrdCounts(
+    crds: CrdInfo[],
+    namespace: string,
+  ): Promise<Record<string, number>>;
+}
+
+export type { Resource };

--- a/src/lib/stores/k8s.logic.ts
+++ b/src/lib/stores/k8s.logic.ts
@@ -7,6 +7,7 @@ import type {
   CrdInfo,
   CrdResourceList,
 } from "../types/index.js";
+import type { KubeIo, Unsubscribe } from "./k8s.io.js";
 
 export interface WatchEvent {
   event_type: "Applied" | "Deleted" | "Resync";
@@ -78,6 +79,30 @@ export class K8sStoreLogic {
 
   _countGeneration = 0;
   _scopeGeneration = 0;
+
+  // ── Backend seam + watch lifecycle ──
+  // Moved here from the Svelte subclass so the load → cache → watch → reconcile
+  // orchestration depends only on the injected KubeIo port and is exercisable
+  // in bun test against a fake adapter.
+  protected _ageInterval: ReturnType<typeof setInterval> | null = null;
+  protected _watchUnlisten: Unsubscribe | null = null;
+  protected _watchActive = false;
+  protected _pendingWatchEvents: WatchEvent[] = [];
+  protected _watchFlushScheduled = false;
+  // Serializes start/stop so two fire-and-forget callers can't race on the
+  // single interval/listener slots and orphan a timer or listener.
+  protected _watchOp: Promise<void> = Promise.resolve();
+
+  constructor(protected io: KubeIo) {}
+
+  /**
+   * How a pending watch-event batch is scheduled to flush. The base batches on
+   * a microtask — deterministic, and works under bun test. The Svelte store
+   * overrides this with requestAnimationFrame to coalesce within a frame.
+   */
+  protected _scheduleFlush(flush: () => void): void {
+    queueMicrotask(flush);
+  }
 
   /** Set both resource type states atomically (for non-async transitions) */
   setResourceType(type: string): void {
@@ -178,44 +203,6 @@ export class K8sStoreLogic {
     this.selectedResource = target;
   }
 
-  /** Handle a single watch event (used by flush in the Svelte store). */
-  handleWatchEvent(event: WatchEvent): void {
-    if (event.resource_type !== this.selectedResourceType) return;
-
-    if (event.event_type === "Resync") {
-      // In the real store this triggers a full refresh via Tauri
-      return;
-    }
-
-    const uid = event.resource.metadata?.uid;
-    if (!uid) return;
-
-    if (event.event_type === "Applied") {
-      const items = this.resources.items;
-      const idx = items.findIndex((r) => r.metadata?.uid === uid);
-      if (idx >= 0) {
-        items[idx] = event.resource;
-      } else {
-        items.push(event.resource);
-      }
-      this.resources = { ...this.resources, items };
-      this._setCount(event.resource_type, items.length);
-      if (this.selectedResource?.metadata?.uid === uid) {
-        this.selectedResource = event.resource;
-      }
-    } else if (event.event_type === "Deleted") {
-      const items = this.resources.items;
-      const idx = items.findIndex((r) => r.metadata?.uid === uid);
-      if (idx >= 0) {
-        items.splice(idx, 1);
-        this.resources = { ...this.resources, items };
-        this._setCount(event.resource_type, items.length);
-        if (this.selectedResource?.metadata?.uid === uid) {
-          this.selectedResource = null;
-        }
-      }
-    }
-  }
 
   /** Synchronous port forward add (no Tauri calls). */
   addPortForwardSync(info: PortForwardInfo): void {
@@ -243,5 +230,235 @@ export class K8sStoreLogic {
   /** Get display key for a CRD (used for counts map) */
   crdKey(crd: CrdInfo): string {
     return `${crd.group}/${crd.kind}`;
+  }
+
+  // =========================================================================
+  // Resource load / watch / reconcile orchestration
+  // Depends only on the injected KubeIo, so the whole state machine (scope
+  // guards, cache-vs-load-vs-reconcile, watch start/stop, batched flush,
+  // resync) is exercisable in bun test via a fake adapter.
+  // =========================================================================
+
+  async loadResources(resourceType: string, scopeGeneration = this._scopeGeneration): Promise<void> {
+    const timer = setTimeout(() => { this.isLoading = true; }, 200);
+    try {
+      this.error = null;
+      this.pendingResourceType = resourceType;
+      const result = await this.io.listResources(resourceType, this.currentNamespace);
+      if (scopeGeneration !== this._scopeGeneration) return;
+      if (this.pendingResourceType !== resourceType) return;
+      this.selectedResourceType = resourceType;
+      // Backend ResourceList carries only `items` — stamp resource_type here so
+      // downstream cache/save logic (saveOutgoingTabState's guard, watch flush)
+      // can trust it. Mirrors restoreResourcesSync.
+      this.resources = { items: result.items, resource_type: resourceType };
+      this._setCount(resourceType, result.items.length);
+      this._startWatch(resourceType, this.currentNamespace);
+    } catch (err) {
+      if (scopeGeneration !== this._scopeGeneration) return;
+      this.error = `Failed to load resources: ${err}`;
+      this.resources = { items: [], resource_type: resourceType };
+    } finally {
+      clearTimeout(timer);
+      if (scopeGeneration === this._scopeGeneration) {
+        this.isLoading = false;
+      }
+    }
+  }
+
+  /** Restore resources from tab cache without fetching, then start a watch. */
+  restoreResources(resourceType: string, items: Resource[]): void {
+    this.restoreResourcesSync(resourceType, items);
+    this._startWatch(resourceType, this.currentNamespace);
+  }
+
+  /**
+   * Silent background refetch used after a cache-restored tab switch. The
+   * cache is a snapshot from when the tab was last active; creates/deletes/
+   * modifications that happened while it was inactive are not replayed by the
+   * freshly-started watcher (the backend suppresses the initial list on watch
+   * start — see k8s/watch.rs), so the cached rows would otherwise stay stale
+   * until each object next changes.
+   *
+   * Unlike loadResources this:
+   *   - never flips isLoading (the cached snapshot is already painted),
+   *   - keeps the current items on error instead of blanking the table,
+   *   - does NOT (re)start the watch — restoreResources already did.
+   */
+  async reconcileResources(resourceType: string): Promise<void> {
+    const scopeGeneration = this._scopeGeneration;
+    try {
+      const result = await this.io.listResources(resourceType, this.currentNamespace);
+      // Discard if the user navigated away (type) or changed scope
+      // (namespace/context) while the fetch was in flight.
+      if (scopeGeneration !== this._scopeGeneration) return;
+      if (this.selectedResourceType !== resourceType) return;
+      // Stamp resource_type (backend omits it) so this reconcile doesn't clobber
+      // the type that restoreResourcesSync just set — otherwise the next
+      // saveOutgoingTabState guard fails and the cache silently stops saving.
+      this.resources = { items: result.items, resource_type: resourceType };
+      this._setCount(resourceType, result.items.length);
+    } catch (err) {
+      // Keep the cached snapshot on error — a transient list failure on tab
+      // return must not wipe the table to empty.
+      if (import.meta.env?.DEV) console.warn("Failed to reconcile after cache restore:", err);
+    }
+  }
+
+  /** Fetch a single resource by type and name without changing current view state. */
+  async fetchResource(resourceType: string, name: string, namespace?: string): Promise<Resource | null> {
+    const result = await this.io.listResources(resourceType, this.currentNamespace);
+    return result.items.find(
+      (r) => r.metadata.name === name && (!namespace || r.metadata.namespace === namespace)
+    ) ?? null;
+  }
+
+  protected _listResources(resourceType: string): Promise<ResourceList> {
+    return this.io.listResources(resourceType, this.currentNamespace);
+  }
+
+  protected _startWatch(resourceType: string, namespace: string): Promise<void> {
+    // Chain onto the shared op so a stop always completes before the next start
+    // runs — no two starts can interleave on the single interval/listener slots.
+    this._watchOp = this._watchOp.then(async () => {
+      await this._stopWatchInner();
+      // Age ticker every 30s to refresh displayed ages (1s is wasteful).
+      this._ageInterval = setInterval(() => { this.ageTick++; }, 30_000);
+      // Don't hold the process open for the display ticker under bun test.
+      (this._ageInterval as { unref?: () => void }).unref?.();
+      try {
+        this._watchUnlisten = await this.io.onWatchEvent((payload) => {
+          this._handleWatchEvents(payload);
+        });
+        await this.io.startResourceWatch(resourceType, namespace);
+        this._watchActive = true;
+      } catch (err) {
+        if (import.meta.env?.DEV) console.warn("Failed to start resource watch:", err);
+      }
+    });
+    return this._watchOp;
+  }
+
+  protected _stopWatch(): Promise<void> {
+    this._watchOp = this._watchOp.then(() => this._stopWatchInner());
+    return this._watchOp;
+  }
+
+  protected async _stopWatchInner(): Promise<void> {
+    this._pendingWatchEvents = [];
+    this._watchFlushScheduled = false;
+    if (this._ageInterval) {
+      clearInterval(this._ageInterval);
+      this._ageInterval = null;
+    }
+    if (this._watchActive) {
+      try {
+        await this.io.stopResourceWatch();
+      } catch {
+        // ignore stop errors
+      }
+      this._watchActive = false;
+    }
+    if (this._watchUnlisten) {
+      this._watchUnlisten();
+      this._watchUnlisten = null;
+    }
+  }
+
+  /** Backend may emit a single event or a coalesced batch (array). */
+  protected _handleWatchEvents(payload: WatchEvent | WatchEvent[]): void {
+    if (Array.isArray(payload)) {
+      for (const event of payload) this._handleWatchEvent(event);
+    } else {
+      this._handleWatchEvent(payload);
+    }
+  }
+
+  protected _handleWatchEvent(event: WatchEvent): void {
+    // Only process events for the currently viewed resource type
+    if (event.resource_type !== this.selectedResourceType) return;
+
+    // Resync: watcher reconnected after a gap, do a full refresh
+    if (event.event_type === "Resync") {
+      this._pendingWatchEvents = [];
+      this._watchFlushScheduled = false;
+      this._refreshAfterResync();
+      return;
+    }
+
+    this._pendingWatchEvents.push(event);
+    if (!this._watchFlushScheduled) {
+      this._watchFlushScheduled = true;
+      this._scheduleFlush(() => this._flushWatchEvents());
+    }
+  }
+
+  protected _flushWatchEvents(): void {
+    const batch = this._pendingWatchEvents;
+    this._pendingWatchEvents = [];
+    this._watchFlushScheduled = false;
+
+    if (batch.length === 0) return;
+
+    // Guard: discard stale events if context/namespace changed during the frame.
+    const scopeGen = this._scopeGeneration;
+
+    // Build an ordered uid→Resource map once (O(N)) so each event is an O(1)
+    // upsert/delete instead of an O(N) findIndex/splice — turns the worst-case
+    // O(N·M) flush into O(N+M). Map iteration order matches the current array
+    // and set() keeps an existing key's position, so item order is preserved.
+    const byUid = new Map<string, Resource>();
+    for (const r of this.resources.items) {
+      const uid = r.metadata?.uid;
+      if (uid) byUid.set(uid, r);
+    }
+
+    let selectedResourceUpdate: Resource | null | undefined;
+    let changed = false;
+
+    for (const event of batch) {
+      if (this._scopeGeneration !== scopeGen) return;
+
+      const uid = event.resource.metadata?.uid;
+      if (!uid) continue;
+
+      if (event.event_type === "Applied") {
+        byUid.set(uid, event.resource);
+        changed = true;
+        if (this.selectedResource?.metadata?.uid === uid) {
+          selectedResourceUpdate = event.resource;
+        }
+      } else if (event.event_type === "Deleted") {
+        if (byUid.delete(uid)) {
+          changed = true;
+          if (this.selectedResource?.metadata?.uid === uid) {
+            selectedResourceUpdate = null;
+          }
+        }
+      }
+    }
+
+    if (changed) {
+      const items = Array.from(byUid.values());
+      // Trigger reactivity ONCE for the entire batch (fresh array required for
+      // $state.raw correctness in the Svelte subclass).
+      this.resources = { items, resource_type: this.resources.resource_type };
+      this._setCount(this.selectedResourceType, items.length);
+    }
+
+    if (selectedResourceUpdate !== undefined) {
+      this.selectedResource = selectedResourceUpdate;
+    }
+  }
+
+  protected async _refreshAfterResync(): Promise<void> {
+    try {
+      const resourceType = this.selectedResourceType;
+      const result = await this.io.listResources(resourceType, this.currentNamespace);
+      this.resources = { items: result.items, resource_type: resourceType };
+      this._setCount(resourceType, result.items.length);
+    } catch (err) {
+      if (import.meta.env?.DEV) console.warn("Failed to refresh after resync:", err);
+    }
   }
 }

--- a/src/lib/stores/k8s.orchestration.test.ts
+++ b/src/lib/stores/k8s.orchestration.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { Resource } from "../types/index.js";
+import { K8sStoreLogic, type WatchEvent } from "./k8s.logic.js";
+import { FakeKubeIo } from "./k8s.io.fake.js";
+
+function mkResource(name: string, namespace = "default"): Resource {
+  return {
+    kind: "Pod",
+    api_version: "v1",
+    metadata: {
+      name,
+      namespace,
+      uid: `uid-${name}`,
+      creation_timestamp: "2024-01-01T00:00:00Z",
+      labels: {},
+      annotations: {},
+      owner_references: [],
+      resource_version: "1",
+    },
+    spec: {},
+    status: {},
+  };
+}
+
+function applied(r: Resource): WatchEvent {
+  return { event_type: "Applied", resource_type: "pods", resource: r };
+}
+function deleted(r: Resource): WatchEvent {
+  return { event_type: "Deleted", resource_type: "pods", resource: r };
+}
+
+/** Drain microtasks + timers so the base's queueMicrotask flush runs. */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * These exercise the load → cache → watch → reconcile orchestration that used
+ * to live in the Tauri-coupled Svelte subclass — the exact code the
+ * stale-on-return bug lived in, and which had no test seam. With KubeIo
+ * extracted, the FakeKubeIo adapter drives the real state machine in bun.
+ */
+describe("K8sStoreLogic orchestration (via FakeKubeIo)", () => {
+  let io: FakeKubeIo;
+  let store: K8sStoreLogic;
+
+  beforeEach(() => {
+    io = new FakeKubeIo();
+    store = new K8sStoreLogic(io);
+  });
+
+  describe("loadResources", () => {
+    test("populates items, selects the type, and starts a watch", async () => {
+      io.setList([mkResource("a"), mkResource("b")], "pods");
+
+      await store.loadResources("pods");
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a", "b"]);
+      expect(store.selectedResourceType).toBe("pods");
+      expect(store.error).toBeNull();
+      expect(io.watchStarted).toEqual({ resourceType: "pods", namespace: "default" });
+    });
+
+    test("stamps resource_type even though the backend omits it", async () => {
+      // The Rust ResourceList carries only `items` — resource_type arrives
+      // undefined. The store must stamp it, or saveOutgoingTabState's cache
+      // guard (resources.resource_type === tab.resourceType) silently fails.
+      io.listResult = { items: [mkResource("a")], resource_type: undefined as unknown as string };
+
+      await store.loadResources("pods");
+
+      expect(store.resources.resource_type).toBe("pods");
+    });
+
+    test("on list failure sets error and blanks the table", async () => {
+      io.listError = new Error("boom");
+
+      await store.loadResources("pods");
+
+      expect(store.error).toContain("Failed to load resources");
+      expect(store.resources.items).toEqual([]);
+    });
+  });
+
+  describe("reconcileResources — the stale-on-return fix, at the real layer", () => {
+    test("reconciles rows that changed while the tab was inactive", async () => {
+      // Tab was active on [a]; watch started (initial list suppressed by backend).
+      io.setList([mkResource("a")], "pods");
+      await store.loadResources("pods");
+      await tick();
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+
+      // While away, the cluster gains pod b. The fresh watcher on return will
+      // NOT replay it — only a refetch can reconcile.
+      io.setList([mkResource("a"), mkResource("b")], "pods");
+
+      // Return: paint the cached (stale) snapshot instantly...
+      store.restoreResources("pods", [mkResource("a")]);
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+
+      // ...then reconcile in the background.
+      await store.reconcileResources("pods");
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a", "b"]);
+    });
+
+    test("reconcile keeps resource_type stamped (does not clobber to undefined)", async () => {
+      io.setList([mkResource("a")], "pods");
+      await store.loadResources("pods");
+      await tick();
+
+      // Backend omits resource_type on the reconcile fetch too.
+      io.listResult = { items: [mkResource("a")], resource_type: undefined as unknown as string };
+      await store.reconcileResources("pods");
+
+      // Must stay "pods" so the next saveOutgoingTabState cache guard passes.
+      expect(store.resources.resource_type).toBe("pods");
+    });
+
+    test("keeps the cached snapshot when the reconcile fetch fails", async () => {
+      io.setList([mkResource("a")], "pods");
+      await store.loadResources("pods");
+      await tick();
+
+      store.restoreResources("pods", [mkResource("a")]);
+      io.listError = new Error("transient");
+
+      await store.reconcileResources("pods");
+
+      // Must NOT blank the table on a transient failure.
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+    });
+
+    test("discards the reconcile result if the type drifted mid-flight", async () => {
+      io.setList([mkResource("a")], "pods");
+      await store.loadResources("pods");
+      await tick();
+
+      // Simulate the user switching type before the reconcile resolves.
+      io.setList([mkResource("stale")], "pods");
+      store.setResourceType("services");
+
+      await store.reconcileResources("pods");
+
+      // The pods result must not overwrite the now-services view.
+      expect(store.resources.items.map((r) => r.metadata.name)).not.toContain("stale");
+    });
+  });
+
+  describe("watch flush (the shipping batched Map-upsert path)", () => {
+    beforeEach(async () => {
+      io.setList([mkResource("a")], "pods");
+      await store.loadResources("pods");
+      await tick();
+    });
+
+    test("coalesces a batch of Applied/Deleted into one update", async () => {
+      store["_handleWatchEvents"]([applied(mkResource("b")), applied(mkResource("c"))]);
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a", "b", "c"]);
+    });
+
+    test("Deleted removes the row", async () => {
+      store["_handleWatchEvents"](deleted(mkResource("a")));
+      await tick();
+
+      expect(store.resources.items).toEqual([]);
+    });
+
+    test("ignores events for a different resource type", async () => {
+      store["_handleWatchEvents"]({
+        event_type: "Applied",
+        resource_type: "services",
+        resource: mkResource("svc"),
+      });
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+    });
+
+    test("Resync triggers a full refetch (previously stubbed, now real)", async () => {
+      io.setList([mkResource("a"), mkResource("b"), mkResource("c")], "pods");
+      store["_handleWatchEvents"]({
+        event_type: "Resync",
+        resource_type: "pods",
+        resource: mkResource("ignored"),
+      });
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a", "b", "c"]);
+    });
+
+    test("Applied updates an existing row in place", async () => {
+      const updated = { ...mkResource("a"), status: { phase: "Succeeded" } };
+      store["_handleWatchEvents"](applied(updated));
+      await tick();
+
+      expect(store.resources.items).toHaveLength(1);
+      expect(store.resources.items[0].status).toEqual({ phase: "Succeeded" });
+    });
+
+    test("Applied to the selected resource updates selectedResource", async () => {
+      store.selectedResource = store.resources.items[0];
+      const updated = { ...mkResource("a"), status: { phase: "Succeeded" } };
+      store["_handleWatchEvents"](applied(updated));
+      await tick();
+
+      expect(store.selectedResource?.status).toEqual({ phase: "Succeeded" });
+    });
+
+    test("Deleting the selected resource clears selectedResource", async () => {
+      store.selectedResource = store.resources.items[0];
+      store["_handleWatchEvents"](deleted(mkResource("a")));
+      await tick();
+
+      expect(store.selectedResource).toBeNull();
+    });
+
+    test("Deleting a non-existent row is a no-op", async () => {
+      store["_handleWatchEvents"](deleted(mkResource("ghost")));
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+    });
+
+    test("ignores an event whose resource has no uid", async () => {
+      const noUid = mkResource("x");
+      (noUid.metadata as { uid?: string }).uid = undefined;
+      store["_handleWatchEvents"](applied(noUid));
+      await tick();
+
+      expect(store.resources.items.map((r) => r.metadata.name)).toEqual(["a"]);
+    });
+  });
+});

--- a/src/lib/stores/k8s.svelte.ts
+++ b/src/lib/stores/k8s.svelte.ts
@@ -1,9 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { Resource, ResourceList, ConnectionStatus, PortForwardInfo, CrdGroup, CrdInfo, CrdResourceList } from "../types/index.js";
 import { settingsStore } from "./settings.svelte";
 import { toastStore } from "./toast.svelte.js";
 import { K8sStoreLogic, COUNTABLE_RESOURCE_TYPES } from "./k8s.logic.js";
+import type { KubeIo, Unsubscribe } from "./k8s.io.js";
+import { TauriKubeIo } from "./k8s.io.tauri.js";
 import { unshadowState } from "./_unshadow.js";
 
 export type { WatchEvent, NavigationEntry } from "./k8s.logic.js";
@@ -48,27 +48,19 @@ class K8sStore extends K8sStoreLogic {
   override crdCounts = $state<Record<string, number>>({});
   override selectedCrd = $state<CrdInfo | null>(null);
 
-  // Private members that require Tauri / browser APIs (not in logic class)
-  private _ageInterval: ReturnType<typeof setInterval> | null = null;
-  private _watchUnlisten: UnlistenFn | null = null;
-  private _watchActive = false;
-  private _pfUnlisten: UnlistenFn | null = null;
-  private _pendingWatchEvents: import("./k8s.logic.js").WatchEvent[] = [];
-  private _watchFlushScheduled = false;
-  // Serializes start/stop so two fire-and-forget callers can't race on the
-  // single _ageInterval/_watchUnlisten/_watchActive slots and orphan a timer
-  // or listener (a slow, unbounded leak under rapid type/tab switching).
-  private _watchOp: Promise<void> = Promise.resolve();
+  // Port-forward listener slot (still Tauri/browser-bound; the resource-watch
+  // lifecycle moved to K8sStoreLogic behind the KubeIo port).
+  private _pfUnlisten: Unsubscribe | null = null;
 
-  constructor() {
-    super();
+  constructor(io: KubeIo = new TauriKubeIo()) {
+    super(io);
     unshadowState(this);
   }
 
   private async _stopAllPortForwards(): Promise<void> {
     const active = [...this.portForwards];
     await Promise.allSettled(
-      active.map((pf) => invoke("stop_port_forward", { sessionId: pf.session_id }))
+      active.map((pf) => this.io.stopPortForward(pf.session_id))
     );
     this.portForwards = [];
   }
@@ -76,8 +68,8 @@ class K8sStore extends K8sStoreLogic {
   private async _stopTransientSessions(): Promise<void> {
     await this._stopWatch();
     await Promise.allSettled([
-      invoke("stop_log_stream"),
-      invoke("stop_terminal_exec"),
+      this.io.stopLogStream(),
+      this.io.stopTerminalExec(),
       this._stopAllPortForwards(),
     ]);
   }
@@ -87,11 +79,11 @@ class K8sStore extends K8sStoreLogic {
       this.contextsLoadError = null;
       this.error = null;
       this.connectionStatus = "connecting";
-      const result = await invoke<string[]>("get_contexts");
+      const result = await this.io.getContexts();
       this.contexts = result;
       if (result.length > 0 && !this.currentContext) {
         try {
-          this.currentContext = await invoke<string>("get_current_context");
+          this.currentContext = await this.io.getCurrentContext();
         } catch {
           this.currentContext = result[0];
         }
@@ -109,7 +101,7 @@ class K8sStore extends K8sStoreLogic {
     try {
       this.namespacesLoadError = null;
       this.error = null;
-      const result = await invoke<string[]>("get_namespaces");
+      const result = await this.io.getNamespaces();
       if (scopeGeneration !== this._scopeGeneration) return;
       this.namespaces = result;
     } catch (err) {
@@ -129,7 +121,7 @@ class K8sStore extends K8sStoreLogic {
       if (scopeGeneration !== this._scopeGeneration) return;
 
       this.connectionStatus = "connecting";
-      await invoke("switch_context", { context });
+      await this.io.switchContext(context);
       if (scopeGeneration !== this._scopeGeneration) return;
 
       this._resetVisibleState({ clearNamespaces: true });
@@ -181,44 +173,6 @@ class K8sStore extends K8sStoreLogic {
     }
   }
 
-  async loadResources(resourceType: string, scopeGeneration = this._scopeGeneration): Promise<void> {
-    const timer = setTimeout(() => { this.isLoading = true; }, 200);
-    try {
-      this.error = null;
-      this.pendingResourceType = resourceType;
-      const result = await this._listResources(resourceType);
-      if (scopeGeneration !== this._scopeGeneration) return;
-      if (this.pendingResourceType !== resourceType) return;
-      this.selectedResourceType = resourceType;
-      this.resources = result;
-      this._setCount(resourceType, result.items.length);
-      this._startWatch(resourceType, this.currentNamespace);
-    } catch (err) {
-      if (scopeGeneration !== this._scopeGeneration) return;
-      this.error = `Failed to load resources: ${err}`;
-      this.resources = { items: [], resource_type: resourceType };
-    } finally {
-      clearTimeout(timer);
-      if (scopeGeneration === this._scopeGeneration) {
-        this.isLoading = false;
-      }
-    }
-  }
-
-  /** Restore resources from tab cache without fetching */
-  restoreResources(resourceType: string, items: Resource[]): void {
-    this.restoreResourcesSync(resourceType, items);
-    this._startWatch(resourceType, this.currentNamespace);
-  }
-
-  /** Fetch a single resource by type and name without changing current view state. */
-  async fetchResource(resourceType: string, name: string, namespace?: string): Promise<Resource | null> {
-    const result = await this._listResources(resourceType);
-    return result.items.find(
-      (r) => r.metadata.name === name && (!namespace || r.metadata.namespace === namespace)
-    ) ?? null;
-  }
-
   /** @deprecated Use openRelatedResourceTab() or openResourceDetail() instead */
   async navigateToRelated(resourceType: string, name: string, namespace?: string): Promise<void> {
     // Push current state
@@ -247,7 +201,7 @@ class K8sStore extends K8sStoreLogic {
     this.selectedResource = entry.resource;
     // Reload resources for the previous type in background
     this._listResources(entry.resourceType).then((result) => {
-      this.resources = result;
+      this.resources = { items: result.items, resource_type: entry.resourceType };
       this._setCount(entry.resourceType, result.items.length);
       this._startWatch(entry.resourceType, this.currentNamespace);
       // Re-find the resource in case it was updated
@@ -270,7 +224,7 @@ class K8sStore extends K8sStoreLogic {
     const expectedType = entry.resourceType;
     this._listResources(expectedType).then((result) => {
       if (this.selectedResourceType !== expectedType) return;
-      this.resources = result;
+      this.resources = { items: result.items, resource_type: expectedType };
       this._setCount(expectedType, result.items.length);
       this._startWatch(expectedType, this.currentNamespace);
       const updated = result.items.find((r) => r.metadata.uid === entry.resource.metadata.uid);
@@ -301,10 +255,7 @@ class K8sStore extends K8sStoreLogic {
     const gen = ++this._countGeneration;
     const namespace = this.currentNamespace;
     try {
-      const counts = await invoke<Record<string, number>>("get_resource_counts", {
-        resourceTypes: [...COUNTABLE_RESOURCE_TYPES],
-        namespace,
-      });
+      const counts = await this.io.getResourceCounts(COUNTABLE_RESOURCE_TYPES, namespace);
       // Discard stale results if namespace/context changed while in-flight
       if (gen !== this._countGeneration || scopeGeneration !== this._scopeGeneration) return;
       this.resourceCounts = { ...this.resourceCounts, ...counts };
@@ -317,7 +268,7 @@ class K8sStore extends K8sStoreLogic {
     try {
       if (context && this.contexts.includes(context) && context !== this.currentContext) {
         this.connectionStatus = "connecting";
-        await invoke("switch_context", { context });
+        await this.io.switchContext(context);
         this.currentContext = context;
         this.connectionStatus = "connected";
       }
@@ -334,166 +285,16 @@ class K8sStore extends K8sStoreLogic {
     settingsStore.updateConnection(this.currentContext, this.currentNamespace);
   }
 
-  private async _listResources(resourceType: string): Promise<ResourceList> {
-    return invoke<ResourceList>("list_resources", {
-      resourceType,
-      namespace: this.currentNamespace,
-    });
-  }
-
-  private _startWatch(resourceType: string, namespace: string): Promise<void> {
-    // Chain onto the shared op so a stop always completes before the next start
-    // runs — no two starts can interleave on the single interval/listener slots.
-    this._watchOp = this._watchOp.then(async () => {
-      await this._stopWatchInner();
-      // Start age ticker every 30s to refresh displayed ages (1s is wasteful – age labels barely change)
-      this._ageInterval = setInterval(() => { this.ageTick++; }, 30_000);
-      try {
-        // Listen for watch events from the backend
-        this._watchUnlisten = await listen<import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]>("resource-watch-event", (event) => {
-          this._handleWatchEvents(event.payload);
-        });
-        // Start the backend watcher
-        await invoke("start_resource_watch", {
-          resourceType,
-          namespace,
-        });
-        this._watchActive = true;
-      } catch (err) {
-        if (import.meta.env.DEV) console.warn("Failed to start resource watch:", err);
-      }
-    });
-    return this._watchOp;
-  }
-
-  private _stopWatch(): Promise<void> {
-    this._watchOp = this._watchOp.then(() => this._stopWatchInner());
-    return this._watchOp;
-  }
-
-  private async _stopWatchInner(): Promise<void> {
-    this._pendingWatchEvents = [];
-    this._watchFlushScheduled = false;
-    if (this._ageInterval) {
-      clearInterval(this._ageInterval);
-      this._ageInterval = null;
-    }
-    if (this._watchActive) {
-      try {
-        await invoke("stop_resource_watch");
-      } catch {
-        // ignore stop errors
-      }
-      this._watchActive = false;
-    }
-    if (this._watchUnlisten) {
-      this._watchUnlisten();
-      this._watchUnlisten = null;
-    }
-  }
-
-  /** Backend may emit a single event or a coalesced batch (array). */
-  private _handleWatchEvents(payload: import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]): void {
-    if (Array.isArray(payload)) {
-      for (const event of payload) this._handleWatchEvent(event);
-    } else {
-      this._handleWatchEvent(payload);
-    }
-  }
-
-  private _handleWatchEvent(event: import("./k8s.logic.js").WatchEvent): void {
-    // Only process events for the currently viewed resource type
-    if (event.resource_type !== this.selectedResourceType) return;
-
-    // Resync: watcher reconnected after a gap, do a full refresh
-    if (event.event_type === "Resync") {
-      this._pendingWatchEvents = [];
-      this._watchFlushScheduled = false;
-      this._refreshAfterResync();
-      return;
-    }
-
-    this._pendingWatchEvents.push(event);
-    if (!this._watchFlushScheduled) {
-      this._watchFlushScheduled = true;
-      requestAnimationFrame(() => this._flushWatchEvents());
-    }
-  }
-
-  private _flushWatchEvents(): void {
-    const batch = this._pendingWatchEvents;
-    this._pendingWatchEvents = [];
-    this._watchFlushScheduled = false;
-
-    if (batch.length === 0) return;
-
-    // Guard: discard stale events if context/namespace changed during the frame
-    const scopeGen = this._scopeGeneration;
-
-    // Build an ordered uid→Resource map once (O(N)) so each event is an O(1)
-    // upsert/delete instead of an O(N) findIndex/splice — turns the worst-case
-    // O(N·M) flush (M events over N items) into O(N+M). Map iteration order
-    // matches the current array and set() keeps an existing key's position, so
-    // the resulting item order is identical to the previous in-place logic.
-    // A fresh array is built at the end (required for $state.raw correctness).
-    const byUid = new Map<string, Resource>();
-    for (const r of this.resources.items) {
-      const uid = r.metadata?.uid;
-      if (uid) byUid.set(uid, r);
-    }
-
-    let selectedResourceUpdate: Resource | null | undefined;
-    let changed = false;
-
-    for (const event of batch) {
-      // Double-check scope hasn't changed mid-flush
-      if (this._scopeGeneration !== scopeGen) return;
-
-      const uid = event.resource.metadata?.uid;
-      if (!uid) continue;
-
-      if (event.event_type === "Applied") {
-        byUid.set(uid, event.resource);
-        changed = true;
-        if (this.selectedResource?.metadata?.uid === uid) {
-          selectedResourceUpdate = event.resource;
-        }
-      } else if (event.event_type === "Deleted") {
-        if (byUid.delete(uid)) {
-          changed = true;
-          if (this.selectedResource?.metadata?.uid === uid) {
-            selectedResourceUpdate = null;
-          }
-        }
-      }
-    }
-
-    if (changed) {
-      const items = Array.from(byUid.values());
-      // Trigger Svelte 5 reactivity ONCE for the entire batch
-      this.resources = { items, resource_type: this.resources.resource_type };
-      this._setCount(this.selectedResourceType, items.length);
-    }
-
-    if (selectedResourceUpdate !== undefined) {
-      this.selectedResource = selectedResourceUpdate;
-    }
-  }
-
-  private async _refreshAfterResync(): Promise<void> {
-    try {
-      const result = await this._listResources(this.selectedResourceType);
-      this.resources = result;
-      this._setCount(this.selectedResourceType, result.items.length);
-    } catch (err) {
-      if (import.meta.env.DEV) console.warn("Failed to refresh after resync:", err);
-    }
+  // requestAnimationFrame coalesces a burst of watch events into one flush per
+  // frame. The base K8sStoreLogic uses a microtask by default (bun-testable);
+  // in the browser we want the real frame-batched behaviour.
+  protected override _scheduleFlush(flush: () => void): void {
+    requestAnimationFrame(flush);
   }
 
   private async _ensurePortForwardListener(): Promise<void> {
     if (this._pfUnlisten) return;
-    this._pfUnlisten = await listen<string>("port-forward-closed", (event) => {
-      const sessionId = event.payload;
+    this._pfUnlisten = await this.io.onPortForwardClosed((sessionId) => {
       const pf = this.portForwards.find((p) => p.session_id === sessionId);
       if (pf) {
         this.portForwards = this.portForwards.filter((p) => p.session_id !== sessionId);
@@ -508,16 +309,13 @@ class K8sStore extends K8sStoreLogic {
   async addPortForward(info: PortForwardInfo): Promise<void> {
     await this._ensurePortForwardListener();
     try {
-      const result = await invoke<{ session_id: string; local_port: number }>(
-        "start_port_forward",
-        {
-          podName: info.pod_name,
-          namespace: info.namespace,
-          containerPort: info.container_port,
-          localPort: info.local_port,
-          sessionId: info.session_id,
-        }
-      );
+      const result = await this.io.startPortForward({
+        podName: info.pod_name,
+        namespace: info.namespace,
+        containerPort: info.container_port,
+        localPort: info.local_port,
+        sessionId: info.session_id,
+      });
       this.portForwards = [
         ...this.portForwards,
         { ...info, local_port: result.local_port, session_id: result.session_id },
@@ -529,7 +327,7 @@ class K8sStore extends K8sStoreLogic {
 
   async removePortForward(sessionId: string): Promise<void> {
     try {
-      await invoke("stop_port_forward", { sessionId });
+      await this.io.stopPortForward(sessionId);
     } catch {
       // ignore stop errors (session may already be gone)
     }
@@ -545,7 +343,7 @@ class K8sStore extends K8sStoreLogic {
     this.crdLoading = true;
     this.crdError = null;
     try {
-      const groups = await invoke<CrdGroup[]>("discover_crds");
+      const groups = await this.io.discoverCrds();
       if (scopeGeneration !== this._scopeGeneration) return;
       this.crdGroups = groups;
     } catch (e) {
@@ -566,7 +364,7 @@ class K8sStore extends K8sStoreLogic {
     this.crdResources = { items: [], columns: [] };
     this.isLoading = true;
     try {
-      const result = await invoke<CrdResourceList>("list_crd_resources", {
+      const result = await this.io.listCrdResources({
         group: crd.group,
         version: crd.version,
         kind: crd.kind,
@@ -588,10 +386,7 @@ class K8sStore extends K8sStoreLogic {
   async loadCrdCounts(crds: CrdInfo[]): Promise<void> {
     if (crds.length === 0) return;
     try {
-      const counts = await invoke<Record<string, number>>("get_crd_counts", {
-        crds,
-        namespace: this.currentNamespace,
-      });
+      const counts = await this.io.getCrdCounts(crds, this.currentNamespace);
       this.crdCounts = { ...this.crdCounts, ...counts };
     } catch {
       // Silently fail — counts are non-essential

--- a/src/lib/stores/k8s.test.ts
+++ b/src/lib/stores/k8s.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import type { Resource, ResourceList, ConnectionStatus, PortForwardInfo } from "../types/index.js";
 import { K8sStoreLogic, type WatchEvent } from "./k8s.logic.js";
+import { FakeKubeIo } from "./k8s.io.fake.js";
 
 interface ResourceOverrides {
   kind?: string;
@@ -33,7 +34,7 @@ describe("K8sStore", () => {
   let store: K8sStoreLogic;
 
   beforeEach(() => {
-    store = new K8sStoreLogic();
+    store = new K8sStoreLogic(new FakeKubeIo());
   });
 
   describe("initial state", () => {
@@ -213,136 +214,10 @@ describe("K8sStore", () => {
     });
   });
 
-  describe("handleWatchEvent", () => {
-    test("ignores events for different resource types", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({ metadata: { name: "svc-1", uid: "uid-1" } });
-      store.handleWatchEvent({
-        event_type: "Applied",
-        resource_type: "services",
-        resource,
-      });
-      expect(store.resources.items).toEqual([]);
-    });
-
-    test("Applied event adds new resource", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({ metadata: { name: "pod-1", uid: "uid-1" } });
-      store.handleWatchEvent({
-        event_type: "Applied",
-        resource_type: "pods",
-        resource,
-      });
-      expect(store.resources.items.length).toBe(1);
-      expect(store.resources.items[0].metadata.name).toBe("pod-1");
-      expect(store.resourceCounts["pods"]).toBe(1);
-    });
-
-    test("Applied event updates existing resource", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({
-        metadata: { name: "pod-1", uid: "uid-1" },
-        status: { phase: "Running" },
-      });
-      store.resources = { items: [resource], resource_type: "pods" };
-
-      const updated = makeResource({
-        metadata: { name: "pod-1", uid: "uid-1" },
-        status: { phase: "Succeeded" },
-      });
-      store.handleWatchEvent({
-        event_type: "Applied",
-        resource_type: "pods",
-        resource: updated,
-      });
-
-      expect(store.resources.items.length).toBe(1);
-      expect(store.resources.items[0].status).toEqual({ phase: "Succeeded" });
-    });
-
-    test("Applied event updates selectedResource if matching", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({
-        metadata: { name: "pod-1", uid: "uid-1" },
-        status: { phase: "Running" },
-      });
-      store.resources = { items: [resource], resource_type: "pods" };
-      store.selectedResource = resource;
-
-      const updated = makeResource({
-        metadata: { name: "pod-1", uid: "uid-1" },
-        status: { phase: "Succeeded" },
-      });
-      store.handleWatchEvent({
-        event_type: "Applied",
-        resource_type: "pods",
-        resource: updated,
-      });
-
-      expect(store.selectedResource?.status).toEqual({ phase: "Succeeded" });
-    });
-
-    test("Deleted event removes resource", () => {
-      store.selectedResourceType = "pods";
-      const r1 = makeResource({ metadata: { name: "pod-1", uid: "uid-1" } });
-      const r2 = makeResource({ metadata: { name: "pod-2", uid: "uid-2" } });
-      store.resources = { items: [r1, r2], resource_type: "pods" };
-      store._setCount("pods", 2);
-
-      store.handleWatchEvent({
-        event_type: "Deleted",
-        resource_type: "pods",
-        resource: r1,
-      });
-
-      expect(store.resources.items.length).toBe(1);
-      expect(store.resources.items[0].metadata.uid).toBe("uid-2");
-      expect(store.resourceCounts["pods"]).toBe(1);
-    });
-
-    test("Deleted event clears selectedResource if matching", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({ metadata: { name: "pod-1", uid: "uid-1" } });
-      store.resources = { items: [resource], resource_type: "pods" };
-      store.selectedResource = resource;
-
-      store.handleWatchEvent({
-        event_type: "Deleted",
-        resource_type: "pods",
-        resource,
-      });
-
-      expect(store.selectedResource).toBeNull();
-    });
-
-    test("Deleted event for non-existent resource is a no-op", () => {
-      store.selectedResourceType = "pods";
-      const existing = makeResource({ metadata: { name: "pod-1", uid: "uid-1" } });
-      store.resources = { items: [existing], resource_type: "pods" };
-
-      const nonExistent = makeResource({ metadata: { name: "pod-2", uid: "uid-2" } });
-      store.handleWatchEvent({
-        event_type: "Deleted",
-        resource_type: "pods",
-        resource: nonExistent,
-      });
-
-      expect(store.resources.items.length).toBe(1);
-    });
-
-    test("ignores event without uid", () => {
-      store.selectedResourceType = "pods";
-      const resource = makeResource({ metadata: { name: "pod-1", uid: "" } });
-      // @ts-ignore - testing edge case
-      resource.metadata.uid = undefined as any;
-      store.handleWatchEvent({
-        event_type: "Applied",
-        resource_type: "pods",
-        resource,
-      });
-      expect(store.resources.items).toEqual([]);
-    });
-  });
+  // Watch-event handling moved to the real batched flush (_flushWatchEvents),
+  // exercised end-to-end in k8s.orchestration.test.ts via FakeKubeIo. The old
+  // duplicate handleWatchEvent (which stubbed Resync and used a different
+  // algorithm than production) has been deleted.
 
   describe("port forwards", () => {
     test("addPortForwardSync adds to list", () => {

--- a/src/lib/utils/tabLifecycle.test.ts
+++ b/src/lib/utils/tabLifecycle.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test";
 import type { Resource, ResourceList } from "$lib/types";
 import type { Tab } from "$lib/stores/ui.logic";
-import { handleTabSwitch, type TabLifecycleK8sStore } from "./tabLifecycle";
+import {
+  handleTabSwitch,
+  invalidateTabCacheForNamespace,
+  type TabLifecycleK8sStore,
+} from "./tabLifecycle";
 
 function mkResource(name: string, namespace = "default"): Resource {
   return {
@@ -45,6 +49,7 @@ function mkStore(overrides: Partial<TabLifecycleK8sStore> = {}): TabLifecycleK8s
     },
     setResourceType: () => {},
     restoreResources: () => {},
+    reconcileResources: async () => {},
     switchNamespace: async () => {},
     loadResources: async () => {},
   };
@@ -128,6 +133,9 @@ describe("handleTabSwitch", () => {
     const k8s = mkStore({
       currentNamespace: "default",
       restoreResources,
+      reconcileResources: async () => {
+        calls.push("reconcileResources");
+      },
       switchNamespace: async () => {
         calls.push("switchNamespace");
       },
@@ -140,7 +148,53 @@ describe("handleTabSwitch", () => {
 
     expect(k8s.currentNamespace).toBe("kube-system");
     expect(restoreResources).toHaveBeenCalledWith("pods", cachedItems);
-    expect(calls).toEqual(["restoreResources"]);
+    // Paint happens from cache first (instant, no empty-state flash)...
+    expect(calls[0]).toBe("restoreResources");
+    // ...and a background reconcile follows so stale rows can't survive.
+    expect(calls).toContain("reconcileResources");
+    // A cache hit must NOT go through the heavier loadResources (spinner +
+    // watch restart + blanks-on-error).
+    expect(calls).not.toContain("loadResources");
+  });
+
+  test("reconciles against the live cluster after a cache hit (stale-on-return)", async () => {
+    // While the tab was inactive the cluster changed: the cache holds the old
+    // snapshot, but a fresh list would return the new one. Returning must not
+    // leave the user staring at the stale rows — the exact reported bug.
+    const stale = [mkResource("old-pod")];
+    const live = [mkResource("old-pod"), mkResource("new-pod")];
+    const toTab = mkTab({
+      id: "to",
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+      cachedItems: stale,
+      cacheReady: true,
+    });
+    const k8s = mkStore({
+      currentNamespace: "default",
+      // Real store: paints the cached snapshot synchronously (restoreResourcesSync).
+      restoreResources(type, items) {
+        this.resources = { items, resource_type: type };
+      },
+      // Real store: reconcileResources awaits list_resources before swapping
+      // items in, so the cached paint is visible until the fetch resolves.
+      reconcileResources: async (type) => {
+        await Promise.resolve();
+        k8s.resources = { items: live, resource_type: type };
+        k8s.selectedResourceType = type;
+      },
+    });
+
+    handleTabSwitch(undefined, toTab, k8s);
+    // Instant paint from cache — the perf win (no empty flash) is preserved.
+    expect(k8s.resources.items).toBe(stale);
+
+    // Let the background reconcile settle.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(k8s.resources.items).toBe(live);
   });
 
   test("cache hit with matching namespace does not mutate currentNamespace", () => {
@@ -324,6 +378,56 @@ describe("handleTabSwitch", () => {
     handleTabSwitch(undefined, toTab, k8s);
 
     expect(loadResources).not.toHaveBeenCalled();
+  });
+});
+
+describe("invalidateTabCacheForNamespace", () => {
+  test("drops a table tab's cache and adopts the new namespace", () => {
+    const tab = mkTab({
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+      cachedItems: [mkResource("a")],
+      count: 1,
+      cacheReady: true,
+    });
+
+    invalidateTabCacheForNamespace(tab, "kube-system");
+
+    expect(tab.namespace).toBe("kube-system");
+    expect(tab.cachedItems).toBeUndefined();
+    expect(tab.count).toBeUndefined();
+    expect(tab.cacheReady).toBe(false);
+  });
+
+  test("no-op when the namespace is unchanged (cache preserved)", () => {
+    const items = [mkResource("a")];
+    const tab = mkTab({
+      type: "table",
+      resourceType: "pods",
+      namespace: "default",
+      cachedItems: items,
+      cacheReady: true,
+    });
+
+    invalidateTabCacheForNamespace(tab, "default");
+
+    expect(tab.cachedItems).toBe(items);
+    expect(tab.cacheReady).toBe(true);
+  });
+
+  test("no-op for a non-table tab", () => {
+    const tab = mkTab({ type: "overview", namespace: "default" });
+
+    invalidateTabCacheForNamespace(tab, "kube-system");
+
+    // A non-table tab has no resource cache to invalidate and its namespace is
+    // left untouched.
+    expect(tab.namespace).toBe("default");
+  });
+
+  test("no-op (no throw) when there is no active tab", () => {
+    expect(() => invalidateTabCacheForNamespace(undefined, "kube-system")).not.toThrow();
   });
 });
 

--- a/src/lib/utils/tabLifecycle.ts
+++ b/src/lib/utils/tabLifecycle.ts
@@ -17,6 +17,7 @@ export interface TabLifecycleK8sStore {
   selectResource(resource: Resource | null): void;
   setResourceType(resourceType: string): void;
   restoreResources(resourceType: string, items: Resource[]): void;
+  reconcileResources(resourceType: string): Promise<void>;
   switchNamespace(namespace: string): Promise<void>;
   loadResources(resourceType: string): Promise<void>;
 }
@@ -53,6 +54,26 @@ export function handleTabSwitch(
   }
 }
 
+/**
+ * Drop a table tab's cached rows when the namespace changes: the cache is a
+ * snapshot for the *previous* namespace, so the next visit must refetch.
+ *
+ * Centralised here (rather than inline in App.svelte's namespace effect) so
+ * every mutation of the per-tab cache lives in one tested module — the cache
+ * invariant is enforced in a single place instead of by several writers
+ * agreeing by luck.
+ */
+export function invalidateTabCacheForNamespace(
+  tab: Tab | undefined,
+  namespace: string,
+): void {
+  if (!isTableTab(tab) || tab.namespace === namespace) return;
+  tab.namespace = namespace;
+  tab.cachedItems = undefined;
+  tab.count = undefined;
+  tab.cacheReady = false;
+}
+
 function saveOutgoingTabState(
   fromTab: Tab | undefined,
   k8s: TabLifecycleK8sStore,
@@ -84,8 +105,18 @@ function restoreFromCache(toTab: Tab, k8s: TabLifecycleK8sStore): void {
   if (toTab.namespace !== undefined && toTab.namespace !== k8s.currentNamespace) {
     k8s.currentNamespace = toTab.namespace;
   }
-  // resourceType guaranteed by caller guard in handleTabSwitch.
-  k8s.restoreResources(toTab.resourceType!, toTab.cachedItems!);
+  const resourceType = toTab.resourceType!; // guaranteed by caller guard.
+  // Paint the cached snapshot immediately so there's no empty-state flash.
+  k8s.restoreResources(resourceType, toTab.cachedItems!);
+
+  // Then reconcile against the cluster in the background. The cache is a
+  // snapshot from when we last left this tab; any create/delete/modify that
+  // happened while it was inactive is not covered by the freshly-started
+  // watcher (the backend suppresses the initial list on watch start — see
+  // k8s/watch.rs). Without this refetch the stale rows survive until each
+  // object next changes. reconcileResources keeps the cached rows on error
+  // and never shows a spinner, so the instant paint above is undisturbed.
+  void k8s.reconcileResources(resourceType);
 }
 
 function triggerLoad(toTab: Tab, k8s: TabLifecycleK8sStore): void {


### PR DESCRIPTION
## What & why

The k8s store's fetch/watch/reconcile orchestration — the scope-generation race guards, the cache-vs-load-vs-reconcile decision, the watch start/stop lifecycle, the batched flush and resync refetch — lived in the Tauri-coupled `k8s.svelte.ts` subclass with **zero unit tests**. That's the exact blind spot the recent stale-on-return bug hid in: the diagnosis loop had to be faked at the `tabLifecycle` seam because this layer was unreachable from `bun test`.

This PR deepens the store behind a **`KubeIo` seam** so that orchestration becomes fully testable, and fixes a latent cache bug uncovered along the way.

## Changes

### `refactor(k8s)` — KubeIo seam + testable orchestration
- **New `KubeIo` port** (`k8s.io.ts`) — a domain-shaped interface (`listResources`, `startResourceWatch`, `onWatchEvent`, `getResourceCounts`, CRD + port-forward calls), not raw Tauri `invoke`/`listen` command strings.
- **`TauriKubeIo`** (`k8s.io.tauri.ts`) is now the *only* place that knows backend command names.
- **`FakeKubeIo`** (`k8s.io.fake.ts`) — the second adapter that makes the seam real: it drives the whole load → cache → watch → reconcile state machine in `bun test` without a cluster.
- Moved `loadResources` / `reconcileResources` / `_listResources` / the watch lifecycle / batched flush / resync down into `K8sStoreLogic` (plain TS, bun-runnable). The Svelte subclass keeps only the `$state` rune overrides, the port-forward listener, and a `requestAnimationFrame` override of the flush scheduler (the base uses `queueMicrotask`).
- Deleted the duplicate `handleWatchEvent` in `k8s.logic.ts` — it stubbed `Resync` and used a different algorithm than production, so its tests were green against code that never shipped. The real batched Map-upsert flush + resync path is now tested through `FakeKubeIo`.

### `fix(k8s)` — stamp `resource_type` so the tab cache actually saves
The Rust `ResourceList` carries only `items` and never sends `resource_type`, so every `this.resources = result` left it `undefined`. That silently broke `saveOutgoingTabState`'s cache guard (`resources.resource_type === tab.resourceType`), so the per-tab cache stopped saving on tab-switch → returning to a table tab became a cache-miss → **skeleton flash on return**. `resource_type` is now stamped at every assignment site (`loadResources`, `reconcileResources`, `_refreshAfterResync`, `navigateBack`, `navigateToHistoryIndex`).

### `refactor(tabs)` — reconcile on return + centralise cache invalidation
- `restoreFromCache` paints the cached snapshot instantly, then kicks a background `reconcileResources`. The freshly-started watcher suppresses the initial list, so without this refetch any create/delete/modify that happened while the tab was inactive would stay stale. `reconcileResources` keeps the cache on error and never shows a spinner, preserving the anti-flash win.
- Moved the namespace-change cache invalidation out of `App.svelte`'s `$effect` into `tabLifecycle` (`invalidateTabCacheForNamespace`) so every per-tab cache mutation lives in one tested module.

## Testing
- **833 unit tests pass** (`bun test`), including new fake-driven orchestration tests: reconcile-on-return, keep-cache-on-error, type-drift guard, the real batched flush + resync, and the `resource_type` stamping invariant.
- `svelte-check` shows no new errors (pre-existing `bun:test` module-resolution warnings only).
- Behaviour-preserving refactor; no Rust changes.

## Notes
- The store core is now Tauri-free; only `TauriKubeIo` imports Tauri. Porting to another backend later means implementing `KubeIo` once more.
- Not addressed (out of scope): contexts/namespaces/CRD/port-forward orchestration still lives in the Svelte layer because it is coupled to `settingsStore`/`toastStore` (both `.svelte.ts` runes). Moving those down needs seams for those too — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource tables now refresh in the background when returning to a tab, keeping cached data responsive while updating it with current cluster results.
  * Kubernetes resource updates are batched for smoother, more consistent table changes.
  * Added support for resource watching, context and namespace operations, port forwarding, and custom resource discovery through the Kubernetes backend.

* **Bug Fixes**
  * Prevented stale table data from being retained after changing namespaces.
  * Improved handling of resource additions, updates, deletions, and full refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->