### PR TITLE
Fix update banner offering the already-installed version

### DIFF
--- a/electron/handlers/updater.ts
+++ b/electron/handlers/updater.ts
@@ -76,7 +76,10 @@ interface AutoUpdaterLike {
   autoInstallOnAppQuit: boolean;
   on(event: string, cb: (...args: unknown[]) => void): unknown;
   removeAllListeners(event?: string): void;
-  checkForUpdates(): Promise<{ updateInfo?: ElectronUpdateInfo } | null>;
+  checkForUpdates(): Promise<{
+    isUpdateAvailable?: boolean;
+    updateInfo?: ElectronUpdateInfo;
+  } | null>;
   downloadUpdate(): Promise<unknown>;
   quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
 }
@@ -168,7 +171,13 @@ async function runCheck(): Promise<UpdateInfo | null> {
   if (!au) return null;
   try {
     const result = await au.checkForUpdates();
-    const info = result?.updateInfo;
+    // Unlike the Tauri updater, checkForUpdates() resolves with the latest
+    // release's updateInfo even when the app is already up to date — the real
+    // signal is isUpdateAvailable (electron-updater's own semver comparison
+    // against app.getVersion()). Without this check the banner offers the
+    // running version as an "update".
+    if (result?.isUpdateAvailable !== true) return null;
+    const info = result.updateInfo;
     if (!info || !info.version) return null;
     return toRendererInfo(info);
   } catch (err) {


### PR DESCRIPTION
## Problem

After updating to 0.2.0, the app still showed the update banner offering 0.2.0 (with the brew upgrade instructions on macOS).

## Cause

`electron-updater`'s `checkForUpdates()` resolves with the latest release's `updateInfo` **even when the app is already up to date** — the actual availability signal is `UpdateCheckResult.isUpdateAvailable` (electron-updater's own semver comparison against `app.getVersion()`). The `__updater_check` handler forwarded `updateInfo` unconditionally, so an up-to-date app offered its own version as an update. The Tauri updater this code ports returned `null` when current, which is what the renderer expects.

## Fix

Gate `runCheck()` on `result.isUpdateAvailable === true` before mapping `updateInfo`, restoring the null-when-current contract for both the manual check and the background `update-available` notification.

## Testing

- `tsc` electron typecheck and `bun test` (820 tests) pass.
- Verified against `electron-updater` 6.8.9 typings: `UpdateCheckResult.isUpdateAvailable: boolean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)