### PR TITLE
test: fix the drain integration test's dependence on pod scheduling

### DIFF
--- a/electron/integration/node-ops.itest.ts
+++ b/electron/integration/node-ops.itest.ts
@@ -213,18 +213,54 @@ describe('integration: node ops', { skip: !enabled }, () => {
     assert.ok(phases.includes('listing'));
     assert.ok(phases.includes('done'));
 
-    // The evicted workloads come back — on the other worker, since this one is
-    // cordoned. That is the whole point of the operation.
-    await waitFor(
-      async () => {
-        const remaining = await podsOn(node);
-        return remaining.every((p) => {
-          const owner = (p.metadata.owner_references as Array<{ kind?: string }> | null) ?? [];
-          return owner.some((o) => o.kind === 'DaemonSet');
-        });
-      },
-      { timeoutMs: 60_000, label: 'the drained node to hold only DaemonSet pods' },
+    // Everything the drain reported as EVICTED has to actually leave the node —
+    // that is the claim under test, and those workloads come back on the other
+    // worker since this one is cordoned.
+    //
+    // What may legitimately stay: DaemonSet pods, and any pod the drain openly
+    // reported as skipped or failed. That second case is not hypothetical. The
+    // seed's `guarded` Deployment runs one replica behind a minAvailable:1 PDB,
+    // so its pod can NEVER be evicted (the next test asserts exactly that), and
+    // the scheduler is free to place it on either worker. Whenever it landed on
+    // the node this test drains, the old "only DaemonSet pods" predicate could
+    // never come true and the test failed after the full 60s — which is what
+    // made this the suite's flakiest test rather than a real signal.
+    //
+    // Asserting against the drain's own report keeps the teeth (an evicted pod
+    // that lingers still fails) while making the outcome independent of where
+    // the scheduler happened to put an unevictable pod.
+    const accountedFor = new Set(
+      [...result.skipped, ...result.failed].map((p) => `${p.namespace}/${p.pod}`),
     );
+    const isDaemonSetPod = (p: Resource): boolean => {
+      const owner = (p.metadata.owner_references as Array<{ kind?: string }> | null) ?? [];
+      return owner.some((o) => o.kind === 'DaemonSet');
+    };
+
+    // Tracked outside the poll so the failure can name the offenders. The old
+    // message said only "timed out", which is why this survived three branches
+    // before anyone could tell what it was actually waiting on.
+    let lingering: string[] = [];
+    try {
+      await waitFor(
+        async () => {
+          lingering = (await podsOn(node))
+            .filter((p) => !isDaemonSetPod(p))
+            .filter((p) => !accountedFor.has(`${p.metadata.namespace}/${p.metadata.name}`))
+            .map((p) => `${p.metadata.namespace}/${p.metadata.name}`);
+          return lingering.length === 0;
+        },
+        { timeoutMs: 60_000, label: 'the evicted pods to leave the drained node' },
+      );
+    } catch (err) {
+      assert.fail(
+        `pods the drain claimed to evict are still on ${node}: ${lingering.join(', ')}\n` +
+          `evicted=${JSON.stringify(result.evicted)}\n` +
+          `skipped=${JSON.stringify(result.skipped)}\n` +
+          `failed=${JSON.stringify(result.failed)}\n` +
+          `(${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
   });
 
   test('a PodDisruptionBudget blocks eviction until the drain times out', async (t) => {


### PR DESCRIPTION
`drain evicts, skips DaemonSets, and reports progress` is the flakiest test in the suite. It has failed on at least three unrelated branches, always with the same message and always after the same ~106s:

| Branch | Date | Failure |
|---|---|---|
| `nmengual/new-features` | Aug 9, 10:07 | `Timed out after 60000ms waiting for the drained node to hold only DaemonSet pods` |
| `nmengual/new-features` | Aug 9, 10:24 | identical |
| `feat/yaml-editor-intellisense` | Aug 10, 15:49 | identical |
| `feat/yaml-editor-intellisense` | Aug 10, 16:03 | identical |
| `nmengual/perf-electron-startup` | Aug 10, 19:27 & 19:41 | identical |

A YAML-intellisense branch cannot break node draining. The standard response so far has been to re-run until it goes green.

## Root cause

Not a slow cluster — a precondition the test never establishes.

`fixtures/seed.yaml` declares a `guarded` Deployment with `replicas: 1` behind a PodDisruptionBudget with `minAvailable: 1`. Its pod is therefore **permanently unevictable**. That is deliberate: it is exactly what the next test, *"a PodDisruptionBudget blocks eviction until the drain times out"*, asserts.

Nothing pins that pod to a node, so the scheduler is free to put it on either worker. When it lands on the worker this test drains:

1. `drain_node` cannot evict it, and burns its full `timeoutSeconds: 45`.
2. The pod stays on the node with its `nodeName` intact.
3. The follow-up wait requires **every** remaining pod to be DaemonSet-owned — so it can never come true, and times out after 60s.

`45 + 60` accounts for the constant ~106s. Scheduler placement accounts for the ~50% failure rate.

## The fix

Assert what `drain_node` actually promises: every pod it reported as **evicted** leaves the node. Pods it openly reported as **skipped** or **failed** are allowed to remain, as are DaemonSet pods.

This keeps the assertion's teeth — an evicted pod that lingers still fails the test — while making the outcome independent of where the scheduler placed an unevictable pod.

I deliberately did not just raise the timeout. No timeout is long enough: with the PDB in place the old predicate is unsatisfiable, not slow. Pinning the `guarded` pod away from the target node was the other option, but that would mean the drain path is never exercised against a node holding a blocked pod — a case worth covering rather than avoiding.

The failure message now names the offending pods and dumps the drain's `evicted` / `skipped` / `failed` report. The old message was just the timeout string, with no indication of what remained — which is why this survived three branches without anyone being able to diagnose it.

`drain_node` itself is untouched; this is an assertion change only.

## Validation

- `npm run typecheck:electron` — clean.
- The suite loads and skips cleanly without `KDASH_TEST_CONTEXT`.
- **I could not run the integration suite locally** (no Kind cluster available here), so CI is the real check.

One caveat when reading CI on this PR: because the bug depends on scheduler placement, **a single green run is not proof** — the old test passed roughly half the time too. I re-ran the integration job several times to build confidence; results in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
