### PR TITLE
Add Homebrew as macOS update channel

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,89 @@
+name: Update Homebrew Tap
+
+# Regenerates Casks/kdashboard.rb in folio-pro/homebrew-tap whenever a release
+# is published (drafts don't trigger this — publish the draft created by
+# build.yml and this runs). macOS users update with `brew upgrade --cask
+# kdashboard` since unsigned builds can't use electron-updater's in-app
+# install (see electron/handlers/updater.ts).
+#
+# Requires the HOMEBREW_TAP_TOKEN secret: a fine-grained PAT with
+# Contents: read+write on folio-pro/homebrew-tap.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to the tap (e.g. v0.2.0)"
+        required: true
+
+jobs:
+  bump-cask:
+    # Skip non-app releases (e.g. the rolling pricing-data release).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download macOS artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          VERSION="${TAG#v}"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "*.dmg"
+          ls -l ./*.dmg
+
+      - name: Compute checksums
+        run: |
+          ARM_SHA=$(sha256sum "kdashboard-${VERSION}-arm64.dmg" | cut -d' ' -f1)
+          INTEL_SHA=$(sha256sum "kdashboard-${VERSION}-x64.dmg" | cut -d' ' -f1)
+          echo "ARM_SHA=$ARM_SHA" >> "$GITHUB_ENV"
+          echo "INTEL_SHA=$INTEL_SHA" >> "$GITHUB_ENV"
+
+      - name: Update cask in folio-pro/homebrew-tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/folio-pro/homebrew-tap.git" tap
+          mkdir -p tap/Casks
+          cat > tap/Casks/kdashboard.rb <<EOF
+          cask "kdashboard" do
+            arch arm: "arm64", intel: "x64"
+
+            version "${VERSION}"
+            sha256 arm: "${ARM_SHA}", intel: "${INTEL_SHA}"
+
+            url "https://github.com/folio-pro/kdashboard/releases/download/v#{version}/kdashboard-#{version}-#{arch}.dmg"
+            name "kdashboard"
+            desc "Kubernetes dashboard desktop app"
+            homepage "https://github.com/folio-pro/kdashboard"
+
+            livecheck do
+              url :url
+              strategy :github_latest
+            end
+
+            auto_updates false
+
+            app "kdashboard.app"
+
+            zap trash: [
+              "~/Library/Application Support/kdashboard",
+              "~/Library/Preferences/com.kdashboard.app.plist",
+              "~/Library/Saved Application State/com.kdashboard.app.savedState",
+            ]
+          end
+          EOF
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/kdashboard.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date"
+            exit 0
+          fi
+          git commit -m "kdashboard ${VERSION}"
+          git push origin HEAD

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Download macOS artifacts
         env:
           GH_TOKEN: ${{ github.token }}
+          # Passed via env (not interpolated into the script) so a crafted
+          # workflow_dispatch input can't inject shell commands.
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
         run: |
-          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[[:alnum:]._-]+$ ]]; then
+            echo "Invalid release tag: $TAG" >&2
+            exit 1
+          fi
           VERSION="${TAG#v}"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ inspect, debug, and act on workloads.
 
 ## Installation
 
+### macOS — Homebrew (recommended)
+
+```bash
+brew install folio-pro/tap/kdashboard
+```
+
+Update later with:
+
+```bash
+brew upgrade --cask kdashboard
+```
+
+Because macOS builds are not signed with an Apple Developer ID, the in-app
+auto-updater cannot install updates on macOS — Homebrew is the update channel
+there. The app still notifies you when a new version is available. (Windows
+and Linux use the in-app auto-updater.)
+
+To skip Gatekeeper's first-launch warning entirely, install with
+`brew install --no-quarantine folio-pro/tap/kdashboard`; otherwise see the
+unsigned-builds note below.
+
 ### Pre-built binaries
 
 Grab the [latest release](https://github.com/folio-pro/kdashboard/releases/latest)
@@ -64,8 +85,8 @@ for your platform (see all past builds on the
 [Releases page](https://github.com/folio-pro/kdashboard/releases)):
 
 - **macOS** — `.dmg` (Apple Silicon and Intel)
-- **Linux** — `.AppImage`, `.deb`, `.rpm`
-- **Windows** — `.msi`, `.exe`
+- **Linux** — `.AppImage`
+- **Windows** — `.exe` (NSIS installer)
 
 > **macOS note — unsigned builds.** Releases are not yet signed with an
 > Apple Developer ID, so Gatekeeper will block the app on first launch

--- a/README.md
+++ b/README.md
@@ -74,9 +74,8 @@ auto-updater cannot install updates on macOS — Homebrew is the update channel
 there. The app still notifies you when a new version is available. (Windows
 and Linux use the in-app auto-updater.)
 
-To skip Gatekeeper's first-launch warning entirely, install with
-`brew install --no-quarantine folio-pro/tap/kdashboard`; otherwise see the
-unsigned-builds note below.
+Gatekeeper will still warn on first launch because the build is unsigned —
+see the unsigned-builds note below for the `xattr` workaround.
 
 ### Pre-built binaries
 

--- a/electron/handlers/updater.ts
+++ b/electron/handlers/updater.ts
@@ -23,13 +23,28 @@ import type { HandlerCtx, HandlerMap } from '../dispatch';
 
 /**
  * UpdateInfo as the renderer expects it (src/lib/types/settings.ts). `body` and
- * `date` are nullable; `version` is always a string.
+ * `date` are nullable; `version` is always a string. `manualInstall` tells the
+ * renderer that in-app install is unavailable and the user must update through
+ * Homebrew instead (see MANUAL_INSTALL below).
  */
 interface UpdateInfo {
   version: string;
   body: string | null;
   date: string | null;
+  manualInstall: boolean;
 }
+
+/**
+ * macOS builds are not signed with an Apple Developer ID certificate, and
+ * Squirrel.Mac refuses to install updates into an unsigned app — so on macOS
+ * the update channel is Homebrew (`brew upgrade --cask kdashboard`, cask in
+ * folio-pro/homebrew-tap). The check still works (it only reads
+ * latest-mac.yml), so we surface the banner but tell the renderer to show
+ * brew instructions instead of the in-app install button.
+ * If Apple signing is ever added (see .github/workflows/build.yml), set this
+ * back to false on darwin.
+ */
+const MANUAL_INSTALL = process.platform === 'darwin';
 
 /**
  * Download-lifecycle event pushed to the renderer over UPDATER_DOWNLOAD_CHANNEL.
@@ -134,6 +149,7 @@ function toRendererInfo(info: ElectronUpdateInfo): UpdateInfo {
     version: info.version,
     body: notesToBody(info.releaseNotes),
     date: info.releaseDate ?? null,
+    manualInstall: MANUAL_INSTALL,
   };
 }
 
@@ -192,6 +208,12 @@ export function checkAndNotify(ctx: HandlerCtx): void {
  * single finally via removeAllListeners on the channels we touched.
  */
 async function runDownloadAndInstall(ctx: HandlerCtx): Promise<null> {
+  if (MANUAL_INSTALL) {
+    // The renderer shows brew instructions instead of calling this on macOS;
+    // fail clearly if it ever does (Squirrel would otherwise error cryptically
+    // against the unsigned app).
+    throw new Error('In-app install is unavailable on macOS; update with: brew upgrade --cask kdashboard');
+  }
   const au = getAutoUpdater();
   if (!au) {
     // Nothing to download in dev — report instant completion. The renderer

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     },
     "mac": {
       "target": ["dmg", "zip"],
-      "icon": "build/icon.icns"
+      "icon": "build/icon.icns",
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "publish": {
       "provider": "github",

--- a/src/lib/components/common/UpdateBanner.svelte
+++ b/src/lib/components/common/UpdateBanner.svelte
@@ -135,6 +135,7 @@
         <button
           class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
           onclick={dismiss}
+          aria-label="Dismiss update"
         >
           <X class="h-3.5 w-3.5" />
         </button>
@@ -149,6 +150,7 @@
         <button
           class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
           onclick={dismiss}
+          aria-label="Dismiss update"
         >
           <X class="h-3.5 w-3.5" />
         </button>

--- a/src/lib/components/common/UpdateBanner.svelte
+++ b/src/lib/components/common/UpdateBanner.svelte
@@ -4,10 +4,10 @@
   import { listen } from "$lib/ipc/event";
   import { onMount } from "svelte";
   import { toastStore } from "$lib/stores/toast.svelte";
-  import { ArrowDownToLine, X } from "lucide-svelte";
+  import { ArrowDownToLine, Copy, X } from "lucide-svelte";
   import { fly } from "svelte/transition";
   import type { UpdateInfo } from "$lib/types";
-  import { isVisible as _isVisible, computeProgress } from "./update-banner";
+  import { isVisible as _isVisible, computeProgress, BREW_UPGRADE_COMMAND } from "./update-banner";
 
   let updateInfo: UpdateInfo | null = $state(null);
   let dismissed = $state(false);
@@ -79,6 +79,15 @@
   function dismiss() {
     dismissed = true;
   }
+
+  async function copyBrewCommand() {
+    try {
+      await navigator.clipboard.writeText(BREW_UPGRADE_COMMAND);
+      toastStore.success("Copied", "Run it in a terminal to update");
+    } catch (err) {
+      toastStore.error("Copy failed", String(err));
+    }
+  }
 </script>
 
 {#if visible}
@@ -107,6 +116,28 @@
           </div>
           <span class="text-[11px] tabular-nums text-[var(--text-muted)]">{progress}%</span>
         </div>
+      {:else if updateInfo?.manualInstall}
+        <!-- Unsigned macOS builds can't self-install; Homebrew is the update channel. -->
+        <code
+          class="rounded bg-[var(--bg-tertiary)] px-2 py-1 text-[11px] text-[var(--text-primary)]"
+        >
+          {BREW_UPGRADE_COMMAND}
+        </code>
+
+        <button
+          class="flex items-center gap-1 rounded px-2.5 py-1 text-[11px] font-medium text-white bg-[var(--accent)] hover:opacity-90 transition-opacity"
+          onclick={copyBrewCommand}
+        >
+          <Copy class="h-3 w-3" />
+          Copy
+        </button>
+
+        <button
+          class="shrink-0 text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          onclick={dismiss}
+        >
+          <X class="h-3.5 w-3.5" />
+        </button>
       {:else}
         <button
           class="rounded px-2.5 py-1 text-[11px] font-medium text-white bg-[var(--accent)] hover:opacity-90 transition-opacity"

--- a/src/lib/components/common/update-banner.ts
+++ b/src/lib/components/common/update-banner.ts
@@ -1,5 +1,9 @@
 import type { UpdateInfo } from "$lib/types";
 
+/** Update command shown on macOS, where unsigned builds can't self-install
+ *  and the update channel is the folio-pro/homebrew-tap cask. */
+export const BREW_UPGRADE_COMMAND = "brew upgrade --cask kdashboard";
+
 export interface UpdateBannerState {
   updateInfo: UpdateInfo | null;
   dismissed: boolean;

--- a/src/lib/ipc/updater.ts
+++ b/src/lib/ipc/updater.ts
@@ -31,6 +31,8 @@ export type DownloadEvent =
 /** Mirror of Tauri's Update handle (only the bits UpdateBanner.svelte uses). */
 export interface Update {
   version: string;
+  /** In-app install unavailable (unsigned macOS build) — update via brew. */
+  manualInstall: boolean;
   downloadAndInstall(onEvent?: (event: DownloadEvent) => void): Promise<void>;
 }
 
@@ -39,6 +41,7 @@ interface BackendUpdateInfo {
   version: string;
   body: string | null;
   date: string | null;
+  manualInstall?: boolean;
 }
 
 /** Channel the backend emits download lifecycle events on. */
@@ -55,6 +58,7 @@ type BackendDownloadEvent = DownloadEvent | { event: 'Error'; data: { message: s
 function makeUpdate(info: BackendUpdateInfo): Update {
   return {
     version: info.version,
+    manualInstall: info.manualInstall === true,
     downloadAndInstall(onEvent?: (event: DownloadEvent) => void): Promise<void> {
       return new Promise<void>((resolve, reject) => {
         const listener = (_e: unknown, payload: unknown): void => {

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -1,8 +1,11 @@
-/** Payload emitted by Rust when an app update is available. */
+/** Payload emitted by the main process when an app update is available. */
 export interface UpdateInfo {
   version: string;
   body: string | null;
   date: string | null;
+  /** True when in-app install is unavailable (unsigned macOS builds) and the
+   *  user must update via Homebrew: `brew upgrade --cask kdashboard`. */
+  manualInstall?: boolean;
 }
 
 export interface ContextCustomization {


### PR DESCRIPTION
## Why

macOS release builds are unsigned (no Apple Developer ID), and Squirrel.Mac refuses to install updates into an unsigned app — so electron-updater's in-app install can never work on macOS as-is. Instead of paying for Apple signing, this PR makes Homebrew the macOS distribution and update channel, while Windows and Linux keep full in-app auto-update.

## What

- **New `.github/workflows/homebrew.yml`** — triggered when a release is *published* (the draft created by `build.yml` won't trigger it until published). Downloads the release dmgs, computes their sha256, regenerates `Casks/kdashboard.rb` in [folio-pro/homebrew-tap](https://github.com/folio-pro/homebrew-tap), and pushes it. Also runnable manually via `workflow_dispatch` with a tag input. Skips non-app releases (e.g. the rolling `pricing-data` release). Requires the `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT, Contents read/write on the tap repo) — already configured.
- **`package.json`** — pin the mac `artifactName` to `${productName}-${version}-${arch}.${ext}` so the cask and workflow can address `-arm64.dmg` / `-x64.dmg` deterministically (electron-builder's default omits the arch suffix for x64).
- **`electron/handlers/updater.ts`** — update *checks* still work on macOS (they only read `latest-mac.yml`, no signature needed), but the payload now carries `manualInstall: true` on darwin. `__updater_download` fails fast with a clear message instead of Squirrel's cryptic signing error if it's ever invoked there.
- **`UpdateBanner.svelte` + ipc shim + types** — when `manualInstall` is set, the banner shows `brew upgrade --cask kdashboard` with a copy button instead of the in-app "Update now" flow.
- **README** — new "macOS — Homebrew (recommended)" install section; binary list updated to what the Electron pipeline actually produces (AppImage / NSIS exe).

## Install / update UX

```sh
brew install folio-pro/tap/kdashboard   # first install
brew upgrade --cask kdashboard          # updates (the app banner points here)
```

If Apple signing is ever provisioned, flip `MANUAL_INSTALL` in `electron/handlers/updater.ts` and macOS regains in-app updates (signing steps are documented in `build.yml`).

## Testing

- `bun test` (820 tests) and `tsc` electron typecheck pass; `svelte-check` reports no new errors.
- Local `electron-builder --mac zip` confirms the new artifact naming and that `app-update.yml` / `latest-mac.yml` are still generated.
- Generated cask validated with `ruby -c`; workflow YAML parse-checked.
- The tap repo is seeded ([folio-pro/homebrew-tap](https://github.com/folio-pro/homebrew-tap)); the cask itself will appear on the first published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation and upgrade support for macOS.
  * macOS updates that require manual installation now display the Homebrew upgrade command with a convenient copy option.
  * Added clearer guidance for unsigned macOS builds and Gatekeeper.

* **Bug Fixes**
  * Prevented unsupported in-app installation for Homebrew-managed macOS builds.

* **Chores**
  * Published macOS artifacts with clearer version and architecture-specific names.
  * Automated Homebrew cask updates for new versioned releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->