### PR TITLE
fix(logs): stop the pod log viewer getting stuck on "Connecting to log stream..."

### DIFF
--- a/electron/handlers/logs.test.ts
+++ b/electron/handlers/logs.test.ts
@@ -1,0 +1,330 @@
+import { test, expect, describe, beforeEach, afterEach, mock } from 'bun:test';
+
+import type { HandlerCtx, HandlerMap } from '../dispatch';
+
+// The handler talks to the cluster through apiStream; stub it so these tests
+// exercise the streaming state machine (batching, epoch guards, terminal
+// status) rather than the network.
+/** Responses staged for upcoming apiStream calls, consumed in order. */
+let responseQueue: Array<() => Promise<Response>> = [];
+
+mock.module('../k8s/api', () => ({
+  META_ACCEPT: 'application/json',
+  apiGet: () => Promise.reject(new Error('not used')),
+  apiStream: (_path: string, _query: URLSearchParams, signal: AbortSignal) => {
+    const next = responseQueue.shift();
+    if (!next) throw new Error('test did not stage a response');
+    return next().then((resp) => {
+      // Mimic fetch: aborting the signal tears the body down.
+      signal.addEventListener('abort', () => {
+        void resp.body?.cancel().catch(() => {});
+      });
+      return resp;
+    });
+  },
+}));
+
+const { register, stopAllLogStreams } = await import('./logs');
+
+interface Emitted {
+  channel: string;
+  payload: unknown;
+}
+
+let emitted: Emitted[] = [];
+let handlers: HandlerMap;
+let ctx: HandlerCtx;
+
+/**
+ * Stage a Response whose body is a stream this test drives by hand. `connectMs`
+ * delays the connect itself, to model one pod still dialling while another is
+ * already streaming.
+ */
+function stagedBody(connectMs = 0): {
+  push: (chunk: string) => void;
+  close: () => void;
+  fail: (err: Error) => void;
+} {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  responseQueue.push(
+    () =>
+      new Promise<Response>((resolve) =>
+        setTimeout(() => resolve(new Response(body, { status: 200 })), connectMs),
+      ),
+  );
+  return {
+    push: (chunk: string) => controller.enqueue(encoder.encode(chunk)),
+    close: () => controller.close(),
+    fail: (err: Error) => controller.error(err),
+  };
+}
+
+/** Stage a connect that fails. */
+function stagedFailure(message: string, times = 1): void {
+  for (let i = 0; i < times; i++) {
+    responseQueue.push(() => Promise.reject(new Error(message)));
+  }
+}
+
+/** Give the handler's background pump a chance to drain and flush (50ms debounce). */
+function settle(ms = 90): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function lines(): string[] {
+  return emitted.filter((e) => e.channel === 'log-lines').flatMap((e) => e.payload as string[]);
+}
+
+function statuses(): Array<{ state: string; message?: string }> {
+  return emitted
+    .filter((e) => e.channel === 'log-stream-status')
+    .map((e) => e.payload as { state: string; message?: string });
+}
+
+beforeEach(() => {
+  emitted = [];
+  handlers = new Map();
+  ctx = { emit: (channel, payload) => emitted.push({ channel, payload }) } as HandlerCtx;
+  register(handlers, ctx);
+});
+
+afterEach(() => {
+  stopAllLogStreams();
+  responseQueue = [];
+});
+
+describe('stream_pod_logs', () => {
+  test('emits complete lines and strips the newline terminators', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('hello\nworld\r\n');
+    await settle();
+
+    expect(lines()).toEqual(['hello', 'world']);
+  });
+
+  test('holds back a partial line until its newline arrives', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('half');
+    await settle();
+    expect(lines()).toEqual([]);
+
+    body.push('-and-half\n');
+    await settle();
+    expect(lines()).toEqual(['half-and-half']);
+  });
+
+  // A clean end already worked before; the marker and status must both fire.
+  test('a graceful end emits the [stream ended] marker and an ended status', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('only line\n');
+    body.close();
+    await settle();
+
+    expect(lines()).toEqual(['only line', '[stream ended]']);
+    expect(statuses()).toEqual([{ state: 'ended' }]);
+  });
+
+  test('a trailing line with no newline is still emitted at EOF', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('no trailing newline');
+    body.close();
+    await settle();
+
+    expect(lines()).toEqual(['no trailing newline', '[stream ended]']);
+  });
+
+  // THE REGRESSION: a stream that dies mid-flight used to tell the renderer
+  // nothing at all, leaving it stuck on "Connecting to log stream...".
+  test('a transport error reports an error status instead of going silent', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('before the drop\n');
+    await settle();
+    body.fail(new Error('connection reset by peer'));
+    await settle();
+
+    expect(lines()).toContain('before the drop');
+    expect(statuses()).toHaveLength(1);
+    expect(statuses()[0].state).toBe('error');
+    expect(statuses()[0].message).toContain('connection reset by peer');
+  });
+
+  test('rejects when the required name arg is missing', async () => {
+    stagedBody();
+    await expect(handlers.get('stream_pod_logs')!({ namespace: 'default' }, ctx)).rejects.toThrow(
+      /missing required arg "name"/,
+    );
+  });
+
+  test('wraps a connect failure with the pod coordinates', async () => {
+    stagedFailure('403 Forbidden');
+    await expect(
+      handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'kube-system' }, ctx),
+    ).rejects.toThrow(/Failed to start log stream for kube-system\/web-0: 403 Forbidden/);
+  });
+});
+
+describe('stop_log_stream', () => {
+  // A deliberate stop is a transition the renderer already knows about; telling
+  // it the stream "errored" would flip the viewer into a false failure state.
+  test('stopping emits no terminal status and silences later output', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('before stop\n');
+    await settle();
+    handlers.get('stop_log_stream')!({}, ctx);
+
+    body.push('after stop\n');
+    body.fail(new Error('aborted'));
+    await settle();
+
+    expect(lines()).toEqual(['before stop']);
+    expect(statuses()).toEqual([]);
+  });
+
+  test('restarting supersedes the previous stream without a status', async () => {
+    const first = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+    first.push('from first\n');
+    await settle();
+
+    const second = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-1', namespace: 'default' }, ctx);
+
+    // The superseded stream must not be able to emit anything more.
+    first.push('late from first\n');
+    first.fail(new Error('aborted'));
+    second.push('from second\n');
+    await settle();
+
+    expect(lines()).toEqual(['from first', 'from second']);
+    expect(statuses()).toEqual([]);
+  });
+});
+
+describe('stream_multi_pod_logs', () => {
+  test('prefixes each line with its pod name', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_multi_pod_logs')!({ pods: ['web-a'], namespace: 'default' }, ctx);
+
+    body.push('hello\n');
+    await settle();
+
+    expect(lines()).toEqual(['[web-a] hello']);
+  });
+
+  test('reports an error status when no pod stream could be started', async () => {
+    stagedFailure('404 Not Found', 2);
+    await handlers.get('stream_multi_pod_logs')!(
+      { pods: ['gone-a', 'gone-b'], namespace: 'default' },
+      ctx,
+    );
+
+    expect(lines()).toEqual(['[gone-a] [error: 404 Not Found]', '[gone-b] [error: 404 Not Found]']);
+    expect(statuses()).toEqual([{ state: 'error', message: 'No pod log streams could be started' }]);
+  });
+
+  test('an empty pod list reports rather than hanging', async () => {
+    await handlers.get('stream_multi_pod_logs')!({ pods: [], namespace: 'default' }, ctx);
+    expect(statuses()).toEqual([{ state: 'error', message: 'No pods to stream' }]);
+  });
+
+  // Pods are dialled one after another, so the reader count legitimately sits at
+  // zero between "the first pod's stream finished" and "the second pod connected".
+  // Reporting the session as ended there would blank a viewer that is about to
+  // receive the rest of the pods' output.
+  test('one pod finishing while another is still connecting is not an ended session', async () => {
+    const a = stagedBody();
+    const b = stagedBody(60);
+
+    const pending = handlers.get('stream_multi_pod_logs')!(
+      { pods: ['pod-a', 'pod-b'], namespace: 'default' },
+      ctx,
+    );
+
+    // pod-a is streaming; pod-b is still dialling.
+    await settle(15);
+    a.push('from a\n');
+    a.close();
+    await settle(25);
+
+    expect(statuses()).toEqual([]);
+
+    await pending;
+    b.push('from b\n');
+    await settle();
+
+    expect(lines()).toEqual(['[pod-a] from a', '[pod-b] from b']);
+    expect(statuses()).toEqual([]);
+  });
+
+  // One pod dropping is not the session failing while its siblings still stream.
+  test('one pod erroring does not end the session while another still streams', async () => {
+    const a = stagedBody();
+    const b = stagedBody();
+    await handlers.get('stream_multi_pod_logs')!(
+      { pods: ['pod-a', 'pod-b'], namespace: 'default' },
+      ctx,
+    );
+
+    a.fail(new Error('econnreset'));
+    await settle();
+
+    // The failure is visible as a line, but the session is still live.
+    expect(lines()).toContain('[pod-a] [error: econnreset]');
+    expect(statuses()).toEqual([]);
+
+    b.push('still going\n');
+    await settle();
+    expect(lines()).toContain('[pod-b] still going');
+    expect(statuses()).toEqual([]);
+  });
+
+  test('a pod failure surfaces once every pod has settled', async () => {
+    const a = stagedBody();
+    const b = stagedBody();
+    await handlers.get('stream_multi_pod_logs')!(
+      { pods: ['pod-a', 'pod-b'], namespace: 'default' },
+      ctx,
+    );
+
+    a.fail(new Error('econnreset'));
+    b.close();
+    await settle();
+
+    expect(statuses()).toEqual([{ state: 'error', message: 'econnreset' }]);
+  });
+
+  test('reports ended once every pod stream has drained', async () => {
+    const a = stagedBody();
+    const b = stagedBody();
+    await handlers.get('stream_multi_pod_logs')!(
+      { pods: ['pod-a', 'pod-b'], namespace: 'default' },
+      ctx,
+    );
+
+    a.close();
+    await settle();
+    expect(statuses()).toEqual([]);
+
+    b.close();
+    await settle();
+    expect(statuses()).toEqual([{ state: 'ended' }]);
+  });
+});

--- a/electron/handlers/logs.test.ts
+++ b/electron/handlers/logs.test.ts
@@ -164,6 +164,22 @@ describe('stream_pod_logs', () => {
     expect(statuses()[0].message).toContain('connection reset by peer');
   });
 
+  // The lines just before a crash are the ones worth reading. A drop inside the
+  // batch debounce window must not take them with it.
+  test('lines still buffered when the stream drops are delivered, then the error', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    body.push('last words\n');
+    // Long enough for the pump to buffer the line, shorter than the 50ms flush
+    // debounce, so the batch is still unflushed when the stream dies.
+    await settle(10);
+    body.fail(new Error('econnreset'));
+    await settle();
+
+    expect(lines()).toEqual(['last words', '[error: econnreset]']);
+  });
+
   test('rejects when the required name arg is missing', async () => {
     stagedBody();
     await expect(handlers.get('stream_pod_logs')!({ namespace: 'default' }, ctx)).rejects.toThrow(

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -1,5 +1,4 @@
-// Logs streaming handler — ports the Tauri "logs" subsystem to
-// @kubernetes/client-node's Log streaming API.
+// Logs streaming handler.
 //
 // Rust source ported (faithful): src-tauri/src/k8s/logs.rs
 //
@@ -9,13 +8,19 @@
 //                               line prefixed with `[pod-name] `
 //   - stop_log_stream        -> takes NO args; aborts whatever is streaming
 //
-// Event channel: "log-lines"
-//   PAYLOAD SHAPE: string[]  (a batch of COMPLETE log lines, no trailing
-//   newline per line). The renderer (src/lib/components/logs/LogViewer.svelte)
-//   does listen<string[]>("log-lines", e => for (line of e.payload) ...), so
-//   every emit MUST be a string[].
+// Event channels:
+//   "log-lines"
+//     PAYLOAD SHAPE: string[]  (a batch of COMPLETE log lines, no trailing
+//     newline per line). The renderer (src/lib/components/logs/LogViewer.svelte)
+//     does listen<string[]>("log-lines", e => for (line of e.payload) ...), so
+//     every emit MUST be a string[].
+//   "log-stream-status"
+//     PAYLOAD SHAPE: { state: 'ended' | 'error'; message?: string }
+//     Emitted at most once per logical stream, when EVERY pod reader in it has
+//     settled. A deliberate stop/restart emits nothing — the renderer drove that
+//     transition and must not be told the stream died.
 //
-// Renderer arg keys (source of truth — src/.../LogViewer.svelte ~280-315):
+// Renderer arg keys (source of truth — src/.../log-viewer.ts buildStreamRequest):
 //   stream_pod_logs:       { name, namespace, container, tailLines,
 //                            sinceSeconds, timestamps, previous }
 //   stream_multi_pod_logs: { pods, namespace, container, tailLines,
@@ -24,36 +29,63 @@
 //    sends camelCase tailLines/sinceSeconds.)
 //
 // Session semantics (mirrors the Rust single global STOP_FLAG): there is ONE
-// active logical log stream at a time. Starting a new stream aborts any prior
-// one. stop_log_stream aborts all underlying streams and clears state. Each
-// stream is also cleaned up when it ends/errors on its own.
+// active logical log stream at a time, held in `activeSession`. Starting a new
+// stream aborts any prior one. Session identity IS the staleness check — every
+// callback compares against `activeSession` before emitting anything.
+//
+// WHY THIS DOES NOT USE @kubernetes/client-node's Log helper
+// ----------------------------------------------------------
+// Log.log() does `response.body.pipe(sink)` and hands back only an
+// AbortController — the response body itself stays private. Node's pipe()
+// forwards NOTHING to the destination when the source dies abnormally: a source
+// error emits no 'error', no 'unpipe' and no 'close' on the destination, and
+// the sink's final() (which is what produced the "[stream ended]" marker) only
+// runs on a graceful end().
+//
+// So when a followed log stream dropped mid-flight — pod restarted, apiserver
+// idle timeout, network blip, credentials expired — the renderer was told
+// nothing at all and sat on "Connecting to log stream..." indefinitely. Owning
+// the fetch means we observe all three endings (clean EOF, transport error,
+// abort) and can report the first two.
 
-import { Writable } from 'node:stream';
-
-import { Log } from '@kubernetes/client-node';
+import { AddOptionsToSearchParams, type LogOptions } from '@kubernetes/client-node';
 
 import type { HandlerCtx, HandlerMap } from '../dispatch';
-import { kc } from '../k8s/client';
+import { apiStream } from '../k8s/api';
 
 const LOG_CHANNEL = 'log-lines';
+const STATUS_CHANNEL = 'log-stream-status';
 
 /** Maximum lines to buffer before emitting a batch (mirrors Rust LOG_BATCH_SIZE). */
 const LOG_BATCH_SIZE = 20;
 /** Maximum time (ms) to wait before flushing a partial batch (mirrors Rust LOG_FLUSH_INTERVAL_MS). */
 const LOG_FLUSH_INTERVAL_MS = 50;
 
+/** Payload of STATUS_CHANNEL. Mirrors StreamStatus in src/.../log-viewer.ts. */
+interface StreamStatus {
+  state: 'ended' | 'error';
+  message?: string;
+}
+
 /**
  * One active logical stream = N underlying abortable per-pod readers. The Rust
  * kept a single global active slot; we do the same with one module-level
- * session object. `epoch` guards against stale callbacks emitting after stop.
+ * session object, and use its identity as the staleness check.
  */
 interface LogSession {
-  epoch: number;
   controllers: AbortController[];
 }
 
 let activeSession: LogSession | null = null;
-let epochCounter = 0;
+
+/** True once this session has been stopped or superseded — emit nothing more. */
+function isStale(session: LogSession): boolean {
+  return activeSession !== session;
+}
+
+function messageOf(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 /** Coerce an optional renderer arg to a string, treating null/'' as absent. */
 function optStr(v: unknown): string | undefined {
@@ -71,19 +103,11 @@ function optBool(v: unknown): boolean | undefined {
 }
 
 /**
- * Build the @kubernetes/client-node Log options from the common optional fields.
- * Mirrors the Rust build_log_params: follow is always true; the rest are only
- * set when present.
+ * Build the log query options from the common optional fields. Mirrors the Rust
+ * build_log_params: follow is always true; the rest are only set when present.
  */
-function buildLogOptions(args: Record<string, unknown>): {
-  follow: true;
-  container?: string;
-  tailLines?: number;
-  sinceSeconds?: number;
-  timestamps?: boolean;
-  previous?: boolean;
-} {
-  const opts: ReturnType<typeof buildLogOptions> = { follow: true };
+function buildLogOptions(args: Record<string, unknown>): LogOptions {
+  const opts: LogOptions = { follow: true };
   const tailLines = optNum(args.tailLines);
   if (tailLines !== undefined) opts.tailLines = tailLines;
   const sinceSeconds = optNum(args.sinceSeconds);
@@ -96,35 +120,29 @@ function buildLogOptions(args: Record<string, unknown>): {
 }
 
 /**
- * A Writable sink that splits the raw byte stream on newlines, batches complete
- * lines, and flushes them as string[] via ctx.emit. Mirrors the Rust
- * spawn_log_reader: coalesce on a batch-size cap OR a short debounce timer, and
- * (for single-pod streams) emit a trailing "[stream ended]" marker on close.
- *
- * `linePrefix`, when set, prefixes each emitted line with `[prefix] ` (multi).
+ * Batches complete log lines and flushes them as string[] over LOG_CHANNEL,
+ * coalescing on a batch-size cap OR a short debounce timer (mirrors the Rust
+ * spawn_log_reader). `linePrefix`, when set, prefixes each line with
+ * `[prefix] ` (multi-pod streams).
  */
-function makeLineSink(
-  ctx: HandlerCtx,
-  session: LogSession,
-  linePrefix: string | undefined,
-): Writable {
-  let partial = '';
+function makeBatcher(ctx: HandlerCtx, session: LogSession, linePrefix: string | undefined) {
   let batch: string[] = [];
   let flushTimer: NodeJS.Timeout | null = null;
 
-  const isStale = () => activeSession !== session || session.epoch !== epochCounter;
+  const decorate = (line: string): string =>
+    linePrefix !== undefined ? `[${linePrefix}] ${line}` : line;
 
-  const clearTimer = () => {
+  const clearTimer = (): void => {
     if (flushTimer) {
       clearTimeout(flushTimer);
       flushTimer = null;
     }
   };
 
-  const flush = () => {
+  const flush = (): void => {
     clearTimer();
     if (batch.length === 0) return;
-    if (isStale()) {
+    if (isStale(session)) {
       batch = [];
       return;
     }
@@ -133,9 +151,8 @@ function makeLineSink(
     ctx.emit(LOG_CHANNEL, out);
   };
 
-  const pushLine = (line: string) => {
-    const formatted = linePrefix !== undefined ? `[${linePrefix}] ${line}` : line;
-    batch.push(formatted);
+  const push = (line: string): void => {
+    batch.push(decorate(line));
     if (batch.length >= LOG_BATCH_SIZE) {
       flush();
     } else if (!flushTimer) {
@@ -143,40 +160,134 @@ function makeLineSink(
     }
   };
 
-  const emitOne = (line: string) => {
-    if (isStale()) return;
-    ctx.emit(LOG_CHANNEL, [linePrefix !== undefined ? `[${linePrefix}] ${line}` : line]);
+  const emitOne = (line: string): void => {
+    if (isStale(session)) return;
+    ctx.emit(LOG_CHANNEL, [decorate(line)]);
   };
 
-  return new Writable({
-    write(chunk: Buffer, _enc, cb) {
-      partial += chunk.toString('utf8');
+  return { push, flush, emitOne, clearTimer };
+}
+
+/**
+ * Read a log response body to completion, splitting on newlines and handing
+ * whole lines to the batcher. Resolves on clean EOF; rejects on transport error
+ * or abort.
+ */
+async function pumpBody(
+  session: LogSession,
+  body: ReadableStream<Uint8Array>,
+  batcher: ReturnType<typeof makeBatcher>,
+): Promise<void> {
+  const decoder = new TextDecoder();
+  const reader = body.getReader();
+  let partial = '';
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      // Stop feeding a stream nobody is listening to any more.
+      if (isStale(session)) return;
+      partial += decoder.decode(value, { stream: true });
       let idx = partial.indexOf('\n');
       while (idx !== -1) {
         // Strip the trailing '\n' (and a preceding '\r' if present) — the
         // renderer expects complete lines with no trailing newline.
         let line = partial.slice(0, idx);
         if (line.endsWith('\r')) line = line.slice(0, -1);
-        pushLine(line);
+        batcher.push(line);
         partial = partial.slice(idx + 1);
         idx = partial.indexOf('\n');
       }
-      cb();
-    },
-    final(cb) {
-      // Flush any buffered complete lines plus a trailing partial line (no
-      // newline terminator from the server, e.g. last line of a non-follow log).
-      if (partial.length > 0) {
-        pushLine(partial);
-        partial = '';
-      }
-      flush();
+    }
+    // A trailing line with no newline terminator from the server.
+    partial += decoder.decode();
+    if (partial.length > 0) batcher.push(partial);
+  } finally {
+    reader.releaseLock();
+  }
+  batcher.flush();
+}
+
+/**
+ * Open ONE pod's log stream. Awaits only until the response headers arrive, so
+ * the caller's command resolves on a real connection; `drained` then settles
+ * whenever that pod's stream finishes, cleanly or otherwise.
+ */
+async function openStream(
+  ctx: HandlerCtx,
+  session: LogSession,
+  namespace: string,
+  podName: string,
+  container: string,
+  args: Record<string, unknown>,
+  linePrefix: string | undefined,
+): Promise<{ drained: Promise<void> }> {
+  const controller = new AbortController();
+  const query = new URLSearchParams();
+  query.set('container', container);
+  AddOptionsToSearchParams(buildLogOptions(args), query);
+
+  const path = `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods/${encodeURIComponent(podName)}/log`;
+  const resp = await apiStream(path, query, controller.signal);
+
+  // A stop/restart raced the connect: drop it. There is no reader to wait on,
+  // and the session is already stale so nothing will be reported for it.
+  if (isStale(session)) {
+    controller.abort();
+    void resp.body?.cancel().catch(() => {});
+    return { drained: Promise.resolve() };
+  }
+
+  // Treated as a connect failure rather than a rejected `drained`: an eagerly
+  // rejected promise would be unhandled until allSettled attaches to it.
+  if (!resp.body) {
+    controller.abort();
+    throw new Error('empty log response');
+  }
+
+  session.controllers.push(controller);
+  const batcher = makeBatcher(ctx, session, linePrefix);
+
+  // Deliberately NOT awaited — see the doc comment above.
+  const drained = pumpBody(session, resp.body, batcher).then(
+    () => {
+      batcher.clearTimer();
       // Single-pod streams emit a "[stream ended]" marker (Rust line_prefix.is_none()).
-      if (linePrefix === undefined) {
-        emitOne('[stream ended]');
-      }
-      cb();
+      if (linePrefix === undefined) batcher.emitOne('[stream ended]');
     },
+    (err: unknown) => {
+      batcher.clearTimer();
+      batcher.emitOne(`[error: ${messageOf(err)}]`);
+      // Rethrow so the session's terminal status sees this reader as failed.
+      throw err;
+    },
+  );
+
+  return { drained };
+}
+
+/**
+ * Emit the session's single terminal status once EVERY reader has settled.
+ *
+ * Waiting for all of them is what keeps a multi-pod stream honest: readers are
+ * dialled one after another, so any "are we done yet" counter would see zero
+ * live readers in the gap between one pod finishing and the next connecting,
+ * and would end the session early. Likewise one pod dropping is not the whole
+ * session failing while its siblings are still streaming.
+ */
+function reportWhenDrained(
+  ctx: HandlerCtx,
+  session: LogSession,
+  drains: Array<Promise<void>>,
+): void {
+  void Promise.allSettled(drains).then((results) => {
+    if (isStale(session)) return;
+    const failure = results.find((r) => r.status === 'rejected');
+    const status: StreamStatus = failure
+      ? { state: 'error', message: messageOf(failure.reason) }
+      : { state: 'ended' };
+    ctx.emit(STATUS_CHANNEL, status);
   });
 }
 
@@ -184,9 +295,9 @@ function makeLineSink(
 function stopActive(): void {
   if (!activeSession) return;
   const session = activeSession;
+  // Clear FIRST: every callback checks identity, so this is what makes the
+  // whole session stale before we start aborting.
   activeSession = null;
-  // Bump epoch so any in-flight sink callbacks become stale and stop emitting.
-  epochCounter += 1;
   for (const controller of session.controllers) {
     try {
       controller.abort();
@@ -196,10 +307,18 @@ function stopActive(): void {
   }
 }
 
+/** Replace whatever is streaming with a fresh single-slot session. */
+function beginSession(): LogSession {
+  stopActive();
+  const session: LogSession = { controllers: [] };
+  activeSession = session;
+  return session;
+}
+
 /**
  * Start streaming logs for ONE pod/container. Aborts any prior active stream
- * first (single-slot semantics, like the Rust STOP_FLAG reset). Returns once
- * the stream has been kicked off; lines arrive asynchronously via "log-lines".
+ * first (single-slot semantics, like the Rust STOP_FLAG reset). Resolves once
+ * the stream is established; lines arrive asynchronously via "log-lines".
  */
 async function streamPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Promise<null> {
   const name = optStr(args.name);
@@ -209,33 +328,17 @@ async function streamPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Pr
     throw new Error('stream_pod_logs: missing required arg "name"');
   }
 
-  stopActive();
-  const session: LogSession = { epoch: ++epochCounter, controllers: [] };
-  activeSession = session;
+  const session = beginSession();
 
-  const log = new Log(kc());
-  const sink = makeLineSink(ctx, session, undefined);
-  const options = buildLogOptions(args);
-
+  let drained: Promise<void>;
   try {
-    const controller = await log.log(namespace, name, container, sink, options);
-    // If stop arrived while we were awaiting, abort immediately.
-    if (activeSession !== session) {
-      try {
-        controller.abort();
-      } catch {
-        /* ignore */
-      }
-      return null;
-    }
-    session.controllers.push(controller);
+    ({ drained } = await openStream(ctx, session, namespace, name, container, args, undefined));
   } catch (err) {
     if (activeSession === session) activeSession = null;
-    throw new Error(
-      `Failed to start log stream for ${namespace}/${name}: ${(err as Error).message ?? String(err)}`,
-    );
+    throw new Error(`Failed to start log stream for ${namespace}/${name}: ${messageOf(err)}`);
   }
 
+  reportWhenDrained(ctx, session, [drained]);
   return null;
 }
 
@@ -246,41 +349,43 @@ async function streamPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Pr
  * the whole command.
  */
 async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Promise<null> {
-  const pods = Array.isArray(args.pods) ? (args.pods as unknown[]).filter((p): p is string => typeof p === 'string') : [];
+  const pods = Array.isArray(args.pods)
+    ? (args.pods as unknown[]).filter((p): p is string => typeof p === 'string')
+    : [];
   const namespace = optStr(args.namespace) ?? '';
   const container = optStr(args.container) ?? '';
 
-  stopActive();
-  const session: LogSession = { epoch: ++epochCounter, controllers: [] };
-  activeSession = session;
-
-  const log = new Log(kc());
-  const options = buildLogOptions(args);
+  const session = beginSession();
+  const drains: Array<Promise<void>> = [];
 
   for (const podName of pods) {
     // Bail out of the loop if a stop/restart raced in between iterations.
-    if (activeSession !== session) break;
+    if (isStale(session)) return null;
 
-    const sink = makeLineSink(ctx, session, podName);
     try {
-      const controller = await log.log(namespace, podName, container, sink, options);
-      if (activeSession !== session) {
-        try {
-          controller.abort();
-        } catch {
-          /* ignore */
-        }
-        break;
-      }
-      session.controllers.push(controller);
+      const { drained } = await openStream(ctx, session, namespace, podName, container, args, podName);
+      drains.push(drained);
     } catch (err) {
       // Emit the per-pod error line and keep going (Rust: continue).
-      if (activeSession === session) {
-        ctx.emit(LOG_CHANNEL, [`[${podName}] [error: ${(err as Error).message ?? String(err)}]`]);
+      if (!isStale(session)) {
+        ctx.emit(LOG_CHANNEL, [`[${podName}] [error: ${messageOf(err)}]`]);
       }
     }
   }
 
+  if (isStale(session)) return null;
+
+  if (drains.length === 0) {
+    // Nothing will ever drain, so report now rather than leaving the renderer
+    // waiting on a stream that never was.
+    ctx.emit(STATUS_CHANNEL, {
+      state: 'error',
+      message: pods.length === 0 ? 'No pods to stream' : 'No pod log streams could be started',
+    } satisfies StreamStatus);
+    return null;
+  }
+
+  reportWhenDrained(ctx, session, drains);
   return null;
 }
 

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -205,8 +205,13 @@ async function pumpBody(
     if (partial.length > 0) batcher.push(partial);
   } finally {
     reader.releaseLock();
+    // In the `finally` so a mid-stream failure still delivers what was already
+    // buffered: push() only arms a 50ms debounce, and the caller's rejection
+    // path clears that timer, so anything batched within the last 50ms of a
+    // dropped stream would otherwise be discarded — exactly the lines before a
+    // crash that are worth reading.
+    batcher.flush();
   }
-  batcher.flush();
 }
 
 /**

--- a/electron/k8s/api.ts
+++ b/electron/k8s/api.ts
@@ -67,3 +67,38 @@ export async function apiGet<T>(
   }
   return (await resp.json()) as T;
 }
+
+/**
+ * Issue an authenticated GET and return the Response with its body UNCONSUMED,
+ * so the caller can read it incrementally and abort it.
+ *
+ * Separate from apiGet, which buffers the whole body and JSON-parses it — the
+ * opposite of what a `follow=true` log stream needs. Resolving as soon as the
+ * response headers arrive also gives callers a truthful "connected" signal.
+ *
+ * The caller owns the returned body: it MUST read or cancel it, otherwise the
+ * socket stays held open.
+ */
+export async function apiStream(
+  path: string,
+  query: URLSearchParams,
+  signal: AbortSignal,
+): Promise<Response> {
+  const cfg = kc();
+  const cluster = cfg.getCurrentCluster();
+  if (!cluster) {
+    throw new Error('No active cluster in kubeconfig');
+  }
+  const url = new URL(cluster.server.replace(/\/$/, '') + path);
+  url.search = query.toString();
+
+  const opts = await cfg.applyToFetchOptions({});
+  opts.method = 'GET';
+
+  const resp = await fetch(url.toString(), { ...(opts as RequestInit), signal });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(`${resp.status} ${resp.statusText}${body ? `: ${body}` : ''}`);
+  }
+  return resp;
+}

--- a/src/lib/components/logs/LogViewer.svelte
+++ b/src/lib/components/logs/LogViewer.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { cn } from "$lib/utils";
   import { ArrowDown } from "lucide-svelte";
-  import { listen } from "$lib/ipc/event";
   import { invoke } from "$lib/ipc/core";
   import { k8sStore } from "$lib/stores/k8s.svelte";
   import { scheduleFlush } from "$lib/utils/frame-scheduler";
@@ -14,10 +13,13 @@
     shortPodName,
     parseLogLine,
     resetLogIdCounter,
-    nextLogId,
+    buildStreamRequest,
+    streamEmptyStateMessage,
   } from "./log-viewer";
+  import { createLogStream } from "./log-stream.svelte";
   import {
     SINCE_LABELS,
+    SINCE_WINDOW_LABELS,
     SINCE_SECONDS,
     LEVEL_BADGE_COLORS,
     LEVEL_LABELS,
@@ -39,10 +41,19 @@
   let containerSourcePod = $state<Resource | null>(null);
   let deploymentPodNames = $state<string[]>([]);
   let podsLoading = $state(false);
-  let isStreaming = $state(false);
   let logContainer: HTMLDivElement | undefined = $state();
-  let unlisten: (() => void) | null = null;
-  let destroyed = false;
+
+  // The whole connect/live/ended/error state machine lives in log-stream.logic.ts.
+  const stream = createLogStream({
+    onLines: (payload) => {
+      for (const line of payload) enqueueLogLine(parseLogLine(line));
+    },
+    onReset: () => clearLogs(),
+  });
+
+  // "Is there a stream at all" — what the header's Stream/Stop toggle needs. The
+  // finer phase distinction only matters for the badge and the empty state.
+  const isStreaming = $derived(stream.isActive);
 
   // --- Virtualizer ---
   const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
@@ -182,34 +193,27 @@
     });
   });
 
-  let emptyStateMessage = $derived.by(() => {
-    const hasLevelFilter = levelFilter !== "all";
-    const hasSearchFilter = filterText.trim().length > 0;
-
-    if (logs.length > 0 && filteredLogs.length === 0) {
-      if (hasLevelFilter && hasSearchFilter) {
-        return `No ${levelFilter.toUpperCase()} logs match the current search.`;
-      }
-      if (hasLevelFilter) {
-        return `No logs found for level ${levelFilter.toUpperCase()}.`;
-      }
-      if (hasSearchFilter) {
-        return "No logs match the current search.";
-      }
-    }
-
-    if (isStreaming) return "Connecting to log stream...";
-    if (isDeployment && podsLoading) return "Loading pods...";
-    if (isDeployment && deploymentPodNames.length === 0) return "No pods found for this deployment";
-    return "Select a container and press Stream to start";
-  });
-
   const isDeployment = $derived(
     k8sStore.selectedResource?.kind?.toLowerCase() === "deployment"
   );
 
   const resourceName = $derived(k8sStore.selectedResource?.metadata?.name ?? "Pod");
   const sinceLabel = $derived(SINCE_LABELS.get(sinceDuration) ?? "1 day ago");
+  const sinceWindowLabel = $derived(SINCE_WINDOW_LABELS.get(sinceDuration) ?? "1 day");
+
+  let emptyStateMessage = $derived(
+    streamEmptyStateMessage({
+      phase: stream.phase,
+      hasLogs: logs.length > 0,
+      levelFilter,
+      filterText,
+      isDeployment,
+      podsLoading,
+      deploymentPodCount: deploymentPodNames.length,
+      sinceWindowLabel,
+      errorMessage: stream.error ?? undefined,
+    }),
+  );
 
   // --- Deployment pod fetching ---
   let _fetchGeneration = 0;
@@ -265,87 +269,65 @@
   });
 
   // --- Streaming lifecycle ---
+
+  /** uid of the resource the current stream belongs to. */
+  let _streamedUid: string | null = null;
   let autoStarted = false;
 
   onMount(() => {
-    return () => {
-      destroyed = true;
-      stopStreaming();
-    };
+    return () => stream.destroy();
   });
 
+  /**
+   * The viewer is mounted per-VIEW, not per-resource (App.svelte renders it when
+   * activeView === "logs"), so switching pods has to be handled here: tear the
+   * old stream down, drop its lines, and auto-start the new one as soon as a
+   * container is known. Without this the viewer kept streaming the previous pod.
+   */
   $effect(() => {
-    if (selectedContainer && !autoStarted) {
-      autoStarted = true;
-      startStreaming();
-    }
+    const uid = k8sStore.selectedResource?.metadata?.uid ?? null;
+    const container = selectedContainer;
+
+    untrack(() => {
+      if (uid !== _streamedUid) {
+        _streamedUid = uid;
+        autoStarted = false;
+        if (stream.phase !== "idle") stopStreaming();
+        clearLogs();
+      }
+      if (container && !autoStarted) {
+        autoStarted = true;
+        startStreaming();
+      }
+    });
   });
 
-  async function startStreaming() {
+  function startStreaming() {
     if (!selectedContainer) return;
-    if (isStreaming) stopStreaming();
-    isStreaming = true;
+    void stream.start(
+      buildStreamRequest({
+        resource: k8sStore.selectedResource,
+        isDeployment,
+        deploymentPodNames,
+        container: selectedContainer,
+        tailLines,
+        sinceSeconds: SINCE_SECONDS.get(sinceDuration) ?? null,
+        timestamps: showTimestamps,
+        previous: showPrevious,
+      }),
+    );
+  }
+
+  function stopStreaming() {
+    stream.stop();
+  }
+
+  /** Empty the view: both the rendered lines and the not-yet-flushed buffer. */
+  function clearLogs() {
     logs = [];
     resetLogIdCounter();
     pendingLogs = [];
     flushScheduled = false;
-    userScrolledAway = false;
-    _seenPodNames = new Set();
-    logPodNames = [];
-
-    const streamOpts = {
-      container: selectedContainer,
-      tailLines,
-      sinceSeconds: SINCE_SECONDS.get(sinceDuration) ?? null,
-      timestamps: showTimestamps,
-      previous: showPrevious || null,
-    };
-
-    try {
-      const unlistenFn = await listen<string[]>("log-lines", (event) => {
-        for (const line of event.payload) {
-          enqueueLogLine(parseLogLine(line));
-        }
-      });
-
-      if (destroyed) {
-        unlistenFn();
-        return;
-      }
-      unlisten = unlistenFn;
-
-      if (isDeployment && deploymentPodNames.length > 0) {
-        await invoke("stream_multi_pod_logs", {
-          pods: deploymentPodNames,
-          namespace: k8sStore.selectedResource?.metadata?.namespace ?? "",
-          ...streamOpts,
-        });
-      } else {
-        const resource = k8sStore.selectedResource;
-        if (!resource || resource.kind.toLowerCase() !== "pod") return;
-        await invoke("stream_pod_logs", {
-          name: resource.metadata.name,
-          namespace: resource.metadata.namespace ?? "",
-          ...streamOpts,
-        });
-      }
-    } catch (err) {
-      logs = [{ id: nextLogId(), message: `Error starting log stream: ${err}`, level: "error" as const, isJson: false }];
-      isStreaming = false;
-    }
-  }
-
-  function stopStreaming() {
-    if (unlisten) {
-      unlisten();
-      unlisten = null;
-    }
-    isStreaming = false;
-    invoke("stop_log_stream").catch(() => {});
-  }
-
-  function clearLogs() {
-    logs = [];
     _seenPodNames = new Set();
     logPodNames = [];
     userScrolledAway = false;
@@ -476,10 +458,15 @@
           {#if lastLogTime}
             <span class="font-mono text-[11px] text-[var(--text-muted)]">last: {lastLogTime}</span>
           {/if}
-          {#if isStreaming}
+          {#if stream.phase === "live"}
             <div class="flex items-center gap-1.5">
               <div class="h-[7px] w-[7px] animate-pulse rounded-full bg-[var(--status-running)]"></div>
               <span class="font-mono text-[11px] font-semibold text-[var(--status-running)]">LIVE</span>
+            </div>
+          {:else if stream.phase === "connecting"}
+            <div class="flex items-center gap-1.5">
+              <div class="h-[7px] w-[7px] animate-pulse rounded-full bg-[var(--status-pending)]"></div>
+              <span class="font-mono text-[11px] font-semibold text-[var(--status-pending)]">CONNECTING</span>
             </div>
           {/if}
         </div>

--- a/src/lib/components/logs/LogViewer.test.ts
+++ b/src/lib/components/logs/LogViewer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import {
+  type EmptyStateOptions,
   type LogLevel,
   type LogLine,
   detectLevel,
@@ -11,6 +12,7 @@ import {
   filterLogs,
   navigateLog,
   resetLogIdCounter,
+  streamEmptyStateMessage,
 } from "./log-viewer";
 
 // --- Tests ---
@@ -532,5 +534,108 @@ describe("navigateLog", () => {
     const single = [{ id: 0, message: "only", level: "info" as const, isJson: false }];
     expect(navigateLog(single, single[0], 1)).toBe(single[0]);
     expect(navigateLog(single, single[0], -1)).toBe(single[0]);
+  });
+});
+
+describe("streamEmptyStateMessage", () => {
+  function opts(over: Partial<EmptyStateOptions> = {}): EmptyStateOptions {
+    return {
+      phase: "idle",
+      hasLogs: false,
+      levelFilter: "all",
+      filterText: "",
+      isDeployment: false,
+      podsLoading: false,
+      deploymentPodCount: 0,
+      sinceWindowLabel: "1 day",
+      ...over,
+    };
+  }
+
+  test("connecting phase announces the connection attempt", () => {
+    expect(streamEmptyStateMessage(opts({ phase: "connecting" }))).toBe(
+      "Connecting to log stream...",
+    );
+  });
+
+  // The regression this whole change exists for: a connected stream from a pod
+  // that simply has not logged anything must NOT claim to still be connecting.
+  test("live phase with no output does not say 'Connecting'", () => {
+    const msg = streamEmptyStateMessage(opts({ phase: "live" }));
+    expect(msg).not.toContain("Connecting");
+    expect(msg).toContain("Connected");
+    expect(msg).toContain("1 day");
+  });
+
+  test("live phase reflects the selected since-window", () => {
+    expect(streamEmptyStateMessage(opts({ phase: "live", sinceWindowLabel: "15 min" }))).toContain(
+      "15 min",
+    );
+  });
+
+  test("ended phase reports the stream finished", () => {
+    expect(streamEmptyStateMessage(opts({ phase: "ended" }))).toBe("Log stream ended.");
+  });
+
+  test("error phase surfaces the backend message", () => {
+    expect(
+      streamEmptyStateMessage(opts({ phase: "error", errorMessage: "connection reset by peer" })),
+    ).toBe("connection reset by peer");
+  });
+
+  test("error phase falls back when no message is supplied", () => {
+    expect(streamEmptyStateMessage(opts({ phase: "error" }))).toBe(
+      "The log stream stopped unexpectedly.",
+    );
+  });
+
+  test("idle phase prompts the user to start", () => {
+    expect(streamEmptyStateMessage(opts())).toBe("Select a container and press Stream to start");
+  });
+
+  test("idle deployment while pods load", () => {
+    expect(streamEmptyStateMessage(opts({ isDeployment: true, podsLoading: true }))).toBe(
+      "Loading pods...",
+    );
+  });
+
+  test("idle deployment with no pods", () => {
+    expect(streamEmptyStateMessage(opts({ isDeployment: true, deploymentPodCount: 0 }))).toBe(
+      "No pods found for this deployment",
+    );
+  });
+
+  // Filters take precedence over the phase: lines DID arrive, they are just hidden.
+  test("level filter hiding all lines wins over the live phase", () => {
+    expect(
+      streamEmptyStateMessage(opts({ phase: "live", hasLogs: true, levelFilter: "error" })),
+    ).toBe("No logs found for level ERROR.");
+  });
+
+  test("search filter hiding all lines wins over the live phase", () => {
+    expect(
+      streamEmptyStateMessage(opts({ phase: "live", hasLogs: true, filterText: "needle" })),
+    ).toBe("No logs match the current search.");
+  });
+
+  test("level and search filters combined", () => {
+    expect(
+      streamEmptyStateMessage(
+        opts({ phase: "live", hasLogs: true, levelFilter: "warn", filterText: "needle" }),
+      ),
+    ).toBe("No WARN logs match the current search.");
+  });
+
+  test("whitespace-only search is not treated as a filter", () => {
+    expect(streamEmptyStateMessage(opts({ phase: "live", hasLogs: true, filterText: "   " }))).toContain(
+      "Connected",
+    );
+  });
+
+  // With no lines at all the filters are irrelevant — the phase is the story.
+  test("filters are ignored when nothing arrived", () => {
+    expect(
+      streamEmptyStateMessage(opts({ phase: "connecting", hasLogs: false, levelFilter: "error" })),
+    ).toBe("Connecting to log stream...");
   });
 });

--- a/src/lib/components/logs/log-constants.ts
+++ b/src/lib/components/logs/log-constants.ts
@@ -23,6 +23,14 @@ export const SINCE_OPTIONS: { label: string; value: SinceDuration; seconds: numb
 export const SINCE_LABELS = new Map(SINCE_OPTIONS.map((o) => [o.value, o.label]));
 export const SINCE_SECONDS = new Map(SINCE_OPTIONS.map((o) => [o.value, o.seconds]));
 
+/**
+ * The same durations phrased as a window ("1 day") instead of a point in time
+ * ("1 day ago"), so they read correctly inside "nothing in the last {…}".
+ */
+export const SINCE_WINDOW_LABELS = new Map(
+  SINCE_OPTIONS.map((o) => [o.value, o.label.replace(/ ago$/, "")]),
+);
+
 // --- Tail options ---
 
 export const TAIL_OPTIONS: TailLines[] = [100, 500, 1000, 5000];

--- a/src/lib/components/logs/log-stream.logic.ts
+++ b/src/lib/components/logs/log-stream.logic.ts
@@ -1,0 +1,180 @@
+// Log stream lifecycle — no Svelte runes (see log-stream.svelte.ts for the
+// reactive subclass), IPC injected so the state machine is testable.
+//
+// This owns the one genuinely subtle part of the log viewer: an async state
+// machine over two event channels, a command that may never settle, and a user
+// who can restart it at any moment. It lives apart from LogViewer.svelte so
+// that component can stay about rendering, and so these transitions can be
+// tested without a DOM or a cluster.
+//
+// The phases and why they exist:
+//
+//   idle ──start()──▶ connecting ──command resolves──▶ live
+//                         │                             │
+//                         │                             ├─ status 'ended' ─▶ ended
+//                         ├─ command rejects ──▶ error  ├─ status 'error' ─▶ error
+//                         └─ watchdog fires ───▶ error  └─ stop() ─────────▶ idle
+//
+// `connecting` covers ONLY the window until the backend confirms the log request
+// is established; `live` means attached, which is NOT the same as "has produced
+// output". Collapsing those two into one boolean is what used to leave a quiet
+// pod showing "Connecting to log stream..." forever.
+
+import type { StreamPhase, StreamRequest, StreamStatus } from "./log-viewer";
+
+/** How long a "connecting" phase may last before we call it a failure. */
+export const CONNECT_TIMEOUT_MS = 15_000;
+
+/**
+ * Side effects the state machine needs. The real IPC is wired up in
+ * log-stream.svelte.ts; tests pass fakes.
+ */
+export interface LogStreamIo {
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+  listen: <T>(channel: string, cb: (payload: T) => void) => Promise<() => void>;
+  /** A batch of raw log lines arrived. */
+  onLines: (lines: string[]) => void;
+  /** A new stream is starting — drop whatever the previous one produced. */
+  onReset: () => void;
+  /** Override the watchdog, mainly so tests do not wait 15 seconds. */
+  connectTimeoutMs?: number;
+}
+
+export class LogStreamLogic {
+  phase: StreamPhase = "idle";
+  error: string | null = null;
+
+  protected _io: LogStreamIo;
+
+  /**
+   * Bumped by every start/stop. Each `await` in start() resumes behind a check
+   * against it, so a slow attempt can never resurrect itself and clobber the
+   * state of a newer one.
+   */
+  private _generation = 0;
+  private _connectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _unlisteners: Array<() => void> = [];
+  private _destroyed = false;
+
+  constructor(io: LogStreamIo) {
+    this._io = io;
+  }
+
+  /** Whether a stream is attached or being attached — drives the Stop button. */
+  get isActive(): boolean {
+    return this.phase === "connecting" || this.phase === "live";
+  }
+
+  async start(request: StreamRequest): Promise<void> {
+    if (this._destroyed) return;
+
+    // Invalidate FIRST, so anything in flight from a previous attempt is stale
+    // before we touch shared state.
+    const gen = this._invalidate();
+    this._stopBackendStream();
+
+    if (request.kind === "unavailable") {
+      this._fail(request.reason);
+      return;
+    }
+
+    this.phase = "connecting";
+    this.error = null;
+    this._io.onReset();
+
+    // Backstop for the one ending the backend cannot report: the connect itself
+    // never settling (unreachable apiserver, hung TLS handshake).
+    this._connectTimer = setTimeout(() => {
+      if (gen !== this._generation) return;
+      // Invalidate this attempt too: we are tearing its subscriptions down, so a
+      // connect that lands late must not be able to flip us back to "live".
+      this._invalidate();
+      this._stopBackendStream();
+      this._fail("Timed out connecting to the log stream.");
+    }, this._io.connectTimeoutMs ?? CONNECT_TIMEOUT_MS);
+
+    try {
+      const unlistenLines = await this._io.listen<string[]>("log-lines", (payload) => {
+        if (gen !== this._generation) return;
+        this._io.onLines(payload);
+      });
+      const unlistenStatus = await this._io.listen<StreamStatus>("log-stream-status", (payload) => {
+        if (gen !== this._generation) return;
+        this._onStatus(payload);
+      });
+
+      if (this._destroyed || gen !== this._generation) {
+        unlistenLines();
+        unlistenStatus();
+        return;
+      }
+      this._unlisteners = [unlistenLines, unlistenStatus];
+
+      await this._io.invoke(request.command, request.args);
+      if (gen !== this._generation) return;
+
+      // The command resolves once the log request is established, so this is a
+      // real connection signal rather than an optimistic guess.
+      this._clearConnectTimer();
+      // A very short-lived stream can report that it already ended before this
+      // resolves, so never overwrite a phase that has already gone terminal.
+      if (this.phase === "connecting") this.phase = "live";
+    } catch (err) {
+      if (gen !== this._generation) return;
+      this._invalidate();
+      this._fail(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  stop(): void {
+    this._invalidate();
+    this.phase = "idle";
+    this.error = null;
+    this._stopBackendStream();
+  }
+
+  /** Stop for good; further start() calls are ignored. */
+  destroy(): void {
+    this._destroyed = true;
+    this.stop();
+  }
+
+  /** The backend reporting that the stream finished on its own. */
+  private _onStatus(status: StreamStatus): void {
+    this._clearConnectTimer();
+    if (status.state === "ended") {
+      this.phase = "ended";
+      return;
+    }
+    this._fail(status.message ?? "The log stream stopped unexpectedly.");
+  }
+
+  private _fail(message: string): void {
+    this.error = message;
+    this.phase = "error";
+  }
+
+  /**
+   * Invalidate in-flight work and drop event subscriptions. Returns the new
+   * generation so a caller can detect its own obsolescence later.
+   */
+  private _invalidate(): number {
+    this._generation += 1;
+    this._clearConnectTimer();
+    for (const unlisten of this._unlisteners) unlisten();
+    this._unlisteners = [];
+    return this._generation;
+  }
+
+  private _clearConnectTimer(): void {
+    if (this._connectTimer !== null) {
+      clearTimeout(this._connectTimer);
+      this._connectTimer = null;
+    }
+  }
+
+  /** Best-effort teardown of the backend's single active stream slot. */
+  private _stopBackendStream(): void {
+    this._io.invoke("stop_log_stream").catch(() => {});
+  }
+}

--- a/src/lib/components/logs/log-stream.svelte.ts
+++ b/src/lib/components/logs/log-stream.svelte.ts
@@ -1,0 +1,34 @@
+// Reactive wrapper over LogStreamLogic: the same state machine, with `phase`
+// and `error` as Svelte 5 runes so the viewer re-renders on every transition.
+// All behaviour lives in the .logic.ts base class, which is where the tests are.
+
+import { invoke } from "$lib/ipc/core";
+import { listen } from "$lib/ipc/event";
+import { unshadowState } from "$lib/stores/_unshadow.js";
+
+import { LogStreamLogic, type LogStreamIo } from "./log-stream.logic";
+import type { StreamPhase } from "./log-viewer";
+
+/** What a caller supplies; the IPC half is wired up here. */
+export type LogStreamHooks = Omit<LogStreamIo, "invoke" | "listen">;
+
+class LogStream extends LogStreamLogic {
+  // Override plain properties with Svelte 5 reactive state
+  phase = $state<StreamPhase>("idle");
+  error = $state<string | null>(null);
+
+  constructor(hooks: LogStreamHooks) {
+    super({
+      ...hooks,
+      invoke: (cmd, args) => invoke(cmd, args),
+      listen: <T,>(channel: string, cb: (payload: T) => void) =>
+        listen<T>(channel, (event) => cb(event.payload)),
+    });
+    unshadowState(this);
+  }
+}
+
+/** Create a reactive log stream. Call destroy() when the owner unmounts. */
+export function createLogStream(hooks: LogStreamHooks): LogStreamLogic {
+  return new LogStream(hooks);
+}

--- a/src/lib/components/logs/log-stream.test.ts
+++ b/src/lib/components/logs/log-stream.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from "bun:test";
+
+import { LogStreamLogic, type LogStreamIo } from "./log-stream.logic";
+import type { StreamRequest, StreamStatus } from "./log-viewer";
+
+const REQUEST: StreamRequest = {
+  kind: "stream",
+  command: "stream_pod_logs",
+  args: { name: "web-0", namespace: "default" },
+};
+
+/** A stream command the fake backend is holding open. */
+interface Pending {
+  resolve: () => void;
+  reject: (e: Error) => void;
+}
+
+interface Harness {
+  stream: LogStreamLogic;
+  /** Commands the machine sent, in order. */
+  invoked: string[];
+  lines: string[][];
+  resets: number;
+  /** Total live subscribers across channels, to catch listener leaks. */
+  live: () => number;
+  emit: (channel: string, payload: unknown) => void;
+  /**
+   * Detach the in-flight stream command so a test can settle THAT attempt later,
+   * even after a restart has replaced it.
+   */
+  takePending: () => Pending;
+  /** Resolve (or reject) the in-flight stream command. */
+  settle: (err?: Error) => void;
+}
+
+/**
+ * A LogStreamLogic wired to fakes. The stream command is held open until the
+ * test calls settle(), so the connecting → live window can be inspected.
+ */
+function harness(over: Partial<LogStreamIo> = {}): Harness {
+  const invoked: string[] = [];
+  const lines: string[][] = [];
+  let resets = 0;
+  const subscribers = new Map<string, Set<(payload: unknown) => void>>();
+  let pending: Pending | null = null;
+
+  function takePending(): Pending {
+    if (!pending) throw new Error("no stream command in flight");
+    const p = pending;
+    pending = null;
+    return p;
+  }
+
+  const io: LogStreamIo = {
+    invoke: (cmd) => {
+      invoked.push(cmd);
+      if (cmd === "stop_log_stream") return Promise.resolve(null);
+      return new Promise<void>((resolve, reject) => {
+        pending = { resolve, reject };
+      });
+    },
+    listen: <T,>(channel: string, cb: (payload: T) => void) => {
+      const set = subscribers.get(channel) ?? new Set();
+      subscribers.set(channel, set);
+      const fn = cb as (payload: unknown) => void;
+      set.add(fn);
+      return Promise.resolve(() => set.delete(fn));
+    },
+    onLines: (payload) => lines.push(payload),
+    onReset: () => {
+      resets += 1;
+    },
+    connectTimeoutMs: 40,
+    ...over,
+  };
+
+  return {
+    stream: new LogStreamLogic(io),
+    invoked,
+    lines,
+    get resets() {
+      return resets;
+    },
+    live: () => [...subscribers.values()].reduce((n, s) => n + s.size, 0),
+    emit: (channel, payload) => {
+      for (const cb of subscribers.get(channel) ?? []) cb(payload);
+    },
+    takePending,
+    settle: (err) => {
+      const p = takePending();
+      if (err) p.reject(err);
+      else p.resolve();
+    },
+  } as Harness;
+}
+
+/** Let queued microtasks (and optionally timers) run. */
+function tick(ms = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("LogStreamLogic phases", () => {
+  test("starts idle", () => {
+    const h = harness();
+    expect(h.stream.phase).toBe("idle");
+    expect(h.stream.isActive).toBe(false);
+  });
+
+  test("is connecting until the backend confirms, then live", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+
+    expect(h.stream.phase).toBe("connecting");
+    expect(h.stream.isActive).toBe(true);
+
+    h.settle();
+    await tick();
+
+    expect(h.stream.phase).toBe("live");
+    expect(h.stream.isActive).toBe(true);
+  });
+
+  test("clears the previous stream's output on start", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    expect(h.resets).toBe(1);
+  });
+
+  test("forwards log lines while live", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.emit("log-lines", ["one", "two"]);
+    expect(h.lines).toEqual([["one", "two"]]);
+  });
+
+  test("an unavailable request fails without contacting the backend", async () => {
+    const h = harness();
+    await h.stream.start({ kind: "unavailable", reason: "No pod selected." });
+
+    expect(h.stream.phase).toBe("error");
+    expect(h.stream.error).toBe("No pod selected.");
+    expect(h.invoked).not.toContain("stream_pod_logs");
+  });
+
+  test("a rejected stream command surfaces the error", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle(new Error("403 Forbidden"));
+    await tick();
+
+    expect(h.stream.phase).toBe("error");
+    expect(h.stream.error).toBe("403 Forbidden");
+    expect(h.stream.isActive).toBe(false);
+  });
+});
+
+describe("LogStreamLogic terminal status", () => {
+  test("an ended status leaves the live phase", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.emit("log-stream-status", { state: "ended" } satisfies StreamStatus);
+    expect(h.stream.phase).toBe("ended");
+    expect(h.stream.isActive).toBe(false);
+  });
+
+  test("an error status carries its message", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.emit("log-stream-status", { state: "error", message: "connection reset" });
+    expect(h.stream.phase).toBe("error");
+    expect(h.stream.error).toBe("connection reset");
+  });
+
+  test("an error status without a message still explains itself", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.emit("log-stream-status", { state: "error" });
+    expect(h.stream.error).toBe("The log stream stopped unexpectedly.");
+  });
+
+  // A stream can end before the command that started it resolves; "live" must
+  // not overwrite a phase that has already gone terminal.
+  test("a stream that ends before the command resolves stays ended", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+
+    h.emit("log-stream-status", { state: "ended" });
+    expect(h.stream.phase).toBe("ended");
+
+    h.settle();
+    await tick();
+    expect(h.stream.phase).toBe("ended");
+  });
+});
+
+describe("LogStreamLogic restarts and staleness", () => {
+  test("stop returns to idle and drops subscriptions", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+    expect(h.live()).toBe(2);
+
+    h.stream.stop();
+    expect(h.stream.phase).toBe("idle");
+    expect(h.stream.error).toBeNull();
+    expect(h.live()).toBe(0);
+  });
+
+  test("a superseded start cannot report over the newer one", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    const first = h.takePending();
+
+    // Restart before the first attempt settles.
+    void h.stream.start(REQUEST);
+    await tick();
+
+    // The first attempt now fails — it must not touch the new attempt's state.
+    first.reject(new Error("stale failure"));
+    await tick();
+    expect(h.stream.phase).toBe("connecting");
+    expect(h.stream.error).toBeNull();
+
+    h.settle();
+    await tick();
+    expect(h.stream.phase).toBe("live");
+  });
+
+  test("restarting does not leak the previous attempt's listeners", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    // Two channels, one subscriber each — not four.
+    expect(h.live()).toBe(2);
+  });
+
+  test("a status from a stopped stream is ignored", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.stream.stop();
+    h.emit("log-stream-status", { state: "error", message: "too late" });
+
+    expect(h.stream.phase).toBe("idle");
+    expect(h.stream.error).toBeNull();
+  });
+
+  test("destroy stops the stream and refuses further starts", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    h.stream.destroy();
+    expect(h.stream.phase).toBe("idle");
+    expect(h.live()).toBe(0);
+
+    await h.stream.start(REQUEST);
+    expect(h.stream.phase).toBe("idle");
+  });
+});
+
+describe("LogStreamLogic connect watchdog", () => {
+  // The one ending the backend cannot report: a connect that never settles.
+  test("a connect that never settles becomes an error", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    expect(h.stream.phase).toBe("connecting");
+
+    await tick(70);
+
+    expect(h.stream.phase).toBe("error");
+    expect(h.stream.error).toBe("Timed out connecting to the log stream.");
+    expect(h.live()).toBe(0);
+  });
+
+  test("a late connect cannot revive a timed-out attempt", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    await tick(70);
+    expect(h.stream.phase).toBe("error");
+
+    h.settle();
+    await tick();
+
+    expect(h.stream.phase).toBe("error");
+  });
+
+  test("the watchdog does not fire once connected", async () => {
+    const h = harness();
+    void h.stream.start(REQUEST);
+    await tick();
+    h.settle();
+    await tick();
+
+    await tick(70);
+
+    expect(h.stream.phase).toBe("live");
+  });
+});

--- a/src/lib/components/logs/log-viewer.ts
+++ b/src/lib/components/logs/log-viewer.ts
@@ -1,5 +1,7 @@
 // Pure logic extracted from LogViewer.svelte — no Svelte imports, no $state/$derived.
 
+import type { Resource } from "$lib/types";
+
 // --- Types ---
 
 export type LogLevel = "all" | "info" | "warn" | "error";
@@ -169,4 +171,153 @@ export function navigateLog(
   const current = selectedLog ? filteredLogs.indexOf(selectedLog) : -1;
   const next = Math.max(0, Math.min(filteredLogs.length - 1, current + direction));
   return filteredLogs[next];
+}
+
+// --- Stream lifecycle ---
+
+/**
+ * How far along the log stream is, from the renderer's point of view.
+ *
+ * `connecting` covers ONLY the window between asking the backend to start and
+ * the backend confirming the request is established. `live` means the stream is
+ * attached — it may simply not have produced output yet.
+ *
+ * Collapsing those two into one `isStreaming` boolean is what used to pin the
+ * viewer on "Connecting to log stream..." forever: the message was shown for
+ * any stream with zero lines, so a perfectly healthy but quiet pod looked
+ * permanently stuck (while the header showed a LIVE badge at the same time).
+ */
+export type StreamPhase = "idle" | "connecting" | "live" | "ended" | "error";
+
+/** Payload of the backend's `log-stream-status` event. */
+export interface StreamStatus {
+  state: "ended" | "error";
+  message?: string;
+  pod?: string;
+}
+
+/** The backend commands that can serve a log stream. */
+export type StreamCommand = "stream_pod_logs" | "stream_multi_pod_logs";
+
+/**
+ * What to ask the backend for — or why there is nothing to ask for.
+ *
+ * Modelled as a union rather than a nullable so the "nothing streamable" case
+ * carries its own explanation. The viewer used to discover this halfway through
+ * starting a stream and `return` early, leaving the streaming flag set: that is
+ * what pinned the empty state on "Connecting to log stream..." forever.
+ */
+export type StreamRequest =
+  | { kind: "stream"; command: StreamCommand; args: Record<string, unknown> }
+  | { kind: "unavailable"; reason: string };
+
+export interface StreamRequestOptions {
+  resource: Resource | null;
+  isDeployment: boolean;
+  deploymentPodNames: string[];
+  container: string;
+  tailLines: number;
+  sinceSeconds: number | null;
+  timestamps: boolean;
+  previous: boolean;
+}
+
+/** Decide which stream command serves the current selection, if any. */
+export function buildStreamRequest(opts: StreamRequestOptions): StreamRequest {
+  const common = {
+    container: opts.container,
+    tailLines: opts.tailLines,
+    sinceSeconds: opts.sinceSeconds,
+    timestamps: opts.timestamps,
+    previous: opts.previous || null,
+  };
+
+  if (opts.isDeployment) {
+    if (opts.deploymentPodNames.length === 0) {
+      return { kind: "unavailable", reason: "This deployment has no running pods to stream." };
+    }
+    return {
+      kind: "stream",
+      command: "stream_multi_pod_logs",
+      args: {
+        pods: opts.deploymentPodNames,
+        namespace: opts.resource?.metadata?.namespace ?? "",
+        ...common,
+      },
+    };
+  }
+
+  const resource = opts.resource;
+  if (!resource || resource.kind.toLowerCase() !== "pod") {
+    // The selection can vanish mid-start — a watch event dropping the pod nulls
+    // it out from under us.
+    return { kind: "unavailable", reason: "No pod selected to stream logs from." };
+  }
+  return {
+    kind: "stream",
+    command: "stream_pod_logs",
+    args: {
+      name: resource.metadata.name,
+      namespace: resource.metadata.namespace ?? "",
+      ...common,
+    },
+  };
+}
+
+export interface EmptyStateOptions {
+  phase: StreamPhase;
+  /** Whether any line arrived at all, before filtering. */
+  hasLogs: boolean;
+  levelFilter: LogLevel;
+  filterText: string;
+  isDeployment: boolean;
+  podsLoading: boolean;
+  deploymentPodCount: number;
+  /** Duration window phrased for "nothing in the last {…}" — e.g. "1 day". */
+  sinceWindowLabel: string;
+  errorMessage?: string;
+}
+
+/**
+ * The message shown in place of the log list when nothing is visible.
+ *
+ * Only called when the filtered list is empty, so `hasLogs` alone distinguishes
+ * "filters hid everything" from "nothing arrived".
+ */
+export function streamEmptyStateMessage(opts: EmptyStateOptions): string {
+  const hasLevelFilter = opts.levelFilter !== "all";
+  const hasSearchFilter = opts.filterText.trim().length > 0;
+
+  // Lines did arrive but the active filters hide all of them — the filters are
+  // the story, not the stream phase.
+  if (opts.hasLogs) {
+    if (hasLevelFilter && hasSearchFilter) {
+      return `No ${opts.levelFilter.toUpperCase()} logs match the current search.`;
+    }
+    if (hasLevelFilter) {
+      return `No logs found for level ${opts.levelFilter.toUpperCase()}.`;
+    }
+    if (hasSearchFilter) {
+      return "No logs match the current search.";
+    }
+  }
+
+  switch (opts.phase) {
+    case "connecting":
+      return "Connecting to log stream...";
+    case "live":
+      return `Connected — waiting for output. Nothing logged in the last ${opts.sinceWindowLabel}.`;
+    case "ended":
+      return "Log stream ended.";
+    case "error":
+      return opts.errorMessage ?? "The log stream stopped unexpectedly.";
+    case "idle":
+      break;
+  }
+
+  if (opts.isDeployment && opts.podsLoading) return "Loading pods...";
+  if (opts.isDeployment && opts.deploymentPodCount === 0) {
+    return "No pods found for this deployment";
+  }
+  return "Select a container and press Stream to start";
 }


### PR DESCRIPTION
## Problem

Opening a pod's **Logs** tab sometimes left the view pinned on `Connecting to log stream...` forever — with the `LIVE` badge pulsing directly above it, saying the opposite.

It turned out to be **five separate bugs**, which is why it looked intermittent.

### 1. There was no "connected" state (the main one)

`isStreaming` was a single boolean meaning both *connecting* and *streaming*, and the message rendered whenever a stream had zero lines. So a perfectly healthy pod that simply **hadn't logged anything** — or whose logs were older than the `since` window — displayed "Connecting..." indefinitely.

### 2. A dropped stream reported nothing at all

`@kubernetes/client-node`'s `Log.log()` does `response.body.pipe(sink)` and keeps the body private. Node's `pipe()` forwards **nothing** to the destination when the source dies abnormally. Verified empirically rather than assumed:

```
CASE graceful end:    write → FINAL → finish → unpipe → close
CASE source error:    write → (nothing)
CASE source destroy:  write → (nothing)
```

The `final()` that produced the `[stream ended]` marker only runs on a graceful `end()`. So pod restarts, apiserver idle timeouts, network blips and expired credentials were all completely silent, and the renderer waited forever. The deprecated `done` callback is never invoked, so there was no hook to use.

### 3. An early return left the flag set

`startStreaming()` set `isStreaming = true`, then returned without clearing it when the selected resource wasn't a streamable pod — reachable when a watch event deletes the selected pod, or for a deployment with no pods.

### 4. No generation guard on overlapping starts

Two concurrent `startStreaming()` calls (auto-start + a click, or rapid filter changes) clobbered each other's `unlisten` handle, leaking a listener, and a stale `catch` could tear down a healthy stream. The file already had this pattern for its pod fetch (`_fetchGeneration`) — the stream path just didn't use it.

### 5. Switching pods never restarted the stream

`LogViewer` is mounted per-*view*, not per-resource, and `autoStarted` was a one-shot flag, so selecting a different pod kept showing the previous pod's stream.

## Fix

**Renderer** — `isStreaming` becomes a `StreamPhase` machine (`idle → connecting → live → ended/error`), extracted from the component into `log-stream.logic.ts`. `connecting` now covers only the window until the backend confirms the request is established; `live` means attached, which is explicitly *not* the same as "has produced output". A quiet pod now reads:

> Connected — waiting for output. Nothing logged in the last 1 day.

Plus a generation guard on every `await`, a 15s connect watchdog, and a restart keyed on the resource uid.

**Backend** — a new `apiStream()` in `electron/k8s/api.ts` (mirroring the existing `apiGet` + origin-scoped undici TLS dispatcher) lets the handler own the log request. It now observes all three endings — clean EOF, transport error, abort — and reports the first two over a new `log-stream-status` channel. A deliberate stop stays silent, since the renderer already drove that transition.

## Structure

The state machine is the subtlest part of this change, so it does not live inside an already-busy component. It follows the repo's existing `*.logic.ts` / `*.svelte.ts` store split: all behaviour in the plain class (IPC injected, fully testable), runes only in the thin reactive subclass.

Two further simplifications came out of self-review:

- The multi-pod handler originally hand-rolled a 4-field reader counter (`active`/`started`/`opening`/`statusSent`). `Promise.allSettled` expresses the same intent in one line, so `LogSession` went from **6 fields to 1** and the session `epoch` — redundant with session identity — was deleted outright.
- `buildStreamRequest()` is now a pure function returning a discriminated union, replacing throw-as-control-flow in the middle of the start path.

Net effect: **`LogViewer.svelte` ends at 544 lines, below the 557 it started at**, despite the feature.

## Behaviour changes

- A failed start renders as the empty-state message instead of a synthetic red log row (one error surface instead of two).
- In a multi-pod stream, one pod dropping no longer flips the whole session to `error` while its siblings still stream; the terminal status fires once everything has settled. This was the same class of bug as a premature `ended` I caught in review.

## Testing

```
bun test                    1154 pass, 0 fail   (+18)
bun test ./electron          133 pass, 0 fail   (+14, handler had no tests)
npm run typecheck:electron   clean
npx svelte-check             0 errors
npm run build                ✓
```

New coverage: phase transitions, generation guard, listener-leak check, connect watchdog, and the backend's line splitting / batching / terminal-status paths. Two regression tests exist specifically for bugs caught during self-review (premature session end; one pod erroring while another streams) — both were written failing first.

⚠️ `npm run test:integration` skips entirely without a cluster, so the **real apiserver path for `apiStream` is unverified here** — the new backend tests stub it, covering the state machine rather than live TLS/auth negotiation. Worth a manual pass against a real cluster before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer log-stream states, including Connecting and Live indicators.
  - Improved empty-state messages for filtering, loading, unavailable resources, and stream errors.
  - Added support for reliable single- and multi-resource log streaming with line prefixes.

- **Bug Fixes**
  - Improved handling of connection failures, stream termination, cancellations, restarts, and timeouts.
  - Logs now refresh correctly when the selected resource or container changes.

- **Tests**
  - Expanded coverage for streaming lifecycle, errors, filtering, empty states, and multi-resource scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->