### PR TITLE
Perf: lean watch events with resourceVersion resume, virtualized CRD table; fix session restore and IPC proxy serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
+test-results/
+playwright-report/
 dist-electron/
 release/
 src-tauri/target/

--- a/e2e/perf-bench.spec.ts
+++ b/e2e/perf-bench.spec.ts
@@ -289,4 +289,84 @@ test.describe("frontend perf bench", () => {
     console.log("\n__NAV_BENCH__" + JSON.stringify(r, null, 2));
     expect(r.navMedianMs).toBeGreaterThan(0);
   });
+
+  test("crd table: mount + scroll stay virtualized at 10k items", async ({ page }) => {
+    test.setTimeout(120_000);
+    await page.addInitScript(`
+      Object.defineProperty(window, "electronAPI", {
+        value: { invoke: async () => null, on: () => {}, off: () => {}, openExternal: async () => {} },
+        writable: true, configurable: true,
+      });
+    `);
+    await page.goto("/");
+    await page.waitForFunction(() => !!(window as any).__kdash?.k8sStore, null, { timeout: 15_000 });
+
+    const r = await page.evaluate(async () => {
+      const { k8sStore, uiStore } = (window as any).__kdash;
+      const raf2 = () => new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+      const N = 10_000;
+      const items = Array.from({ length: N }, (_, i) => ({
+        kind: "Widget", api_version: "example.com/v1",
+        metadata: {
+          name: "widget-" + String(i).padStart(5, "0"),
+          namespace: ["default", "prod", "staging"][i % 3],
+          uid: "crd-uid-" + i,
+          creation_timestamp: new Date(Date.now() - (i % 400) * 3600000).toISOString(),
+        },
+        spec: { size: i % 9, mode: i % 2 ? "active" : "passive" },
+        status: { ready: i % 4 !== 0 },
+      }));
+      const columns = [
+        { name: "Size", json_path: ".spec.size", type: "integer", description: "" },
+        { name: "Mode", json_path: ".spec.mode", type: "string", description: "" },
+        { name: "Ready", json_path: ".status.ready", type: "boolean", description: "" },
+      ];
+
+      k8sStore.connectionStatus = "connected";
+      k8sStore.selectedCrd = { group: "example.com", version: "v1", kind: "Widget", plural: "widgets", scope: "Namespaced" };
+      uiStore.activeView = "crd-table";
+      await raf2();
+
+      const t0 = performance.now();
+      k8sStore.crdResources = { items, columns };
+      // Lazy view + first paint.
+      for (let k = 0; k < 240; k++) {
+        if (document.querySelector("tbody tr")) break;
+        await new Promise((res) => requestAnimationFrame(res));
+      }
+      await raf2();
+      const mountMs = performance.now() - t0;
+      const renderedRows = document.querySelectorAll("tbody tr").length;
+
+      // Scroll through the list, measuring per-frame main-thread cost.
+      const el = Array.from(document.querySelectorAll("div")).find(
+        (d) => d.scrollHeight > d.clientHeight * 5 && d.querySelector("tbody"),
+      ) as HTMLElement | undefined;
+      let scrollP95 = -1;
+      if (el) {
+        const frames: number[] = [];
+        const maxScroll = el.scrollHeight - el.clientHeight;
+        for (let i = 1; i <= 100; i++) {
+          await new Promise<void>((resolve) => requestAnimationFrame(() => {
+            const t = performance.now();
+            el.scrollTop = (maxScroll / 100) * i;
+            void el.offsetHeight;
+            frames.push(performance.now() - t);
+            resolve();
+          }));
+        }
+        frames.sort((a, b) => a - b);
+        scrollP95 = frames[Math.floor(frames.length * 0.95)];
+      }
+
+      const rnd = (n: number) => Math.round(n * 100) / 100;
+      return { mountMs: rnd(mountMs), renderedRows, total: N, scrollP95: rnd(scrollP95) };
+    });
+
+    // eslint-disable-next-line no-console
+    console.log("\n__CRD_BENCH__" + JSON.stringify(r, null, 2));
+    // Virtualization invariant: the DOM must hold a window of rows, not the list.
+    expect(r.renderedRows).toBeGreaterThan(0);
+    expect(r.renderedRows).toBeLessThan(200);
+  });
 });

--- a/e2e/session-restore.spec.ts
+++ b/e2e/session-restore.spec.ts
@@ -60,6 +60,25 @@ const MOCK = `(cmd, args) => {
   return null;
 }`;
 
+// Same layout but the detail tab is NOT active: a table tab has focus on boot.
+// bootstrapActiveTab only hydrates the active tab, so switching to the detail
+// tab later must re-fetch its resource (rehydrateResourceTab in App.svelte).
+const SEED_TABS_BACKGROUND_DETAIL = {
+  version: 1,
+  tabs: [
+    {
+      id: "tab-table-1",
+      type: "table",
+      label: "Pods",
+      closable: true,
+      resourceType: "pods",
+      namespace: "default",
+    },
+    ...SEED_TABS.tabs,
+  ],
+  activeTabId: "tab-table-1",
+};
+
 test.describe("session restore", () => {
   test("restored pod detail tab is hydrated, not blank, on cold boot", async ({ page, mockInvoke }) => {
     await mockInvoke(MOCK);
@@ -73,6 +92,76 @@ test.describe("session restore", () => {
     // set. Before the fix this never appeared (panel was blank).
     await expect(page.getByText(POD_NAME).first()).toBeVisible({ timeout: 10_000 });
     // And the pod's kind/identity is shown, proving the full object hydrated.
+    await expect(page.getByText("node-1").first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("boot shows loading skeleton, never a false 'no pods' empty state", async ({ page, mockInvoke }) => {
+    // list_resources resolves after 800ms — during that window the table must
+    // show the loading skeleton, NOT the empty state (isLoading is delayed
+    // 200ms, so before viewLoaded existed the empty state flashed first).
+    await mockInvoke(`(cmd, args) => {
+      if (cmd === "get_contexts") return ["bench"];
+      if (cmd === "get_current_context") return "bench";
+      if (cmd === "get_namespaces") return ["default"];
+      if (cmd === "get_resource_counts") return {};
+      if (cmd === "bench_config") return { enabled: false };
+      if (cmd === "list_resources") {
+        return new Promise((resolve) => setTimeout(() => resolve({
+          items: [{
+            kind: "Pod", api_version: "v1",
+            metadata: { name: "slow-pod-1", namespace: "default", uid: "u-slow-1",
+              creation_timestamp: "2024-01-01T00:00:00Z", resource_version: "1" },
+            spec: { nodeName: "node-1", containers: [{ name: "main", image: "nginx" }] },
+            status: { phase: "Running" },
+          }],
+          resource_type: "pods",
+        }), 800));
+      }
+      return null;
+    }`);
+    await page.addInitScript(`window.localStorage.setItem("kdashboard-tabs-v1", '${JSON.stringify({
+      version: 1,
+      tabs: [{ id: "tab-table-1", type: "table", label: "Pods", closable: true, resourceType: "pods", namespace: "default" }],
+      activeTabId: "tab-table-1",
+    })}');`);
+
+    // Record whether the empty state EVER renders during boot — a one-shot
+    // assertion races the ~200ms flash window and passes vacuously.
+    await page.addInitScript(`
+      (window).__sawEmptyState = false;
+      const scan = () => {
+        if (document.body && /No pods/i.test(document.body.textContent || "")) {
+          (window).__sawEmptyState = true;
+        }
+        requestAnimationFrame(scan);
+      };
+      requestAnimationFrame(scan);
+    `);
+
+    await page.goto("/");
+
+    // Data lands after the delay…
+    await expect(page.getByText("slow-pod-1")).toBeVisible({ timeout: 10_000 });
+    // …and at no point before that did the false empty state flash.
+    const sawEmpty = await page.evaluate(() => (window as unknown as { __sawEmptyState: boolean }).__sawEmptyState);
+    expect(sawEmpty).toBe(false);
+  });
+
+  test("restored BACKGROUND detail tab hydrates when switched to", async ({ page, mockInvoke }) => {
+    await mockInvoke(MOCK);
+    await page.addInitScript(`window.localStorage.setItem("kdashboard-tabs-v1", '${JSON.stringify(SEED_TABS_BACKGROUND_DETAIL)}');`);
+
+    await page.goto("/");
+    // Boot lands on the table tab; the detail tab is restored but unhydrated.
+    const detailTab = page.getByRole("tab", { name: POD_NAME }).or(page.getByText(POD_NAME).first());
+    await expect(detailTab.first()).toBeVisible({ timeout: 10_000 });
+
+    // Switch to the restored detail tab.
+    await detailTab.first().click();
+
+    // Before the fix the panel stayed empty forever (cachedResource is never
+    // persisted and nothing re-fetched it). Now it must show the pod's data.
+    await expect(page.getByTestId("detail-panel")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText("node-1").first()).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/electron/handlers/resources.ts
+++ b/electron/handlers/resources.ts
@@ -34,7 +34,7 @@ import type {
   ResourceList,
   ResourceMetadata,
 } from '../k8s/resource-types';
-import { metaFrom, listMetaFrom } from '../k8s/resource-mapping';
+import { metaFrom, listMetaFrom, listProjectionFor } from '../k8s/resource-mapping';
 import { apiVersionOf, resolveKindOrThrow } from '../k8s/kinds';
 import type { Handler, HandlerMap } from '../dispatch';
 
@@ -237,11 +237,12 @@ export async function apiGet<T>(
   return (await resp.json()) as T;
 }
 
-async function listRaw(opts: ListOpts): Promise<RawObject[]> {
+async function listRaw(opts: ListOpts): Promise<{ items: RawObject[]; resourceVersion?: string }> {
   const { ar, namespace, labelSelector, paginate = true, accept } = opts;
   const path = resourcePath(ar, namespace);
   const items: RawObject[] = [];
   let cont: string | undefined;
+  let resourceVersion: string | undefined;
 
   // Loop while there is a continue token (matches the Rust continue-token loop).
   for (;;) {
@@ -252,13 +253,16 @@ async function listRaw(opts: ListOpts): Promise<RawObject[]> {
 
     const list = await apiGet<RawList>(path, query, accept);
     if (list.items) items.push(...list.items);
+    // Every page carries the SAME list resourceVersion (set at the first page);
+    // keep the last non-empty one and hand it to the watch as its resume point.
+    if (list.metadata?.resourceVersion) resourceVersion = list.metadata.resourceVersion;
 
     const token = list.metadata?.continue;
     if (!paginate || !token || token.length === 0) break;
     cont = token;
   }
 
-  return items;
+  return { items, resourceVersion };
 }
 
 async function getRaw(ar: ApiResource, name: string, namespace: string): Promise<RawObject> {
@@ -267,281 +271,21 @@ async function getRaw(ar: ApiResource, name: string, namespace: string): Promise
 }
 
 // ---------------------------------------------------------------------------
-// Per-kind projection of a raw object into a Resource.
-//
-// `fields` selects which of spec/status/data ride along, matching the
-// spec=/status=/data= flags the Rust listing macros pass per kind.
-// ---------------------------------------------------------------------------
-
-interface FieldSel {
-  spec: boolean;
-  status: boolean;
-  data: boolean;
-}
-
-function projectGeneric(
-  obj: RawObject,
-  apiVersion: string,
-  kind: string,
-  fields: FieldSel,
-): Resource {
-  const res: Resource = {
-    api_version: apiVersion,
-    kind,
-    metadata: listMetaFrom(obj.metadata),
-  };
-  if (fields.spec) {
-    const v = presentOrUndefined(obj.spec);
-    if (v !== undefined) res.spec = v;
-  }
-  if (fields.status) {
-    const v = presentOrUndefined(obj.status);
-    if (v !== undefined) res.status = v;
-  }
-  if (fields.data) {
-    const v = presentOrUndefined(obj.data);
-    if (v !== undefined) res.data = v;
-  }
-  return res;
-}
-
-// Per resource_type: api_version + kind + which fields project. Mirrors the
-// listing.rs match arms (note kind is the SINGULAR Kind, e.g. "Pod").
-// Entries handled specially (pods, secrets, bindings, vpa) are omitted here.
-const GENERIC_KIND_TABLE: Record<
-  string,
-  { apiVersion: string; kind: string; fields: FieldSel }
-> = {
-  deployments: { apiVersion: 'apps/v1', kind: 'Deployment', fields: { spec: true, status: true, data: false } },
-  services: { apiVersion: 'v1', kind: 'Service', fields: { spec: true, status: true, data: false } },
-  configmaps: { apiVersion: 'v1', kind: 'ConfigMap', fields: { spec: false, status: false, data: true } },
-  ingresses: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', fields: { spec: true, status: true, data: false } },
-  statefulsets: { apiVersion: 'apps/v1', kind: 'StatefulSet', fields: { spec: true, status: true, data: false } },
-  daemonsets: { apiVersion: 'apps/v1', kind: 'DaemonSet', fields: { spec: true, status: true, data: false } },
-  jobs: { apiVersion: 'batch/v1', kind: 'Job', fields: { spec: true, status: true, data: false } },
-  cronjobs: { apiVersion: 'batch/v1', kind: 'CronJob', fields: { spec: true, status: true, data: false } },
-  replicasets: { apiVersion: 'apps/v1', kind: 'ReplicaSet', fields: { spec: true, status: true, data: false } },
-  nodes: { apiVersion: 'v1', kind: 'Node', fields: { spec: true, status: true, data: false } },
-  namespaces: { apiVersion: 'v1', kind: 'Namespace', fields: { spec: true, status: true, data: false } },
-  hpa: { apiVersion: 'autoscaling/v2', kind: 'HorizontalPodAutoscaler', fields: { spec: true, status: true, data: false } },
-  wpa: { apiVersion: 'datadoghq.com/v1alpha1', kind: 'WatermarkPodAutoscaler', fields: { spec: true, status: true, data: false } },
-  networkpolicies: { apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy', fields: { spec: true, status: false, data: false } },
-  persistentvolumes: { apiVersion: 'v1', kind: 'PersistentVolume', fields: { spec: true, status: true, data: false } },
-  persistentvolumeclaims: { apiVersion: 'v1', kind: 'PersistentVolumeClaim', fields: { spec: true, status: true, data: false } },
-  storageclasses: { apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass', fields: { spec: false, status: false, data: false } },
-  roles: { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'Role', fields: { spec: false, status: false, data: false } },
-  clusterroles: { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole', fields: { spec: false, status: false, data: false } },
-  resourcequotas: { apiVersion: 'v1', kind: 'ResourceQuota', fields: { spec: true, status: true, data: false } },
-  limitranges: { apiVersion: 'v1', kind: 'LimitRange', fields: { spec: true, status: false, data: false } },
-  poddisruptionbudgets: { apiVersion: 'policy/v1', kind: 'PodDisruptionBudget', fields: { spec: true, status: true, data: false } },
-};
-
-// ---------------------------------------------------------------------------
-// Pod projection — port of listing.rs list_pods_projected.
-//
-// The pods table only reads a handful of fields; project them so we never ship
-// the full spec/status. The keys MUST match what TableRow.getCellValue +
-// container status rendering read (and src/lib/types PodStatus/ContainerStatus):
-//   spec.nodeName, spec.containers[].{name,image}, spec.initContainers[].{name,image}
-//   status.{phase,podIP,hostIP,startTime}
-//   status.conditions[].{type,status}
-//   status.containerStatuses[].{name,ready,restartCount,image,state,started}
-//   status.initContainerStatuses[...]
-// ---------------------------------------------------------------------------
-
-interface RawContainer {
-  name?: string;
-  image?: string;
-}
-interface RawCondition {
-  type?: string;
-  status?: string;
-}
-interface RawContainerStatus {
-  name?: string;
-  ready?: boolean;
-  restartCount?: number;
-  image?: string;
-  state?: unknown;
-  started?: boolean;
-}
-interface RawPodSpec {
-  nodeName?: string;
-  containers?: RawContainer[];
-  initContainers?: RawContainer[];
-}
-interface RawPodStatus {
-  phase?: string;
-  podIP?: string;
-  hostIP?: string;
-  startTime?: string;
-  conditions?: RawCondition[];
-  containerStatuses?: RawContainerStatus[];
-  initContainerStatuses?: RawContainerStatus[];
-}
-
-/** Drop undefined-valued keys so the object matches serde skip_serializing_if. */
-function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(o)) {
-    if (v !== undefined) out[k] = v;
-  }
-  return out as Partial<T>;
-}
-
-function projectContainer(c: RawContainer): Partial<RawContainer> {
-  return compact({ name: c.name, image: c.image });
-}
-
-function projectContainerStatus(cs: RawContainerStatus): Partial<RawContainerStatus> {
-  return compact({
-    name: cs.name,
-    ready: cs.ready,
-    restartCount: cs.restartCount,
-    image: cs.image,
-    state: cs.state,
-    started: cs.started,
-  });
-}
-
-function projectPod(obj: RawObject): Resource {
-  const rawSpec = (obj.spec ?? undefined) as RawPodSpec | undefined;
-  const rawStatus = (obj.status ?? undefined) as RawPodStatus | undefined;
-
-  let spec: Record<string, unknown> | undefined;
-  if (rawSpec) {
-    const s = compact({
-      nodeName: rawSpec.nodeName,
-      containers: rawSpec.containers?.map(projectContainer),
-      initContainers: rawSpec.initContainers?.map(projectContainer),
-    });
-    spec = Object.keys(s).length > 0 ? s : undefined;
-  }
-
-  let status: Record<string, unknown> | undefined;
-  if (rawStatus) {
-    const st = compact({
-      phase: rawStatus.phase,
-      podIP: rawStatus.podIP,
-      hostIP: rawStatus.hostIP,
-      startTime: rawStatus.startTime,
-      conditions: rawStatus.conditions?.map((c) => compact({ type: c.type, status: c.status })),
-      containerStatuses: rawStatus.containerStatuses?.map(projectContainerStatus),
-      initContainerStatuses: rawStatus.initContainerStatuses?.map(projectContainerStatus),
-    });
-    status = Object.keys(st).length > 0 ? st : undefined;
-  }
-
-  const res: Resource = {
-    api_version: 'v1',
-    kind: 'Pod',
-    metadata: listMetaFrom(obj.metadata),
-  };
-  if (spec !== undefined) res.spec = spec;
-  if (status !== undefined) res.status = status;
-  return res;
-}
-
-// ---------------------------------------------------------------------------
-// Special-case projections
-// ---------------------------------------------------------------------------
-
-/** base64-encode every Secret data value; fall back to stringData. */
-function projectSecret(obj: RawObject): Resource {
-  let data: Record<string, string> | undefined;
-  if (obj.data && typeof obj.data === 'object') {
-    // Secret.data values arrive already base64-encoded from the JSON API, so
-    // pass them through verbatim — matches the Rust output (which base64s the
-    // decoded bytes back to the same string).
-    data = obj.data as Record<string, string>;
-  } else if (obj.stringData) {
-    data = obj.stringData;
-  }
-  const res: Resource = {
-    api_version: 'v1',
-    kind: 'Secret',
-    metadata: listMetaFrom(obj.metadata),
-  };
-  if (data !== undefined) res.data = data;
-  if (obj.type !== undefined) res.type = obj.type;
-  return res;
-}
-
-/** RoleBinding / ClusterRoleBinding -> synthetic spec { roleRef, subjects }. */
-function projectBinding(obj: RawObject, kind: string): Resource {
-  const spec: Record<string, unknown> = {};
-  if (obj.roleRef !== undefined) spec.roleRef = obj.roleRef;
-  if (obj.subjects !== undefined) spec.subjects = obj.subjects;
-  return {
-    api_version: 'rbac.authorization.k8s.io/v1',
-    kind,
-    metadata: listMetaFrom(obj.metadata),
-    spec,
-  };
-}
-
-/** VPA (CRD) -> spec/status pulled straight from the object body. */
-function projectVpa(obj: RawObject): Resource {
-  const res: Resource = {
-    api_version: 'autoscaling.k8s.io/v1',
-    kind: 'VerticalPodAutoscaler',
-    metadata: listMetaFrom(obj.metadata),
-  };
-  const spec = presentOrUndefined(obj.spec);
-  const status = presentOrUndefined(obj.status);
-  if (spec !== undefined) res.spec = spec;
-  if (status !== undefined) res.status = status;
-  return res;
-}
-
-// ---------------------------------------------------------------------------
 // list_resources
+//
+// Per-kind projections (pods lean projection, secrets, bindings, vpa, generic
+// FieldSel table) live in electron/k8s/resource-mapping.ts — shared with the
+// watch path so a watch event replaces a list row with the SAME lean shape.
 // ---------------------------------------------------------------------------
 
 async function listResources(resourceType: string, namespace?: string): Promise<ResourceList> {
-  // Pods: lean projection (hot path).
-  if (resourceType === 'pods') {
-    const ar = apiResourceForType('pods');
-    if (!ar) throw new Error(`Unknown resource type: ${resourceType}`);
-    const raw = await listRaw({ ar, namespace });
-    return { items: raw.map(projectPod) };
-  }
-
-  // Secrets: base64 data + type.
-  if (resourceType === 'secrets') {
-    const ar = apiResourceForType('secrets');
-    if (!ar) throw new Error(`Unknown resource type: ${resourceType}`);
-    const raw = await listRaw({ ar, namespace });
-    return { items: raw.map(projectSecret) };
-  }
-
-  // RBAC bindings: synthetic spec.
-  if (resourceType === 'rolebindings' || resourceType === 'clusterrolebindings') {
-    const ar = apiResourceForType(resourceType);
-    if (!ar) throw new Error(`Unknown resource type: ${resourceType}`);
-    const kind = resourceType === 'rolebindings' ? 'RoleBinding' : 'ClusterRoleBinding';
-    const raw = await listRaw({ ar, namespace });
-    return { items: raw.map((o) => projectBinding(o, kind)) };
-  }
-
-  // VPA: CRD via dynamic group.
-  if (resourceType === 'vpa') {
-    const ar = apiResourceForType('vpa');
-    if (!ar) throw new Error(`Unknown resource type: ${resourceType}`);
-    const raw = await listRaw({ ar, namespace });
-    return { items: raw.map(projectVpa) };
-  }
-
-  // Generic kinds (pods/deployments/services/... handled by table).
-  const meta = GENERIC_KIND_TABLE[resourceType];
-  if (meta) {
-    const ar = apiResourceForType(resourceType);
-    if (!ar) throw new Error(`Unknown resource type: ${resourceType}`);
-    const raw = await listRaw({ ar, namespace });
-    return { items: raw.map((o) => projectGeneric(o, meta.apiVersion, meta.kind, meta.fields)) };
-  }
-
-  throw new Error(`Unknown resource type: ${resourceType}`);
+  const ar = apiResourceForType(resourceType);
+  const project = listProjectionFor(resourceType);
+  if (!ar || !project) throw new Error(`Unknown resource type: ${resourceType}`);
+  const { items: raw, resourceVersion } = await listRaw({ ar, namespace });
+  const out: ResourceList = { items: raw.map(project), resource_type: resourceType };
+  if (resourceVersion) out.resource_version = resourceVersion;
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -551,7 +295,7 @@ async function listResources(resourceType: string, namespace?: string): Promise<
 async function listPodsBySelector(namespace: string, selector: string): Promise<ResourceList> {
   const ar = apiResourceForType('pods')!;
   // Rust uses Api::namespaced/all with a label selector, single list (no paging).
-  const raw = await listRaw({
+  const { items: raw } = await listRaw({
     ar,
     namespace: namespace.length === 0 ? undefined : namespace,
     labelSelector: selector,

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -23,9 +23,10 @@
 // only reads resource.metadata.uid, but we project the full struct faithfully so
 // the upsert replaces the list item with the same shape list_resources produced.
 //
-// PROJECTION NOTE: watch.rs uses the GENERIC dynamic_to_resource projection —
-// spec/status/data are taken VERBATIM from the object body for every kind (NOT
-// the lean per-kind pod projection used by list_resources). We mirror that here.
+// PROJECTION NOTE: watch events use the SAME per-kind lean projection as
+// list_resources (listProjectionFor) — a watch event replaces a list row
+// wholesale in the store, so anything fatter than the list shape only bloats
+// IPC payloads and renderer-resident memory as the cluster churns.
 //
 // TYPE TRANSLATION: the kube `watcher` runtime the Rust used emits desired-state
 // events (Apply/Delete) and skips the initial list. The JS Watch is a RAW watch
@@ -38,7 +39,7 @@ import { Watch } from '@kubernetes/client-node';
 
 import { kc } from '../k8s/client';
 import type { RawObject, Resource } from '../k8s/resource-types';
-import { dynamicToResource } from '../k8s/resource-mapping';
+import { dynamicToResource, listProjectionFor } from '../k8s/resource-mapping';
 import type { Handler, HandlerCtx, HandlerMap } from '../dispatch';
 
 const WATCH_CHANNEL = 'resource-watch-event';
@@ -117,6 +118,8 @@ function apiResourceForType(resourceType: string): ApiResource | undefined {
     resourcequotas: ['', 'v1', 'ResourceQuota', 'resourcequotas', false],
     limitranges: ['', 'v1', 'LimitRange', 'limitranges', false],
     poddisruptionbudgets: ['policy', 'v1', 'PodDisruptionBudget', 'poddisruptionbudgets', false],
+    vpa: ['autoscaling.k8s.io', 'v1', 'VerticalPodAutoscaler', 'verticalpodautoscalers', false],
+    wpa: ['datadoghq.com', 'v1alpha1', 'WatermarkPodAutoscaler', 'watermarkpodautoscalers', false],
   };
   const row = table[resourceType];
   if (!row) return undefined;
@@ -143,10 +146,9 @@ function watchPath(ar: ApiResource, namespace?: string): string {
 // Projection — port of helpers.rs meta_from + watch.rs dynamic_to_resource.
 // ---------------------------------------------------------------------------
 
-// dynamic_to_resource + meta_from now live in electron/k8s/resource-mapping.ts
-// (shared with the resources and CRD paths). watch.rs uses the GENERIC
-// projection — spec/status/data taken verbatim for every kind — which is
-// exactly what the shared dynamicToResource does.
+// Projections live in electron/k8s/resource-mapping.ts (shared with the
+// resources and CRD paths): listProjectionFor gives the per-kind lean list
+// shape; dynamicToResource is the verbatim fallback for unknown kinds.
 
 // ---------------------------------------------------------------------------
 // Single active watch slot (mirrors watch.rs WATCHER_ABORT / WATCHER_RUNNING).
@@ -169,6 +171,14 @@ interface ActiveWatch {
   openedAt: number;
   /** Set true by stop() so reconnect loops bail. */
   stopped: boolean;
+  /**
+   * Last resourceVersion seen (seeded from the list, advanced by every event +
+   * bookmark). While set, (re)connects resume from it — the server sends only
+   * NEW deltas instead of replaying the whole list as ADDED, and no Resync
+   * (full renderer relist) is needed. Cleared on 410 Gone (history expired),
+   * which forces the classic replay + Resync path once.
+   */
+  lastRV: string | undefined;
 }
 
 // Identity of the live ActiveWatch is the generation token: callbacks captured
@@ -207,6 +217,7 @@ function clearActive(): void {
 async function startResourceWatch(
   resourceType: string,
   namespace: string | undefined,
+  listResourceVersion: string | undefined,
   ctx: HandlerCtx,
 ): Promise<void> {
   // Stop any existing watcher first (single active slot, like watch.rs).
@@ -222,16 +233,23 @@ async function startResourceWatch(
     flushTimer: null,
     reconnectTimer: null,
     batch: [],
-    hadInitialSync: false,
+    // With a list RV the initial sync IS the list the renderer just loaded.
+    hadInitialSync: !!listResourceVersion,
     backoffMs: BACKOFF_BASE_MS,
     openedAt: 0,
     stopped: false,
+    lastRV: listResourceVersion,
   };
   active = state;
 
   const path = watchPath(ar, namespace);
-  const apiVersion = ar.apiVersion;
-  const kind = ar.kind;
+  // Same lean projection as list_resources, resolved once for the whole watch:
+  // the renderer replaces the list row wholesale, so shipping more than the
+  // list shape only bloats IPC and renderer memory. Fallback keeps unknown
+  // types on the generic verbatim shape.
+  const project =
+    listProjectionFor(resourceType) ??
+    ((obj: RawObject) => dynamicToResource(obj, ar.apiVersion, ar.kind));
 
   const isCurrent = (): boolean => active === state && !state.stopped;
 
@@ -252,7 +270,7 @@ async function startResourceWatch(
     state.batch.push({
       event_type: eventType,
       resource_type: resourceType,
-      resource: dynamicToResource(obj, apiVersion, kind),
+      resource: project(obj),
     });
     if (state.batch.length >= WATCH_BATCH_SIZE) {
       flush();
@@ -269,6 +287,11 @@ async function startResourceWatch(
   // resolve when the watch opens, reject if that first open fails. Later
   // reconnects run in background with backoff and never surface here.
   let settled = false;
+
+  // Set when the server reports 410 Gone (RV expired): the next close must
+  // emit a Resync even if the connection was short-lived, because the
+  // no-RV reconnect's replay cannot cover deletes missed during the gap.
+  let rvExpired = false;
 
   return await new Promise<void>((resolve, reject) => {
     const settleOk = (): void => {
@@ -302,21 +325,47 @@ async function startResourceWatch(
     const connect = (): void => {
       if (!isCurrent()) return;
 
+      // Resume from the last seen RV when we have one: the server then sends
+      // only deltas newer than the list/previous stream — no ADDED replay of
+      // the entire list on every (re)connect. Bookmarks keep lastRV fresh even
+      // when the resource is quiet, so a resume stays possible after the
+      // server's periodic stream close.
+      const query: Record<string, string | number | boolean | undefined> = {
+        allowWatchBookmarks: true,
+      };
+      if (state.lastRV) query.resourceVersion = state.lastRV;
+
       watch
         .watch(
           path,
-          {},
+          query,
           (type: string, obj: RawObject) => {
             if (!isCurrent()) return;
+            const rv = obj?.metadata?.resourceVersion;
             switch (type) {
               case 'ADDED':
               case 'MODIFIED':
+                if (rv) state.lastRV = rv;
                 pushEvent('Applied', obj);
                 break;
               case 'DELETED':
+                if (rv) state.lastRV = rv;
                 pushEvent('Deleted', obj);
                 break;
-              // BOOKMARK / ERROR carry no resource delta the store consumes.
+              case 'BOOKMARK':
+                if (rv) state.lastRV = rv;
+                break;
+              case 'ERROR': {
+                // Status object; 410 Gone = our RV expired from watch history.
+                // Clear it so the next reconnect does a fresh replay + Resync
+                // (the relist covers any deletes we missed).
+                const code = (obj as { code?: number } | undefined)?.code;
+                if (code === 410) {
+                  state.lastRV = undefined;
+                  rvExpired = true;
+                }
+                break;
+              }
               default:
                 break;
             }
@@ -341,9 +390,16 @@ async function startResourceWatch(
             if (healthy) state.backoffMs = BACKOFF_BASE_MS;
 
             if (state.hadInitialSync) {
-              if (healthy) {
-                // Re-sync after a disconnect: emit a Resync so the store
-                // triggers a full refresh (matches watch.rs InitDone-on-resync).
+              // A resumable close (lastRV still valid) leaves NO gap: the
+              // reconnect picks up exactly where the stream ended, so no
+              // Resync — the renderer never has to do a full relist for the
+              // server's routine stream closes. A Resync (full refresh, since
+              // missed deletes can't be replayed) is only needed when the RV
+              // expired (410) or a healthy stream closed without one. Flapping
+              // non-410 closes keep the healthy gate so a broken watch can't
+              // relist in a loop.
+              if (!state.lastRV && (healthy || rvExpired)) {
+                rvExpired = false;
                 ctx.emit(WATCH_CHANNEL, [
                   {
                     event_type: 'Resync',
@@ -385,6 +441,13 @@ async function startResourceWatch(
             `[watch] failed to open watch for ${resourceType} (hadInitialSync=${state.hadInitialSync})`,
             err instanceof Error ? err.message : err,
           );
+          // A 410 at open means our resume RV already expired: drop it so the
+          // retry does a fresh replay, and force a Resync on the next close.
+          const status = (err as { code?: number; statusCode?: number } | undefined);
+          if (status?.code === 410 || status?.statusCode === 410) {
+            state.lastRV = undefined;
+            rvExpired = true;
+          }
           // Failed to OPEN the watch. If this is the first attempt, tear down
           // and reject the start invoke; otherwise keep the loop alive with
           // backoff so a transient open failure (e.g. a token refresh) doesn't
@@ -414,7 +477,13 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
     // or null for cluster-wide. Treat empty/missing as "all namespaces".
     const namespace =
       typeof args.namespace === 'string' && args.namespace.length > 0 ? args.namespace : undefined;
-    await startResourceWatch(resourceType, namespace, ctx);
+    // Optional: the resourceVersion of the list the renderer just rendered.
+    // When present the watch resumes from it instead of replaying the list.
+    const resourceVersion =
+      typeof args.resourceVersion === 'string' && args.resourceVersion.length > 0
+        ? args.resourceVersion
+        : undefined;
+    await startResourceWatch(resourceType, namespace, resourceVersion, ctx);
     return null;
   };
 

--- a/electron/k8s/resource-mapping.ts
+++ b/electron/k8s/resource-mapping.ts
@@ -73,3 +73,251 @@ export function dynamicToResource(obj: RawObject, apiVersion: string, kind: stri
   if (typeof obj.type === 'string') res.type = obj.type;
   return res;
 }
+
+// ---------------------------------------------------------------------------
+// Per-resource_type LIST projections — the lean shapes list_resources ships to
+// the renderer. The watch path MUST use the same projection: a watch event
+// replaces a list row wholesale in the store, so a fatter projection would make
+// rows grow to the full object (entire pod spec, last-applied annotation, …)
+// as soon as the cluster churns — paying that size on every IPC event and
+// keeping it resident in the renderer for the lifetime of the row.
+// ---------------------------------------------------------------------------
+
+interface FieldSel {
+  spec: boolean;
+  status: boolean;
+  data: boolean;
+}
+
+// Per resource_type: api_version + kind + which fields project. Mirrors the
+// listing.rs match arms (note kind is the SINGULAR Kind, e.g. "Pod").
+// Entries handled specially (pods, secrets, bindings, vpa) are omitted here.
+export const GENERIC_KIND_TABLE: Record<
+  string,
+  { apiVersion: string; kind: string; fields: FieldSel }
+> = {
+  deployments: { apiVersion: 'apps/v1', kind: 'Deployment', fields: { spec: true, status: true, data: false } },
+  services: { apiVersion: 'v1', kind: 'Service', fields: { spec: true, status: true, data: false } },
+  configmaps: { apiVersion: 'v1', kind: 'ConfigMap', fields: { spec: false, status: false, data: true } },
+  ingresses: { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', fields: { spec: true, status: true, data: false } },
+  statefulsets: { apiVersion: 'apps/v1', kind: 'StatefulSet', fields: { spec: true, status: true, data: false } },
+  daemonsets: { apiVersion: 'apps/v1', kind: 'DaemonSet', fields: { spec: true, status: true, data: false } },
+  jobs: { apiVersion: 'batch/v1', kind: 'Job', fields: { spec: true, status: true, data: false } },
+  cronjobs: { apiVersion: 'batch/v1', kind: 'CronJob', fields: { spec: true, status: true, data: false } },
+  replicasets: { apiVersion: 'apps/v1', kind: 'ReplicaSet', fields: { spec: true, status: true, data: false } },
+  nodes: { apiVersion: 'v1', kind: 'Node', fields: { spec: true, status: true, data: false } },
+  namespaces: { apiVersion: 'v1', kind: 'Namespace', fields: { spec: true, status: true, data: false } },
+  hpa: { apiVersion: 'autoscaling/v2', kind: 'HorizontalPodAutoscaler', fields: { spec: true, status: true, data: false } },
+  wpa: { apiVersion: 'datadoghq.com/v1alpha1', kind: 'WatermarkPodAutoscaler', fields: { spec: true, status: true, data: false } },
+  networkpolicies: { apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy', fields: { spec: true, status: false, data: false } },
+  persistentvolumes: { apiVersion: 'v1', kind: 'PersistentVolume', fields: { spec: true, status: true, data: false } },
+  persistentvolumeclaims: { apiVersion: 'v1', kind: 'PersistentVolumeClaim', fields: { spec: true, status: true, data: false } },
+  storageclasses: { apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass', fields: { spec: false, status: false, data: false } },
+  roles: { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'Role', fields: { spec: false, status: false, data: false } },
+  clusterroles: { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole', fields: { spec: false, status: false, data: false } },
+  resourcequotas: { apiVersion: 'v1', kind: 'ResourceQuota', fields: { spec: true, status: true, data: false } },
+  limitranges: { apiVersion: 'v1', kind: 'LimitRange', fields: { spec: true, status: false, data: false } },
+  poddisruptionbudgets: { apiVersion: 'policy/v1', kind: 'PodDisruptionBudget', fields: { spec: true, status: true, data: false } },
+};
+
+export function projectGeneric(
+  obj: RawObject,
+  apiVersion: string,
+  kind: string,
+  fields: FieldSel,
+): Resource {
+  const res: Resource = {
+    api_version: apiVersion,
+    kind,
+    metadata: listMetaFrom(obj.metadata),
+  };
+  if (fields.spec) {
+    const v = presentOrUndefined(obj.spec);
+    if (v !== undefined) res.spec = v;
+  }
+  if (fields.status) {
+    const v = presentOrUndefined(obj.status);
+    if (v !== undefined) res.status = v;
+  }
+  if (fields.data) {
+    const v = presentOrUndefined(obj.data);
+    if (v !== undefined) res.data = v;
+  }
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Pod projection — port of listing.rs list_pods_projected.
+//
+// The pods table only reads a handful of fields; project them so we never ship
+// the full spec/status. The keys MUST match what TableRow.getCellValue +
+// container status rendering read (and src/lib/types PodStatus/ContainerStatus):
+//   spec.nodeName, spec.containers[].{name,image}, spec.initContainers[].{name,image}
+//   status.{phase,podIP,hostIP,startTime}
+//   status.conditions[].{type,status}
+//   status.containerStatuses[].{name,ready,restartCount,image,state,started}
+//   status.initContainerStatuses[...]
+// ---------------------------------------------------------------------------
+
+interface RawContainer {
+  name?: string;
+  image?: string;
+}
+interface RawCondition {
+  type?: string;
+  status?: string;
+}
+interface RawContainerStatus {
+  name?: string;
+  ready?: boolean;
+  restartCount?: number;
+  image?: string;
+  state?: unknown;
+  started?: boolean;
+}
+interface RawPodSpec {
+  nodeName?: string;
+  containers?: RawContainer[];
+  initContainers?: RawContainer[];
+}
+interface RawPodStatus {
+  phase?: string;
+  podIP?: string;
+  hostIP?: string;
+  startTime?: string;
+  conditions?: RawCondition[];
+  containerStatuses?: RawContainerStatus[];
+  initContainerStatuses?: RawContainerStatus[];
+}
+
+/** Drop undefined-valued keys so the object matches serde skip_serializing_if. */
+function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(o)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out as Partial<T>;
+}
+
+function projectContainer(c: RawContainer): Partial<RawContainer> {
+  return compact({ name: c.name, image: c.image });
+}
+
+function projectContainerStatus(cs: RawContainerStatus): Partial<RawContainerStatus> {
+  return compact({
+    name: cs.name,
+    ready: cs.ready,
+    restartCount: cs.restartCount,
+    image: cs.image,
+    state: cs.state,
+    started: cs.started,
+  });
+}
+
+export function projectPod(obj: RawObject): Resource {
+  const rawSpec = (obj.spec ?? undefined) as RawPodSpec | undefined;
+  const rawStatus = (obj.status ?? undefined) as RawPodStatus | undefined;
+
+  let spec: Record<string, unknown> | undefined;
+  if (rawSpec) {
+    const s = compact({
+      nodeName: rawSpec.nodeName,
+      containers: rawSpec.containers?.map(projectContainer),
+      initContainers: rawSpec.initContainers?.map(projectContainer),
+    });
+    spec = Object.keys(s).length > 0 ? s : undefined;
+  }
+
+  let status: Record<string, unknown> | undefined;
+  if (rawStatus) {
+    const st = compact({
+      phase: rawStatus.phase,
+      podIP: rawStatus.podIP,
+      hostIP: rawStatus.hostIP,
+      startTime: rawStatus.startTime,
+      conditions: rawStatus.conditions?.map((c) => compact({ type: c.type, status: c.status })),
+      containerStatuses: rawStatus.containerStatuses?.map(projectContainerStatus),
+      initContainerStatuses: rawStatus.initContainerStatuses?.map(projectContainerStatus),
+    });
+    status = Object.keys(st).length > 0 ? st : undefined;
+  }
+
+  const res: Resource = {
+    api_version: 'v1',
+    kind: 'Pod',
+    metadata: listMetaFrom(obj.metadata),
+  };
+  if (spec !== undefined) res.spec = spec;
+  if (status !== undefined) res.status = status;
+  return res;
+}
+
+/** base64-encode every Secret data value; fall back to stringData. */
+export function projectSecret(obj: RawObject): Resource {
+  let data: Record<string, string> | undefined;
+  if (obj.data && typeof obj.data === 'object') {
+    // Secret.data values arrive already base64-encoded from the JSON API, so
+    // pass them through verbatim — matches the Rust output (which base64s the
+    // decoded bytes back to the same string).
+    data = obj.data as Record<string, string>;
+  } else if (obj.stringData) {
+    data = obj.stringData;
+  }
+  const res: Resource = {
+    api_version: 'v1',
+    kind: 'Secret',
+    metadata: listMetaFrom(obj.metadata),
+  };
+  if (data !== undefined) res.data = data;
+  if (obj.type !== undefined) res.type = obj.type;
+  return res;
+}
+
+/** RoleBinding / ClusterRoleBinding -> synthetic spec { roleRef, subjects }. */
+export function projectBinding(obj: RawObject, kind: string): Resource {
+  const spec: Record<string, unknown> = {};
+  if (obj.roleRef !== undefined) spec.roleRef = obj.roleRef;
+  if (obj.subjects !== undefined) spec.subjects = obj.subjects;
+  return {
+    api_version: 'rbac.authorization.k8s.io/v1',
+    kind,
+    metadata: listMetaFrom(obj.metadata),
+    spec,
+  };
+}
+
+/** VPA (CRD) -> spec/status pulled straight from the object body. */
+export function projectVpa(obj: RawObject): Resource {
+  const res: Resource = {
+    api_version: 'autoscaling.k8s.io/v1',
+    kind: 'VerticalPodAutoscaler',
+    metadata: listMetaFrom(obj.metadata),
+  };
+  const spec = presentOrUndefined(obj.spec);
+  const status = presentOrUndefined(obj.status);
+  if (spec !== undefined) res.spec = spec;
+  if (status !== undefined) res.status = status;
+  return res;
+}
+
+// Types whose list shape is not the generic FieldSel projection.
+const SPECIAL_PROJECTIONS: Record<string, (obj: RawObject) => Resource> = {
+  pods: projectPod,
+  secrets: projectSecret,
+  rolebindings: (obj) => projectBinding(obj, 'RoleBinding'),
+  clusterrolebindings: (obj) => projectBinding(obj, 'ClusterRoleBinding'),
+  vpa: projectVpa,
+};
+
+/**
+ * The lean per-kind projector list_resources uses for `resourceType`, or null
+ * when the type has no list projection (the caller decides how to fall back /
+ * error). Resolve ONCE per listing/watch, then apply per object.
+ */
+export function listProjectionFor(resourceType: string): ((obj: RawObject) => Resource) | null {
+  const special = SPECIAL_PROJECTIONS[resourceType];
+  if (special) return special;
+  const meta = GENERIC_KIND_TABLE[resourceType];
+  if (meta) return (obj) => projectGeneric(obj, meta.apiVersion, meta.kind, meta.fields);
+  return null;
+}

--- a/electron/k8s/resource-types.ts
+++ b/electron/k8s/resource-types.ts
@@ -33,6 +33,10 @@ export interface Resource {
 
 export interface ResourceList {
   items: Resource[];
+  /** Echo of the requested plural resource type (the renderer stores it). */
+  resource_type?: string;
+  /** List's resourceVersion — lets the watch resume without replaying the list. */
+  resource_version?: string;
 }
 
 export interface RawObjectMeta {
@@ -64,5 +68,5 @@ export interface RawObject {
 
 export interface RawList {
   items?: RawObject[];
-  metadata?: { continue?: string };
+  metadata?: { continue?: string; resourceVersion?: string };
 }

--- a/playwright.bench.config.ts
+++ b/playwright.bench.config.ts
@@ -1,0 +1,26 @@
+// Bench-only Playwright config: identical to playwright.config.ts but pinned to
+// its own port so runs never hit a dev server from another worktree/session
+// (port 1420 is first-come; a stale server there silently benchmarks the WRONG
+// code). --strictPort makes vite fail loudly instead of drifting to 1420.
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 1421;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30000,
+  expect: { timeout: 5000 },
+  fullyParallel: true,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "line",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `npm run dev -- --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: false,
+    timeout: 120000,
+  },
+});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -31,7 +31,7 @@
   // (prevents empty state flash). Implementation lives in tabLifecycle
   // util so the race-guard + namespace sync logic is unit-testable.
   uiStore.onBeforeTabSwitch = (fromTab, toTab) => {
-    handleTabSwitch(fromTab, toTab, k8sStore);
+    handleTabSwitch(fromTab, toTab, k8sStore, (tabId) => uiStore.activeTabId === tabId);
   };
 
   // When namespace changes, save it to the active tab and invalidate cache.
@@ -121,6 +121,10 @@
       return;
     }
 
+    // The restored namespace may not exist in THIS cluster — snap to a real
+    // one now that the cluster's namespace list is known.
+    k8sStore.restoreNamespace();
+
     // Re-hydrate the restored active tab so it isn't blank on cold boot. The
     // selected resource and visible list are ephemeral (never persisted), so a
     // details/logs/yaml or table tab restored from a previous session has no
@@ -147,9 +151,8 @@
     const tab = uiStore.activeTab;
     if (!tab) return;
 
-    if (tab.namespace !== undefined && tab.namespace !== k8sStore.currentNamespace) {
-      k8sStore.currentNamespace = tab.namespace;
-    }
+    // Adopt the tab's namespace only when it is usable in this cluster.
+    k8sStore.restoreNamespace(tab.namespace);
 
     if (tab.type === "table" && tab.resourceType) {
       await k8sStore.loadResources(tab.resourceType);

--- a/src/lib/actions/navigation.ts
+++ b/src/lib/actions/navigation.ts
@@ -7,7 +7,11 @@ import { uiStore } from "$lib/stores/ui.svelte";
  */
 export function openResourceDetail(resource: Resource, resourceType?: string): void {
   k8sStore.selectedResource = resource;
-  uiStore.showDetails(resource.metadata.name, resourceType ?? resource.kind);
+  uiStore.showDetails(
+    resource.metadata.name,
+    resourceType ?? resource.kind,
+    resource.metadata.namespace ?? undefined,
+  );
   const tab = uiStore.activeTab;
   if (tab) tab.cachedResource = resource;
 }

--- a/src/lib/components/crd/CrdTableView.svelte
+++ b/src/lib/components/crd/CrdTableView.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { untrack } from "svelte";
+  import { createVirtualizer } from "@tanstack/svelte-virtual";
   import { k8sStore } from "$lib/stores/k8s.svelte";
   import { uiStore } from "$lib/stores/ui.svelte";
-  import { ScrollArea } from "$lib/components/ui/scroll-area";
   import { cn } from "$lib/utils";
   import { formatAge } from "$lib/utils/age";
   import { resolveJsonPath } from "$lib/utils/k8s-helpers";
@@ -10,6 +11,38 @@
 
   let selectedResource = $state<Resource | null>(null);
   let showDetail = $state(false);
+
+  // Virtualized rows (same pattern as ResourceTable): CRD listings are
+  // arbitrary user data and can hold thousands of items — rendering them all
+  // makes the DOM (and every reactive update) scale with the dataset.
+  const ROW_HEIGHT = 29;
+  let scrollRef: HTMLDivElement | undefined = $state();
+
+  const virtualizer = createVirtualizer<HTMLDivElement, Element>({
+    count: 0,
+    getScrollElement: () => scrollRef ?? null,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  // Gate on scrollRef so the virtualizer acquires its scroll element on remount.
+  // setOptions notifies the virtualizer store; untrack breaks the self-retrigger.
+  $effect(() => {
+    if (!scrollRef) return;
+    const count = k8sStore.crdResources.items.length;
+    untrack(() => {
+      $virtualizer.setOptions({ count });
+    });
+  });
+
+  let virtualItems = $derived($virtualizer.getVirtualItems());
+  let paddingTop = $derived(virtualItems.length > 0 ? virtualItems[0].start : 0);
+  let paddingBottom = $derived(
+    virtualItems.length > 0
+      ? $virtualizer.getTotalSize() - virtualItems[virtualItems.length - 1].end
+      : 0,
+  );
+  let colspan = $derived(k8sStore.crdResources.columns.length + 3);
 
   function handleRowClick(resource: Resource) {
     selectedResource = resource;
@@ -54,9 +87,9 @@
         </span>
       </div>
     {:else}
-      <ScrollArea class="flex-1">
+      <div class="flex-1 overflow-auto" bind:this={scrollRef}>
         <table class="w-full text-xs">
-          <thead>
+          <thead class="sticky top-0 z-10">
             <tr class="border-b border-[var(--border-color)] bg-[var(--bg-secondary)]">
               <th class="px-3 py-2 text-left font-medium text-[var(--text-secondary)]">Name</th>
               <th class="px-3 py-2 text-left font-medium text-[var(--text-secondary)]">Namespace</th>
@@ -69,30 +102,39 @@
             </tr>
           </thead>
           <tbody>
-            {#each k8sStore.crdResources.items as resource}
-              <tr
-                class={cn(
-                  "cursor-pointer border-b border-[var(--table-border)] transition-colors",
-                  "hover:bg-[var(--table-row-hover)]",
-                  selectedResource?.metadata?.uid === resource.metadata?.uid && "bg-[var(--table-row-selected)]"
-                )}
-                onclick={() => handleRowClick(resource)}
-              >
-                <td class="px-3 py-1.5 text-[var(--text-primary)]">{resource.metadata.name}</td>
-                <td class="px-3 py-1.5 text-[var(--text-secondary)]">{resource.metadata.namespace ?? "—"}</td>
-                {#each k8sStore.crdResources.columns as col}
-                  <td class="px-3 py-1.5 text-[var(--text-secondary)]">
-                    {resolveJsonPath(resource, col.json_path) || "—"}
+            {#if paddingTop > 0}
+              <tr><td {colspan} style="height: {paddingTop}px; padding: 0; border: none;"></td></tr>
+            {/if}
+            {#each virtualItems as vi (vi.index)}
+              {@const resource = k8sStore.crdResources.items[vi.index]}
+              {#if resource}
+                <tr
+                  class={cn(
+                    "cursor-pointer border-b border-[var(--table-border)] transition-colors",
+                    "hover:bg-[var(--table-row-hover)]",
+                    selectedResource?.metadata?.uid === resource.metadata?.uid && "bg-[var(--table-row-selected)]"
+                  )}
+                  onclick={() => handleRowClick(resource)}
+                >
+                  <td class="px-3 py-1.5 text-[var(--text-primary)]">{resource.metadata.name}</td>
+                  <td class="px-3 py-1.5 text-[var(--text-secondary)]">{resource.metadata.namespace ?? "—"}</td>
+                  {#each k8sStore.crdResources.columns as col}
+                    <td class="px-3 py-1.5 text-[var(--text-secondary)]">
+                      {resolveJsonPath(resource, col.json_path) || "—"}
+                    </td>
+                  {/each}
+                  <td class="px-3 py-1.5 text-right text-[var(--text-muted)]">
+                    {resource.metadata.creation_timestamp ? formatAge(resource.metadata.creation_timestamp) : "—"}
                   </td>
-                {/each}
-                <td class="px-3 py-1.5 text-right text-[var(--text-muted)]">
-                  {resource.metadata.creation_timestamp ? formatAge(resource.metadata.creation_timestamp) : "—"}
-                </td>
-              </tr>
+                </tr>
+              {/if}
             {/each}
+            {#if paddingBottom > 0}
+              <tr><td {colspan} style="height: {paddingBottom}px; padding: 0; border: none;"></td></tr>
+            {/if}
           </tbody>
         </table>
-      </ScrollArea>
+      </div>
     {/if}
   </div>
 {/if}

--- a/src/lib/components/details/DetailPanel.svelte
+++ b/src/lib/components/details/DetailPanel.svelte
@@ -153,7 +153,7 @@
 </script>
 
 {#if resource}
-  <div class="flex h-full flex-col bg-[var(--bg-primary)]">
+  <div data-testid="detail-panel" class="flex h-full flex-col bg-[var(--bg-primary)]">
     <!-- Header -->
     <div class="flex h-[68px] items-center justify-between border-b border-[var(--border-color)] bg-[var(--bg-primary)] px-6">
       <!-- Left: Breadcrumbs + Info -->
@@ -320,5 +320,16 @@
         </ScrollArea>
       {/if}
     </div>
+  </div>
+{:else}
+  <!-- No resource: a restored tab whose object is gone (e.g. the pod was
+       replaced while the app was closed) or a hydration still in flight.
+       Never render a silent blank panel. -->
+  <div data-testid="detail-panel-empty" class="flex h-full flex-col items-center justify-center gap-2 bg-[var(--bg-primary)]">
+    <span class="text-sm text-[var(--text-muted)]">Resource not available</span>
+    <span class="max-w-[360px] text-center text-xs text-[var(--text-dimmed)]">
+      It may have been deleted or replaced while the app was closed. Close this
+      tab, or open the resource again from its table.
+    </span>
   </div>
 {/if}

--- a/src/lib/components/table/ResourceTable.svelte
+++ b/src/lib/components/table/ResourceTable.svelte
@@ -85,6 +85,12 @@
 
   // Step 2: Sort (depends on filteredItems, sortColumn, sortDirection — NOT ageTick)
   let filteredResources = $derived(sortResources(filteredItems, uiStore.sortColumn, uiStore.sortDirection as "asc" | "desc"));
+  // Also skeleton while the view has never completed a list: isLoading is
+  // deliberately delayed 200ms, which would flash the empty state on boot.
+  let showLoadingSkeleton = $derived(
+    k8sStore.isLoading ||
+      (!k8sStore.viewLoaded && !k8sStore.error && filteredResources.length === 0),
+  );
 
   // Virtual scrolling
   const ROW_HEIGHT: Record<string, number> = { compact: 32, comfortable: 44 };
@@ -465,7 +471,7 @@
   <div class="relative flex-1 overflow-hidden">
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="virtual-scroll-container h-full overflow-auto border-t border-[var(--border-color)] bg-[var(--bg-primary)]" bind:this={scrollRef} oncontextmenu={handleTableContextMenu} role="region" aria-label="{resourceTypeLabel} resources">
-    {#if k8sStore.isLoading}
+    {#if showLoadingSkeleton}
       <TableEmptyStates
         state="loading"
         {columns}

--- a/src/lib/ipc/core.ts
+++ b/src/lib/ipc/core.ts
@@ -9,6 +9,24 @@
 const IPC_WRAPPER = /^Error invoking remote method '[^']+': (?:Error: )?/;
 
 /**
+ * Deep-plain-clone an args object IF it contains a non-plain value (Svelte 5
+ * $state proxies above all). ipcRenderer.invoke serializes with the structured
+ * clone algorithm, which THROWS "An object could not be cloned" on any Proxy —
+ * so e.g. passing `settingsStore.settings` (deep $state) made save_settings
+ * fail on every call under Electron (Tauri JSON-serialized, masking this).
+ * JSON round-trip is safe here: IPC payloads are plain JSON data by contract.
+ * The common case (plain strings/numbers already) pays only a cheap scan.
+ */
+function toCloneable(args: Record<string, unknown>): Record<string, unknown> {
+  for (const v of Object.values(args)) {
+    if (typeof v === 'object' && v !== null) {
+      return JSON.parse(JSON.stringify(args)) as Record<string, unknown>;
+    }
+  }
+  return args;
+}
+
+/**
  * Invoke a backend command. Mirrors Tauri's invoke<T>(cmd, args?) signature:
  * resolves with the handler's result, rejects with its Error message.
  */
@@ -17,7 +35,7 @@ export async function invoke<T = unknown>(
   args?: Record<string, unknown>,
 ): Promise<T> {
   try {
-    return (await window.electronAPI.invoke(cmd, args ?? {})) as T;
+    return (await window.electronAPI.invoke(cmd, args ? toCloneable(args) : {})) as T;
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);
     throw new Error(raw.replace(IPC_WRAPPER, ''));

--- a/src/lib/stores/k8s.logic.ts
+++ b/src/lib/stores/k8s.logic.ts
@@ -52,6 +52,13 @@ export class K8sStoreLogic {
   resourceCounts: Record<string, number> = {};
   portForwards: PortForwardInfo[] = [];
   ageTick: number = 0;
+  /**
+   * False until the CURRENT view's first list completes (or cache restores).
+   * Distinguishes "never loaded yet" (show loading) from "loaded, genuinely
+   * empty" (show empty state) — isLoading alone can't: it is deliberately
+   * delayed 200ms to avoid flicker, which flashed "No pods found" on boot.
+   */
+  viewLoaded: boolean = false;
 
   // CRD state
   crdGroups: CrdGroup[] = [];
@@ -81,6 +88,7 @@ export class K8sStoreLogic {
 
   /** Set both resource type states atomically (for non-async transitions) */
   setResourceType(type: string): void {
+    if (type !== this.selectedResourceType) this.viewLoaded = false;
     this.selectedResourceType = type;
     this.pendingResourceType = type;
   }
@@ -93,6 +101,7 @@ export class K8sStoreLogic {
     this.error = null;
     this.contextsLoadError = null;
     this.namespacesLoadError = null;
+    this.viewLoaded = false;
     this.resources = { items: [], resource_type: this.selectedResourceType };
     this.selectedResource = null;
     this.clearNavHistory();
@@ -158,6 +167,26 @@ export class K8sStoreLogic {
     this._setCount(resourceType, items.length);
     this.isLoading = false;
     this.error = null;
+    this.viewLoaded = true;
+  }
+
+  /**
+   * Adopt a restored namespace only if it is usable in THIS cluster, then make
+   * sure currentNamespace itself is real. A candidate is adopted when non-empty
+   * ("" would list at CLUSTER scope — 403 under restrictive RBAC, and the
+   * picker offers no way out) and present in the loaded namespace list (tabs/
+   * settings can carry one from another context — listing there returns empty
+   * forever). With no list loaded, the candidate is trusted as-is.
+   */
+  restoreNamespace(candidate?: string): void {
+    const nss = this.namespaces;
+    if (candidate && (nss.length === 0 || nss.includes(candidate))) {
+      this.currentNamespace = candidate;
+      return;
+    }
+    if (nss.length > 0 && !nss.includes(this.currentNamespace)) {
+      this.currentNamespace = nss.includes("default") ? "default" : nss[0];
+    }
   }
 
   _setCount(resourceType: string, count: number): void {

--- a/src/lib/stores/k8s.svelte.ts
+++ b/src/lib/stores/k8s.svelte.ts
@@ -4,6 +4,7 @@ import type { Resource, ResourceList, ConnectionStatus, PortForwardInfo, CrdGrou
 import { settingsStore } from "./settings.svelte";
 import { toastStore } from "./toast.svelte.js";
 import { K8sStoreLogic, COUNTABLE_RESOURCE_TYPES } from "./k8s.logic.js";
+import { resourceTypeForRef } from "$lib/utils/related-resources";
 import { unshadowState } from "./_unshadow.js";
 
 export type { WatchEvent, NavigationEntry } from "./k8s.logic.js";
@@ -41,6 +42,7 @@ class K8sStore extends K8sStoreLogic {
   override resourceCounts = $state<Record<string, number>>({});
   override portForwards = $state<PortForwardInfo[]>([]);
   override ageTick = $state(0);
+  override viewLoaded = $state(false);
 
   // CRD state
   override crdGroups = $state<CrdGroup[]>([]);
@@ -142,11 +144,13 @@ class K8sStore extends K8sStoreLogic {
       await this.loadNamespaces(scopeGeneration);
       if (scopeGeneration !== this._scopeGeneration) return;
 
+      // Never fall back to "" — that lists at CLUSTER scope, which restrictive
+      // RBAC forbids (403 on every list) and the namespace picker can't leave.
       const fallbackNamespace = this.namespaces.includes(this.currentNamespace)
         ? this.currentNamespace
         : this.namespaces.includes("default")
           ? "default"
-          : (this.namespaces[0] ?? "");
+          : (this.namespaces[0] ?? "default");
       this.currentNamespace = fallbackNamespace;
 
       await this.loadResources(this.selectedResourceType, scopeGeneration);
@@ -197,7 +201,7 @@ class K8sStore extends K8sStoreLogic {
       this.selectedResourceType = resourceType;
       this.resources = result;
       this._setCount(resourceType, result.items.length);
-      this._startWatch(resourceType, this.currentNamespace);
+      this._startWatch(resourceType, this.currentNamespace, result.resource_version);
     } catch (err) {
       if (scopeGeneration !== this._scopeGeneration) return;
       this.error = `Failed to load resources: ${errMsg(err)}`;
@@ -206,6 +210,9 @@ class K8sStore extends K8sStoreLogic {
       clearTimeout(timer);
       if (scopeGeneration === this._scopeGeneration) {
         this.isLoading = false;
+        // First list for this view finished (either way): the table may now
+        // legitimately show its empty/error states instead of "loading".
+        this.viewLoaded = true;
       }
     }
   }
@@ -236,29 +243,38 @@ class K8sStore extends K8sStoreLogic {
    * (plural form). Returns true if a resource was selected.
    */
   async selectResourceByRef(typeOrKind: string, name: string, namespace?: string): Promise<boolean> {
+    const found = await this.resolveResourceByRef(typeOrKind, name, namespace);
+    if (found) {
+      this.selectedResource = found;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Fetch a resource by reference WITHOUT touching the selection — callers that
+   * re-hydrate a background tab decide themselves whether the result may become
+   * the visible selectedResource (the user may have switched tabs meanwhile).
+   */
+  async resolveResourceByRef(typeOrKind: string, name: string, namespace?: string): Promise<Resource | null> {
     try {
       const full = await invoke<Resource>("get_resource", {
         kind: typeOrKind,
         name,
         namespace: namespace ?? "",
       });
-      if (full) {
-        this.selectedResource = full;
-        return true;
-      }
+      if (full) return full;
     } catch {
       // Not a Kind alias (e.g. a plural type) or the object is gone — try listing.
     }
     try {
-      const found = await this.fetchResource(typeOrKind, name, namespace);
-      if (found) {
-        this.selectedResource = found;
-        return true;
-      }
+      // The fallback lists by PLURAL type — normalize a Kind ("Deployment")
+      // to its plural ("deployments") or list_resources rejects it outright.
+      return await this.fetchResource(resourceTypeForRef(typeOrKind), name, namespace);
     } catch {
       // Unknown type or list failed — leave selection unset (view shows empty).
     }
-    return false;
+    return null;
   }
 
   /** @deprecated Use openRelatedResourceTab() or openResourceDetail() instead */
@@ -291,7 +307,7 @@ class K8sStore extends K8sStoreLogic {
     this._listResources(entry.resourceType).then((result) => {
       this.resources = result;
       this._setCount(entry.resourceType, result.items.length);
-      this._startWatch(entry.resourceType, this.currentNamespace);
+      this._startWatch(entry.resourceType, this.currentNamespace, result.resource_version);
       // Re-find the resource in case it was updated
       const updated = result.items.find((r) => r.metadata.uid === entry.resource.metadata.uid);
       if (updated) this.selectedResource = updated;
@@ -314,7 +330,7 @@ class K8sStore extends K8sStoreLogic {
       if (this.selectedResourceType !== expectedType) return;
       this.resources = result;
       this._setCount(expectedType, result.items.length);
-      this._startWatch(expectedType, this.currentNamespace);
+      this._startWatch(expectedType, this.currentNamespace, result.resource_version);
       const updated = result.items.find((r) => r.metadata.uid === entry.resource.metadata.uid);
       if (updated) this.selectedResource = updated;
     }).catch(() => {});
@@ -383,7 +399,7 @@ class K8sStore extends K8sStoreLogic {
     });
   }
 
-  private _startWatch(resourceType: string, namespace: string): Promise<void> {
+  private _startWatch(resourceType: string, namespace: string, resourceVersion?: string): Promise<void> {
     // Chain onto the shared op so a stop always completes before the next start
     // runs — no two starts can interleave on the single interval/listener slots.
     this._watchOp = this._watchOp.then(async () => {
@@ -395,10 +411,12 @@ class K8sStore extends K8sStoreLogic {
         this._watchUnlisten = await listen<import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]>("resource-watch-event", (event) => {
           this._handleWatchEvents(event.payload);
         });
-        // Start the backend watcher
+        // Start the backend watcher. Passing the list's resourceVersion lets it
+        // resume from what we just rendered instead of replaying every item.
         await invoke("start_resource_watch", {
           resourceType,
           namespace,
+          resourceVersion: resourceVersion ?? null,
         });
         this._watchActive = true;
       } catch (err) {
@@ -495,6 +513,13 @@ class K8sStore extends K8sStoreLogic {
       if (!uid) continue;
 
       if (event.event_type === "Applied") {
+        // Same resourceVersion = identical object (k8s bumps RV on every
+        // change): the event is a replay (initial watch sync / reconnect),
+        // not a delta. Skipping it avoids re-rendering the whole table once
+        // per replayed batch right after navigation/restore.
+        const prev = byUid.get(uid);
+        const rv = event.resource.metadata?.resource_version;
+        if (prev && rv && prev.metadata?.resource_version === rv) continue;
         byUid.set(uid, event.resource);
         changed = true;
         if (this.selectedResource?.metadata?.uid === uid) {

--- a/src/lib/stores/k8s.test.ts
+++ b/src/lib/stores/k8s.test.ts
@@ -176,6 +176,67 @@ describe("K8sStore", () => {
     });
   });
 
+  describe("viewLoaded", () => {
+    test("false initially (boot must show loading, not empty)", () => {
+      expect(store.viewLoaded).toBe(false);
+    });
+
+    test("restoreResourcesSync marks the view loaded", () => {
+      store.restoreResourcesSync("pods", []);
+      expect(store.viewLoaded).toBe(true);
+    });
+
+    test("switching resource type resets it; same type keeps it", () => {
+      store.restoreResourcesSync("pods", []);
+      store.setResourceType("deployments");
+      expect(store.viewLoaded).toBe(false);
+      store.restoreResourcesSync("deployments", []);
+      store.setResourceType("deployments");
+      expect(store.viewLoaded).toBe(true);
+    });
+
+    test("_resetVisibleState resets it", () => {
+      store.restoreResourcesSync("pods", []);
+      store._resetVisibleState();
+      expect(store.viewLoaded).toBe(false);
+    });
+  });
+
+  describe("restoreNamespace", () => {
+    test("adopts a candidate that exists in the cluster", () => {
+      store.namespaces = ["default", "prod"];
+      store.restoreNamespace("prod");
+      expect(store.currentNamespace).toBe("prod");
+    });
+
+    test("trusts the candidate when no namespace list is loaded", () => {
+      store.namespaces = [];
+      store.restoreNamespace("prod");
+      expect(store.currentNamespace).toBe("prod");
+    });
+
+    test("rejects empty candidate (cluster-scope listing) and keeps a valid current", () => {
+      store.namespaces = ["default", "prod"];
+      store.currentNamespace = "prod";
+      store.restoreNamespace("");
+      expect(store.currentNamespace).toBe("prod");
+    });
+
+    test("snaps an invalid current namespace to default", () => {
+      store.namespaces = ["default", "prod"];
+      store.currentNamespace = "gone-namespace";
+      store.restoreNamespace();
+      expect(store.currentNamespace).toBe("default");
+    });
+
+    test("snaps to the first namespace when default is absent", () => {
+      store.namespaces = ["alpha", "beta"];
+      store.currentNamespace = "gone-namespace";
+      store.restoreNamespace("also-gone");
+      expect(store.currentNamespace).toBe("alpha");
+    });
+  });
+
   describe("_beginScopeChange", () => {
     test("increments scope and count generations", () => {
       const gen1 = store._beginScopeChange();

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -363,7 +363,7 @@ export class UiStoreLogic {
     }
   }
 
-  protected _switchView(view: ActiveView, opts?: { label?: string; resourceName?: string; resourceType?: string }): void {
+  protected _switchView(view: ActiveView, opts?: { label?: string; resourceName?: string; resourceType?: string; namespace?: string }): void {
     this.previousView = this.activeView;
     this.openTab(view, opts);
   }
@@ -376,11 +376,15 @@ export class UiStoreLogic {
     this._switchView("settings");
   }
 
-  showDetails(resourceName?: string, resourceType?: string): void {
+  showDetails(resourceName?: string, resourceType?: string, namespace?: string): void {
     this._switchView("details", {
       label: resourceName ?? "Detail",
       resourceName,
       resourceType,
+      // Persisted with the tab: session restore re-fetches by (type, name,
+      // namespace) — without the namespace a targeted get degrades to a
+      // cluster-scope get (RBAC-fragile) or a wrong-namespace list.
+      namespace,
     });
   }
 
@@ -653,7 +657,11 @@ export function restoreTab(st: SerializableTab): Tab {
     closable: st.closable,
     resourceName: st.resourceName,
     resourceType: st.resourceType,
-    namespace: st.namespace,
+    // "" is never a deliberate namespace (the picker has no all-namespaces
+    // option) — it leaked from a context switch whose namespace list failed
+    // to load. Restoring it would list at cluster scope (403 under
+    // restrictive RBAC), so treat it as unset.
+    namespace: st.namespace || undefined,
     filter: st.filter,
     _debouncedFilter: st.filter,
     sortColumn: st.sortColumn,

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -585,6 +585,18 @@ describe("UiStore", () => {
       expect(podsRestored.namespace).toBe("default");
     });
 
+    test("restoreTab drops an empty-string namespace (never restore cluster-scope)", () => {
+      const restored = restoreTab({
+        id: "tab-9",
+        type: "table",
+        label: "Pods",
+        closable: true,
+        resourceType: "pods",
+        namespace: "",
+      });
+      expect(restored.namespace).toBeUndefined();
+    });
+
     test("deserializeTabs rejects null / empty / invalid JSON", () => {
       expect(deserializeTabs(null)).toBeNull();
       expect(deserializeTabs("")).toBeNull();

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -31,6 +31,9 @@ export interface Resource {
 export interface ResourceList {
   items: Resource[];
   resource_type: string;
+  /** resourceVersion of the backing list — passed to the watch so it resumes
+   *  from this point instead of replaying every item as an Applied event. */
+  resource_version?: string;
 }
 
 export type ResourceType =

--- a/src/lib/utils/related-resources.test.ts
+++ b/src/lib/utils/related-resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { kindToResourceType, displayKind, getRelatedResources } from "./related-resources";
+import { kindToResourceType, resourceTypeForRef, displayKind, getRelatedResources } from "./related-resources";
 import type { Resource } from "$lib/types";
 
 function makeResource(overrides: Partial<Resource> = {}): Resource {
@@ -33,6 +33,20 @@ describe("kindToResourceType", () => {
   test("falls back to lowercase+s for unknown kinds", () => {
     expect(kindToResourceType("Widget")).toBe("widgets");
     expect(kindToResourceType("FooBar")).toBe("foobars");
+  });
+});
+
+describe("resourceTypeForRef", () => {
+  test("maps Kinds to plural resource types", () => {
+    expect(resourceTypeForRef("Deployment")).toBe("deployments");
+    expect(resourceTypeForRef("Pod")).toBe("pods");
+    expect(resourceTypeForRef("HorizontalPodAutoscaler")).toBe("hpa");
+  });
+
+  test("passes plurals through verbatim (never 'podss')", () => {
+    expect(resourceTypeForRef("pods")).toBe("pods");
+    expect(resourceTypeForRef("deployments")).toBe("deployments");
+    expect(resourceTypeForRef("hpa")).toBe("hpa");
   });
 });
 

--- a/src/lib/utils/related-resources.ts
+++ b/src/lib/utils/related-resources.ts
@@ -41,6 +41,17 @@ export function kindToResourceType(kind: string): string {
   return KIND_TO_RESOURCE_TYPE[kind] ?? kind.toLowerCase() + "s";
 }
 
+/**
+ * Normalize a "type or Kind" reference (as stored in restored tabs: "Pod" when
+ * opened from the table, "pods" from related-resource nav) to the plural
+ * resource type list_resources expects. Unlike kindToResourceType, an input
+ * that is not a known Kind passes through VERBATIM — it is already a plural
+ * ("pods" must not become "podss").
+ */
+export function resourceTypeForRef(typeOrKind: string): string {
+  return KIND_TO_RESOURCE_TYPE[typeOrKind] ?? typeOrKind;
+}
+
 function rel(kind: string, name: string): RelatedResource | null {
   const resourceType = KIND_TO_RESOURCE_TYPE[kind];
   if (!resourceType) return null;

--- a/src/lib/utils/tabLifecycle.test.ts
+++ b/src/lib/utils/tabLifecycle.test.ts
@@ -47,6 +47,7 @@ function mkStore(overrides: Partial<TabLifecycleK8sStore> = {}): TabLifecycleK8s
     restoreResources: () => {},
     switchNamespace: async () => {},
     loadResources: async () => {},
+    resolveResourceByRef: async () => null,
   };
   return { ...base, ...overrides };
 }
@@ -324,6 +325,64 @@ describe("handleTabSwitch", () => {
     handleTabSwitch(undefined, toTab, k8s);
 
     expect(loadResources).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleTabSwitch — restored resource tab rehydration", () => {
+  const flushMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  test("uncached details tab re-fetches by ref and selects the result", async () => {
+    const pod = mkResource("restored-pod");
+    const resolve = mock(async () => pod);
+    const store = mkStore({ resolveResourceByRef: resolve });
+    const tab = mkTab({ id: "tab-d", type: "details", resourceName: "restored-pod", resourceType: "Pod", namespace: "default" });
+
+    handleTabSwitch(undefined, tab, store, () => true);
+    expect(store.selectedResource).toBeNull(); // cleared while in flight
+    await flushMicrotasks();
+
+    expect(resolve).toHaveBeenCalledWith("Pod", "restored-pod", "default");
+    expect(tab.cachedResource).toBe(pod);
+    expect(store.selectedResource).toBe(pod);
+  });
+
+  test("result is cached but NOT selected when the tab is no longer active", async () => {
+    const pod = mkResource("restored-pod");
+    const store = mkStore({ resolveResourceByRef: async () => pod });
+    const tab = mkTab({ id: "tab-d", type: "details", resourceName: "restored-pod", resourceType: "Pod" });
+
+    handleTabSwitch(undefined, tab, store, () => false);
+    await flushMicrotasks();
+
+    expect(tab.cachedResource).toBe(pod);
+    expect(store.selectedResource).toBeNull();
+  });
+
+  test("fresh open adopts the pre-assigned selection instead of re-fetching", async () => {
+    const pod = mkResource("fresh-pod");
+    const resolve = mock(async () => null);
+    const store = mkStore({ selectedResource: pod, resolveResourceByRef: resolve });
+    const tab = mkTab({ id: "tab-d", type: "details", resourceName: "fresh-pod", resourceType: "Pod", namespace: "default" });
+
+    handleTabSwitch(undefined, tab, store, () => true);
+    await flushMicrotasks();
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(tab.cachedResource).toBe(pod);
+    expect(store.selectedResource).toBe(pod);
+  });
+
+  test("cached resource tab restores from cache without fetching", async () => {
+    const pod = mkResource("cached-pod");
+    const resolve = mock(async () => null);
+    const store = mkStore({ resolveResourceByRef: resolve });
+    const tab = mkTab({ id: "tab-d", type: "details", resourceName: "cached-pod", resourceType: "Pod", cachedResource: pod });
+
+    handleTabSwitch(undefined, tab, store, () => true);
+    await flushMicrotasks();
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(store.selectedResource).toBe(pod);
   });
 });
 

--- a/src/lib/utils/tabLifecycle.ts
+++ b/src/lib/utils/tabLifecycle.ts
@@ -19,6 +19,7 @@ export interface TabLifecycleK8sStore {
   restoreResources(resourceType: string, items: Resource[]): void;
   switchNamespace(namespace: string): Promise<void>;
   loadResources(resourceType: string): Promise<void>;
+  resolveResourceByRef(typeOrKind: string, name: string, namespace?: string): Promise<Resource | null>;
 }
 
 type TableTabType = Extract<Tab["type"], "table" | "crd-table">;
@@ -40,9 +41,10 @@ export function handleTabSwitch(
   fromTab: Tab | undefined,
   toTab: Tab,
   k8s: TabLifecycleK8sStore,
+  isTabActive: (tabId: string) => boolean = () => true,
 ): void {
   saveOutgoingTabState(fromTab, k8s);
-  restoreIncomingSelection(toTab, k8s);
+  restoreIncomingSelection(toTab, k8s, isTabActive);
 
   if (!isTableTab(toTab) || !toTab.resourceType) return;
 
@@ -73,10 +75,48 @@ function saveOutgoingTabState(
   }
 }
 
-function restoreIncomingSelection(toTab: Tab, k8s: TabLifecycleK8sStore): void {
-  if (RESOURCE_TAB_TYPES.has(toTab.type) && toTab.cachedResource) {
+function restoreIncomingSelection(
+  toTab: Tab,
+  k8s: TabLifecycleK8sStore,
+  isTabActive: (tabId: string) => boolean,
+): void {
+  if (!RESOURCE_TAB_TYPES.has(toTab.type)) return;
+
+  if (toTab.cachedResource) {
     k8s.selectResource(toTab.cachedResource);
+    return;
   }
+  if (!toTab.resourceName || !toTab.resourceType) return;
+
+  // No cache: a resource tab restored from a previous session (cachedResource
+  // is ephemeral, never persisted). Without a re-fetch its view stays empty
+  // forever — App.initApp only hydrates the tab that was ACTIVE at boot.
+  //
+  // Fresh open (openResourceDetail): the selection was assigned right before
+  // this hook fired and the tab's cachedResource is set right after — the
+  // store already holds this tab's resource, so adopt it instead of
+  // clearing + re-fetching.
+  const sel = k8s.selectedResource;
+  if (
+    sel &&
+    sel.metadata?.name === toTab.resourceName &&
+    (!toTab.namespace || sel.metadata?.namespace === toTab.namespace)
+  ) {
+    toTab.cachedResource = sel;
+    return;
+  }
+
+  // Clear the outgoing tab's resource so the view never shows a stale,
+  // unrelated object while the fetch is in flight; publish the result as the
+  // visible selection only if the tab is still the active one.
+  k8s.selectResource(null);
+  void k8s
+    .resolveResourceByRef(toTab.resourceType, toTab.resourceName, toTab.namespace)
+    .then((found) => {
+      if (!found) return;
+      toTab.cachedResource = found;
+      if (isTabActive(toTab.id)) k8s.selectResource(found);
+    });
 }
 
 function restoreFromCache(toTab: Tab, k8s: TabLifecycleK8sStore): void {


### PR DESCRIPTION
## Summary

Benchmark-driven pass over CPU/memory usage, plus a chain of session-restore bugs it surfaced while testing against a real cluster.

### Performance

- **Watch events ship the lean list projection.** Watch previously projected objects verbatim, so every event replaced a lean list row with the full object (entire pod spec, last-applied annotation…) — renderer memory grew with cluster churn and IPC paid the full spec per event. Projections are now shared (`listProjectionFor` in `electron/k8s/resource-mapping.ts`) between `list_resources` and the watch. Measured on a realistic pod: **14.9 KB → 1.6 KB per event (−89%)**, batch serialization **−64% CPU**.
- **Informer-style watch resume.** The watch now starts from the list's `resourceVersion` (with `allowWatchBookmarks`), so connects and periodic server-side stream closes no longer replay the entire list as `ADDED` events, and routine reconnects no longer trigger a full renderer relist. `410 Gone` clears the RV and falls back to the classic replay + `Resync` path.
- **Renderer skips no-op replays.** `Applied` events whose `resourceVersion` matches the stored row are dropped, avoiding whole-table re-renders after navigation/restore.
- **CRD table virtualized** (same pattern as `ResourceTable`). At 10k items: **10,000 DOM rows → ~31**, mount **418 ms → 218 ms**, scroll p95 1.1 ms. A new perf-bench test asserts the virtualization invariant (`renderedRows < 200`).

### Bug fixes (found testing the app live)

- **Settings never persisted under Electron.** `invoke("save_settings", { settings })` passed a Svelte 5 `$state` proxy; Electron's structured clone throws `An object could not be cloned` on proxies, so every save failed silently (Tauri JSON-serialized and masked this). `invoke()` now deep-plain-clones object args centrally.
- **Restored tabs showed empty views.** `cachedResource` is ephemeral, and only the boot-active tab was rehydrated — any other restored details/logs/yaml/terminal tab stayed blank forever. Tab switches now rehydrate uncached resource tabs by their persisted `(type, name, namespace)` ref, with a race guard so a slow fetch can't overwrite another tab's selection. Detail tabs persist their namespace; a resource that no longer exists shows an explicit "Resource not available" state instead of a blank panel.
- **Cluster-scope 403s from restored namespaces.** An empty-string namespace could leak into persisted state (context switch whose namespace listing failed) and made every list run at cluster scope — 403 under restrictive RBAC. `k8sStore.restoreNamespace()` now validates restored namespaces against the connected cluster (rejects `""` and namespaces from other contexts), and `switchContext` can no longer fall back to `""`.
- **Kind vs plural in restore fallback.** Restored tabs store `resourceType` as a Kind (`"Deployment"`) when opened from the table; the list fallback expected plurals and rejected it. Added `resourceTypeForRef` normalization.
- **False "No pods found" flash on boot.** `isLoading` is deliberately delayed 200 ms, so the empty state rendered before the first list arrived. New `viewLoaded` flag keeps the loading skeleton up until the first list of a view completes — no added latency, rows render the same frame they did before.
- Watch now supports `vpa`/`wpa`; `DetailPanel` exposes `data-testid="detail-panel"` (the detail-open benchmark was silently measuring its own 240-frame timeout).

### Benchmarks & tests

- `playwright.bench.config.ts`: dedicated port (1421, `strictPort`, no server reuse) so benches can never silently measure a dev server from another worktree (this happened — baseline numbers came from a different branch).
- New e2e coverage: background-tab rehydration, boot loading skeleton (with a per-frame observer so the flash can't pass vacuously), CRD virtualization invariant. Each was verified red without its fix.
- 828 unit tests, 6 e2e (mocked cluster), electron typecheck, and svelte-check all green; frontend perf bench unchanged (scroll p95 3 ms @ 10k rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)