### PR TITLE
feat: events view, ephemeral debug containers, node shell, and namespace compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ inspect, debug, and act on workloads.
   posture at a glance.
 - **Diagnostics** — surface events, warnings, and common failure modes for
   each resource.
+- **Cluster events feed** — a kubectl-style Events view in the sidebar:
+  live-updating, newest first, Normal/Warning stat cards that filter on
+  click, and search across reason and message.
 - **CRD-aware** — custom resources are first-class citizens. CRD discovery
   falls back to the discovery API (`/apis`) when listing
   `CustomResourceDefinition` objects is forbidden, so it works without

--- a/e2e/compare-dialog.spec.ts
+++ b/e2e/compare-dialog.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Compare Across Namespaces: right-click a namespaced resource, pick a target
+ * namespace, and get a read-only CodeMirror MergeView of the two YAMLs.
+ */
+import { test, expect } from "./fixtures/mocked-cluster";
+
+function mockPod(name: string, namespace: string) {
+  return {
+    kind: "Pod",
+    api_version: "v1",
+    metadata: {
+      name,
+      namespace,
+      uid: `pod-uid-${namespace}-${name}`,
+      creation_timestamp: "2026-01-01T00:00:00Z",
+      labels: {},
+      annotations: {},
+      owner_references: [],
+      resource_version: "1",
+    },
+    spec: { nodeName: "node-1", containers: [{ name: "web", image: "nginx:1.0" }] },
+    status: { phase: "Running" },
+  };
+}
+
+// Standalone handler (not clusterBootMock): the boot mock pins get_namespaces
+// to ["default"], and this flow needs a second namespace to diff against.
+const MOCK = `(cmd, args) => {
+  if (cmd === "get_contexts") return ["bench"];
+  if (cmd === "get_current_context") return "bench";
+  if (cmd === "get_namespaces") return ["default", "staging"];
+  if (cmd === "get_resource_counts") return {};
+  if (cmd === "bench_config") return { enabled: false };
+  if (cmd === "list_resources" && args.resourceType === "pods") {
+    return { resource_type: "pods", items: [${JSON.stringify(mockPod("web-0", "default"))}] };
+  }
+  if (cmd === "list_resources") return { items: [], columns: [] };
+  if (cmd === "get_resource_yaml") {
+    if (args.namespace === "staging") return "image: nginx:2.0\\nreplicas: 3\\n";
+    return "image: nginx:1.0\\nreplicas: 1\\n";
+  }
+  if (cmd === "discover_crds") return [];
+  return null;
+}`;
+
+test("diffs a resource against its sibling in another namespace", async ({ page, mockInvoke }) => {
+  await mockInvoke(MOCK);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Pods", exact: true })).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("tbody tr").first().click({ button: "right" });
+  await page.getByRole("menuitem", { name: /Compare Across Namespaces/ }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toContainText("Compare Pod");
+  // "staging" is the only other namespace, so it is preselected.
+  await dialog.getByRole("button", { name: "Compare", exact: true }).click();
+
+  // Both sides of the MergeView render their YAML.
+  await expect(dialog).toContainText("nginx:1.0");
+  await expect(dialog).toContainText("nginx:2.0");
+});

--- a/e2e/events-view.spec.ts
+++ b/e2e/events-view.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Global Events view: a kubectl-style cluster event feed backed by the same
+ * registry-driven table as every other resource type. Guards the pieces that
+ * are unique to events — the synthetic-spec columns, the newest-first default
+ * sort (there is no Name column to fall back to), and reason/message filtering.
+ */
+import { test, expect, clusterBootMock } from "./fixtures/mocked-cluster";
+
+const now = Date.now();
+const iso = (minutesAgo: number) => new Date(now - minutesAgo * 60_000).toISOString();
+
+function mockEvent(
+  name: string,
+  minutesAgo: number,
+  type: string,
+  reason: string,
+  message: string,
+  object: { kind: string; name: string },
+) {
+  return {
+    kind: "Event",
+    api_version: "v1",
+    metadata: {
+      name,
+      namespace: "default",
+      uid: `event-uid-${name}`,
+      creation_timestamp: iso(minutesAgo),
+      labels: {},
+      annotations: {},
+      owner_references: [],
+      resource_version: "1",
+    },
+    // list projection lifts the Event's top-level fields into a synthetic spec
+    spec: {
+      type,
+      reason,
+      message,
+      count: 2,
+      involvedObject: object,
+      lastTimestamp: iso(minutesAgo),
+    },
+  };
+}
+
+const MOCK = clusterBootMock(`(cmd, args) => {
+  if (cmd === "list_resources" && args.resourceType === "events") {
+    return { resource_type: "events", items: ${JSON.stringify([
+      mockEvent("old-pull", 60, "Normal", "Pulled", "Container image pulled", { kind: "Pod", name: "web-1" }),
+      mockEvent("fresh-backoff", 1, "Warning", "BackOff", "Back-off restarting failed container", { kind: "Pod", name: "web-0" }),
+      mockEvent("mid-schedule", 30, "Normal", "Scheduled", "Successfully assigned default/web-1", { kind: "Pod", name: "web-1" }),
+    ])} };
+  }
+  if (cmd === "list_resources" && args.resourceType === "pods") {
+    return { resource_type: "pods", items: [{
+      kind: "Pod",
+      api_version: "v1",
+      metadata: {
+        name: "web-0", namespace: "default", uid: "pod-uid-web-0",
+        creation_timestamp: ${JSON.stringify(iso(120))},
+        labels: {}, annotations: {}, owner_references: [], resource_version: "1",
+      },
+      spec: { nodeName: "node-1", containers: [{ name: "web", image: "nginx" }] },
+      status: { phase: "Running" },
+    }] };
+  }
+  if (cmd === "list_resources") return { items: [], columns: [] };
+  if (cmd === "discover_crds") return [];
+}`);
+
+test.beforeEach(async ({ page, mockInvoke }) => {
+  await mockInvoke(MOCK);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Pods", exact: true })).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: /^Events/ }).first().click();
+  await expect(page.getByRole("heading", { name: "Events", exact: true })).toBeVisible();
+});
+
+test("lists events with kubectl-style columns, newest first", async ({ page }) => {
+  const rows = page.locator("tbody tr");
+  await expect(rows).toHaveCount(3);
+
+  // Default sort is eventLastSeen "asc" = most recent activity on top.
+  await expect(rows.nth(0)).toContainText("BackOff");
+  await expect(rows.nth(1)).toContainText("Scheduled");
+  await expect(rows.nth(2)).toContainText("Pulled");
+
+  // Event-specific columns render from the synthetic spec.
+  await expect(rows.nth(0)).toContainText("Pod/web-0");
+  await expect(rows.nth(0)).toContainText("Back-off restarting failed container");
+  await expect(rows.nth(0)).toContainText("warning");
+});
+
+test("the Object column deep-links to the involved resource", async ({ page }) => {
+  await page.getByRole("button", { name: "Pod/web-0" }).click();
+  await expect(page.locator('[data-testid="detail-panel"]')).toBeVisible();
+  await expect(page.locator('[data-testid="detail-panel"]')).toContainText("web-0");
+});
+
+test("filter matches event reason and message", async ({ page }) => {
+  const filter = page.getByPlaceholder("Search events...");
+  await filter.fill("backoff");
+  await expect(page.locator("tbody tr")).toHaveCount(1);
+  await expect(page.locator("tbody tr").first()).toContainText("BackOff");
+
+  await filter.fill("assigned default");
+  await expect(page.locator("tbody tr")).toHaveCount(1);
+  await expect(page.locator("tbody tr").first()).toContainText("Scheduled");
+});

--- a/electron/handlers/debug.test.ts
+++ b/electron/handlers/debug.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, describe } from 'bun:test';
+
+import { buildDebugPatch, classifyDebugState, type EphemeralContainerStatus } from './debug';
+
+describe('buildDebugPatch', () => {
+  test('carries only the new container, merged by name', () => {
+    const patch = buildDebugPatch('debug-abc123', 'busybox:1.36', 'app') as {
+      spec: { ephemeralContainers: Array<Record<string, unknown>> };
+    };
+    expect(patch.spec.ephemeralContainers).toHaveLength(1);
+    expect(patch.spec.ephemeralContainers[0]).toMatchObject({
+      name: 'debug-abc123',
+      image: 'busybox:1.36',
+      targetContainerName: 'app',
+      imagePullPolicy: 'IfNotPresent',
+    });
+  });
+
+  test('omits targetContainerName when there is no target', () => {
+    const patch = buildDebugPatch('debug-abc123', 'busybox:1.36', undefined) as {
+      spec: { ephemeralContainers: Array<Record<string, unknown>> };
+    };
+    expect('targetContainerName' in patch.spec.ephemeralContainers[0]!).toBe(false);
+  });
+
+  test('keeps the container alive with a portable sleep (no `sleep infinity`)', () => {
+    const patch = buildDebugPatch('d', 'busybox:1.36', undefined) as {
+      spec: { ephemeralContainers: Array<{ command: string[] }> };
+    };
+    expect(patch.spec.ephemeralContainers[0]!.command).toEqual(['sh', '-c', 'sleep 2147483647']);
+  });
+});
+
+describe('classifyDebugState', () => {
+  const status = (state: EphemeralContainerStatus['state']): EphemeralContainerStatus => ({
+    name: 'debug-abc123',
+    state,
+  });
+
+  test('running is running', () => {
+    expect(classifyDebugState(status({ running: { startedAt: 'now' } }))).toEqual({ kind: 'running' });
+  });
+
+  test('no status yet is pending', () => {
+    expect(classifyDebugState(undefined)).toEqual({ kind: 'pending', detail: 'not yet reported' });
+  });
+
+  test('ordinary waiting reasons stay pending', () => {
+    expect(classifyDebugState(status({ waiting: { reason: 'ContainerCreating' } }))).toEqual({
+      kind: 'pending',
+      detail: 'ContainerCreating',
+    });
+  });
+
+  test('image pull failures fail fast with the reason', () => {
+    const verdict = classifyDebugState(
+      status({ waiting: { reason: 'ImagePullBackOff', message: 'Back-off pulling image "nope"' } }),
+    );
+    expect(verdict.kind).toBe('failed');
+    expect((verdict as { message: string }).message).toContain('Back-off pulling image');
+  });
+
+  test('terminations surface reason and exit code', () => {
+    const verdict = classifyDebugState(status({ terminated: { reason: 'Error', exitCode: 127 } }));
+    expect(verdict).toEqual({
+      kind: 'failed',
+      message: 'Debug container terminated (Error, exit code 127)',
+    });
+  });
+});

--- a/electron/handlers/debug.ts
+++ b/electron/handlers/debug.ts
@@ -1,0 +1,174 @@
+// Handler module: debug — ephemeral debug containers (kubectl debug).
+//
+// Commands:
+//   debug_pod -> add an ephemeral debug container to a running pod and wait
+//                until it is running, so the renderer can exec straight into
+//                it with the existing terminal subsystem.
+//
+// Flow mirrors `kubectl debug <pod> --image=<img> --target=<container>`:
+// a strategic-merge patch on the pod's `ephemeralcontainers` subresource
+// (ephemeralContainers merge by name, so the patch carries only the new
+// container). The container runs a long sleep instead of an interactive
+// shell — the app's exec model attaches a PTY afterwards via
+// start_terminal_exec, exactly like it does for regular containers.
+//
+// Ephemeral containers cannot be removed from a pod once added (API
+// restriction) — they die with the pod. The UI copy reflects that.
+
+import { randomBytes } from 'node:crypto';
+
+import { PatchStrategy, setHeaderOptions } from '@kubernetes/client-node';
+
+import { getCoreV1Api } from '../k8s/client.js';
+import { k8sErrorMessage } from '../k8s/errors.js';
+import type { HandlerCtx, HandlerMap } from '../dispatch.js';
+
+/** Default debug image: small, ubiquitous, has a usable shell. */
+const DEFAULT_DEBUG_IMAGE = 'busybox:1.36';
+
+/** How long to wait for the runtime to start the debug container. */
+const READY_TIMEOUT_MS = 60_000;
+const READY_POLL_INTERVAL_MS = 500;
+
+export interface EphemeralContainerStatus {
+  name?: string;
+  state?: { running?: unknown; waiting?: { reason?: string; message?: string }; terminated?: { reason?: string; exitCode?: number } };
+}
+
+/** One poll's verdict on the debug container. */
+export type DebugContainerState =
+  | { kind: 'running' }
+  | { kind: 'pending'; detail: string }
+  | { kind: 'failed'; message: string };
+
+/**
+ * Classify a single observation of the debug container's status. Pure — the
+ * poll loop above it owns timing. Terminations and pull failures are terminal:
+ * neither resolves by waiting, so the caller fails fast with the real reason.
+ */
+export function classifyDebugState(
+  status: EphemeralContainerStatus | undefined,
+): DebugContainerState {
+  if (status?.state?.running) return { kind: 'running' };
+  if (status?.state?.terminated) {
+    const t = status.state.terminated;
+    return {
+      kind: 'failed',
+      message: `Debug container terminated (${t.reason ?? 'unknown'}, exit code ${t.exitCode ?? '?'})`,
+    };
+  }
+  if (status?.state?.waiting) {
+    const w = status.state.waiting;
+    if (w.reason === 'ErrImagePull' || w.reason === 'ImagePullBackOff') {
+      return { kind: 'failed', message: `Debug container image pull failed: ${w.message ?? w.reason}` };
+    }
+    return { kind: 'pending', detail: w.reason ?? 'waiting' };
+  }
+  return { kind: 'pending', detail: 'not yet reported' };
+}
+
+/**
+ * The strategic-merge patch that adds the debug container. Ephemeral
+ * containers merge by name, so the patch carries only the new one.
+ */
+export function buildDebugPatch(
+  container: string,
+  image: string,
+  target: string | undefined,
+): Record<string, unknown> {
+  return {
+    spec: {
+      ephemeralContainers: [
+        {
+          name: container,
+          image,
+          // Keep the container alive; the PTY comes from a later exec. busybox
+          // sh has no `sleep infinity`, so use the largest portable duration.
+          command: ['sh', '-c', 'sleep 2147483647'],
+          imagePullPolicy: 'IfNotPresent',
+          terminationMessagePolicy: 'File',
+          ...(target ? { targetContainerName: target } : {}),
+        },
+      ],
+    },
+  };
+}
+
+function reqStr(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`Missing or invalid '${key}' argument`);
+  }
+  return v;
+}
+
+function optStr(args: Record<string, unknown>, key: string): string | undefined {
+  const v = args[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wait until the named ephemeral container reports `running`. Surfaces waiting
+ * reasons (ImagePullBackOff, …) and terminations as errors instead of letting
+ * the caller exec into a dead container and get an opaque failure.
+ */
+async function waitForDebugContainer(
+  name: string,
+  namespace: string,
+  container: string,
+): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  let lastState = 'not yet reported';
+
+  while (Date.now() < deadline) {
+    const pod = await getCoreV1Api().readNamespacedPod({ name, namespace });
+    const statuses = (pod.status?.ephemeralContainerStatuses ?? []) as EphemeralContainerStatus[];
+    const verdict = classifyDebugState(statuses.find((s) => s.name === container));
+
+    if (verdict.kind === 'running') return;
+    if (verdict.kind === 'failed') throw new Error(verdict.message);
+    lastState = verdict.detail;
+
+    await sleep(READY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timed out waiting for debug container to start (last state: ${lastState})`);
+}
+
+/**
+ * debug_pod: { name, namespace, image?, target? } -> { container }
+ * `target` shares the target container's process namespace (when the runtime
+ * supports it), so its processes are visible from the debug shell.
+ */
+async function debugPod(args: Record<string, unknown>): Promise<{ container: string }> {
+  const name = reqStr(args, 'name');
+  const namespace = reqStr(args, 'namespace');
+  const image = optStr(args, 'image') ?? DEFAULT_DEBUG_IMAGE;
+  const target = optStr(args, 'target');
+
+  const container = `debug-${randomBytes(3).toString('hex')}`;
+  const patch = buildDebugPatch(container, image, target);
+
+  try {
+    await getCoreV1Api().patchNamespacedPodEphemeralcontainers(
+      { name, namespace, body: patch },
+      setHeaderOptions('Content-Type', PatchStrategy.StrategicMergePatch),
+    );
+  } catch (err) {
+    throw new Error(k8sErrorMessage(err));
+  }
+
+  try {
+    await waitForDebugContainer(name, namespace, container);
+  } catch (err) {
+    throw new Error(k8sErrorMessage(err));
+  }
+
+  return { container };
+}
+
+export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
+  handlers.set('debug_pod', async (args) => debugPod(args));
+}

--- a/electron/handlers/node-shell.test.ts
+++ b/electron/handlers/node-shell.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from 'bun:test';
+
+import { buildNodeShellPod, NODE_SHELL_LABEL } from './node-shell';
+
+describe('buildNodeShellPod', () => {
+  const pod = buildNodeShellPod('kdashboard-node-shell-abc123', 'kube-system', 'worker-1');
+
+  test('pins to the node and enters the host namespaces', () => {
+    expect(pod.spec).toMatchObject({
+      nodeName: 'worker-1',
+      hostPID: true,
+      hostIPC: true,
+      hostNetwork: true,
+      restartPolicy: 'Never',
+    });
+  });
+
+  test('the container is privileged and only sleeps (PTY comes from exec)', () => {
+    const container = pod.spec!.containers[0]!;
+    expect(container.securityContext?.privileged).toBe(true);
+    expect(container.command).toEqual(['sh', '-c', 'sleep 2147483647']);
+  });
+
+  test('tolerates every taint — cordoned nodes are the point', () => {
+    expect(pod.spec!.tolerations).toEqual([{ operator: 'Exists' }]);
+  });
+
+  test('carries the reaper deadline so an orphaned pod dies on its own', () => {
+    expect(pod.spec!.activeDeadlineSeconds).toBe(3600);
+    expect(pod.spec!.terminationGracePeriodSeconds).toBe(0);
+  });
+
+  test('is labelled for the renderer nsenter wrapper and marks its node', () => {
+    expect(pod.metadata!.labels?.[NODE_SHELL_LABEL]).toBe('true');
+    expect(pod.metadata!.annotations?.[NODE_SHELL_LABEL]).toBe('worker-1');
+  });
+});

--- a/electron/handlers/node-shell.ts
+++ b/electron/handlers/node-shell.ts
@@ -1,0 +1,146 @@
+// Handler module: node-shell — a host shell on a node (Lens-style).
+//
+// Commands:
+//   start_node_shell { nodeName, namespace? } -> { name, namespace }
+//   stop_node_shell  { name, namespace }      -> null
+//
+// start_node_shell creates a privileged hostPID pod pinned to the node and
+// waits until it runs. The pod only sleeps — the renderer then execs
+// `nsenter -t 1 -m -u -i -n -p -- <shell>` into it through the regular
+// terminal subsystem, which drops into the HOST's mount/UTS/IPC/net/pid
+// namespaces (the same trick as kubectl-node-shell). busybox ships an
+// nsenter applet, so the tiny debug image is enough.
+//
+// The pod is transient: the renderer deletes it when the terminal closes
+// (stop_node_shell), and `activeDeadlineSeconds` reaps it after an hour in
+// case the app dies with the shell open.
+
+import { randomBytes } from 'node:crypto';
+
+import type { V1Pod } from '@kubernetes/client-node';
+
+import { getCoreV1Api } from '../k8s/client.js';
+import { k8sErrorMessage } from '../k8s/errors.js';
+import type { HandlerCtx, HandlerMap } from '../dispatch.js';
+
+const NODE_SHELL_IMAGE = 'busybox:1.36';
+const NODE_SHELL_NAMESPACE = 'kube-system';
+/** Safety reaper: the kubelet kills the pod even if the app never cleans up. */
+const NODE_SHELL_DEADLINE_SECONDS = 3600;
+
+const READY_TIMEOUT_MS = 60_000;
+const READY_POLL_INTERVAL_MS = 500;
+
+/** Label that marks node-shell pods; the renderer keys its exec wrapper on it. */
+export const NODE_SHELL_LABEL = 'kdashboard.io/node-shell';
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function reqStr(args: Record<string, unknown>, key: string): string {
+  const v = args[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new Error(`Missing or invalid '${key}' argument`);
+  }
+  return v;
+}
+
+/** The transient pod spec: privileged, host namespaces, pinned to the node. */
+export function buildNodeShellPod(name: string, namespace: string, nodeName: string): V1Pod {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      namespace,
+      labels: {
+        'app.kubernetes.io/managed-by': 'kdashboard',
+        [NODE_SHELL_LABEL]: 'true',
+      },
+      annotations: { [NODE_SHELL_LABEL]: nodeName },
+    },
+    spec: {
+      nodeName,
+      hostPID: true,
+      hostIPC: true,
+      hostNetwork: true,
+      restartPolicy: 'Never',
+      activeDeadlineSeconds: NODE_SHELL_DEADLINE_SECONDS,
+      terminationGracePeriodSeconds: 0,
+      // Cordoned/tainted nodes are exactly where a host shell is needed.
+      tolerations: [{ operator: 'Exists' }],
+      containers: [
+        {
+          name: 'shell',
+          image: NODE_SHELL_IMAGE,
+          // Sleep only — the PTY comes from a later exec (nsenter wrapper).
+          command: ['sh', '-c', 'sleep 2147483647'],
+          securityContext: { privileged: true },
+        },
+      ],
+    },
+  };
+}
+
+async function waitForPodRunning(name: string, namespace: string): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  let lastPhase = 'Pending';
+
+  while (Date.now() < deadline) {
+    const pod = await getCoreV1Api().readNamespacedPod({ name, namespace });
+    const phase = pod.status?.phase ?? 'Pending';
+    if (phase === 'Running') return;
+    if (phase === 'Failed' || phase === 'Succeeded') {
+      throw new Error(`Node shell pod ended prematurely (phase ${phase})`);
+    }
+    lastPhase = phase;
+    await sleep(READY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timed out waiting for the node shell pod to start (last phase: ${lastPhase})`);
+}
+
+/** Best-effort delete; NotFound is success (something else reaped it). */
+async function deleteNodeShellPod(name: string, namespace: string): Promise<void> {
+  try {
+    await getCoreV1Api().deleteNamespacedPod({ name, namespace, gracePeriodSeconds: 0 });
+  } catch (err) {
+    const msg = k8sErrorMessage(err);
+    if (!/not found/i.test(msg)) throw new Error(msg);
+  }
+}
+
+async function startNodeShell(args: Record<string, unknown>): Promise<{ name: string; namespace: string }> {
+  const nodeName = reqStr(args, 'nodeName');
+  const namespace =
+    typeof args.namespace === 'string' && args.namespace.length > 0
+      ? args.namespace
+      : NODE_SHELL_NAMESPACE;
+  const name = `kdashboard-node-shell-${randomBytes(3).toString('hex')}`;
+
+  try {
+    await getCoreV1Api().createNamespacedPod({
+      namespace,
+      body: buildNodeShellPod(name, namespace, nodeName),
+    });
+  } catch (err) {
+    throw new Error(k8sErrorMessage(err));
+  }
+
+  try {
+    await waitForPodRunning(name, namespace);
+  } catch (err) {
+    // Don't leave a dead privileged pod behind when startup fails.
+    await deleteNodeShellPod(name, namespace).catch(() => {});
+    throw new Error(k8sErrorMessage(err));
+  }
+
+  return { name, namespace };
+}
+
+export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
+  handlers.set('start_node_shell', async (args) => startNodeShell(args));
+  handlers.set('stop_node_shell', async (args) => {
+    await deleteNodeShellPod(reqStr(args, 'name'), reqStr(args, 'namespace'));
+    return null;
+  });
+}

--- a/electron/handlers/node-shell.ts
+++ b/electron/handlers/node-shell.ts
@@ -99,9 +99,18 @@ async function waitForPodRunning(name: string, namespace: string): Promise<void>
   throw new Error(`Timed out waiting for the node shell pod to start (last phase: ${lastPhase})`);
 }
 
-/** Best-effort delete; NotFound is success (something else reaped it). */
+/**
+ * Best-effort delete; NotFound is success (something else reaped it). Only
+ * pods carrying the node-shell label are deletable through this path — the
+ * renderer supplies name/namespace, and without the guard stop_node_shell
+ * would be a force-delete primitive for arbitrary pods.
+ */
 async function deleteNodeShellPod(name: string, namespace: string): Promise<void> {
   try {
+    const pod = await getCoreV1Api().readNamespacedPod({ name, namespace });
+    if (pod.metadata?.labels?.[NODE_SHELL_LABEL] !== 'true') {
+      throw new Error(`Pod ${namespace}/${name} is not a node shell pod`);
+    }
     await getCoreV1Api().deleteNamespacedPod({ name, namespace, gracePeriodSeconds: 0 });
   } catch (err) {
     const msg = k8sErrorMessage(err);

--- a/electron/k8s/kinds.test.ts
+++ b/electron/k8s/kinds.test.ts
@@ -102,6 +102,12 @@ describe('resolveResourceType', () => {
       group: 'admissionregistration.k8s.io',
       clusterScoped: true,
     });
+    expect(resolveResourceType('events')).toMatchObject({
+      group: '',
+      version: 'v1',
+      kind: 'Event',
+      clusterScoped: false,
+    });
   });
 
   test('returns undefined for a virtual view id', () => {

--- a/electron/k8s/kinds.ts
+++ b/electron/k8s/kinds.ts
@@ -124,6 +124,10 @@ export const RESOURCE_TYPES: Record<string, ResourceTypeEntry> = {
   priorityclasses: r('priorityclasses', 'scheduling.k8s.io', 'v1', 'priorityclasses', 'PriorityClass', true, synth('value', 'globalDefault', 'preemptionPolicy', 'description'), ['pc']),
   runtimeclasses: r('runtimeclasses', 'node.k8s.io', 'v1', 'runtimeclasses', 'RuntimeClass', true, synth('handler')),
   leases: r('leases', 'coordination.k8s.io', 'v1', 'leases', 'Lease', false, SPEC),
+  // core/v1 Event keeps everything at the top level (no spec/status), so the
+  // table fields ride in via `synth`. The per-resource get_events handler keeps
+  // serving the detail panel; this row is what backs the global Events view.
+  events: r('events', '', 'v1', 'events', 'Event', false, synth('type', 'reason', 'message', 'count', 'source', 'involvedObject', 'firstTimestamp', 'lastTimestamp', 'eventTime', 'series', 'reportingComponent'), ['ev']),
 };
 
 /** Resolve a `resource_type` (exact key, as sent by the frontend). */
@@ -146,9 +150,6 @@ function buildKinds(): Record<string, KindEntry> {
     out[entry.kind.toLowerCase()] = k;
     for (const alias of entry.aliases ?? []) out[alias.toLowerCase()] = k;
   }
-  // Events are addressable by kind (get_resource / YAML) but are not a listable
-  // sidebar resource_type — they have their own get_events handler.
-  out.event = { group: '', version: 'v1', plural: 'events', kind: 'Event', clusterScoped: false };
   return out;
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -46,6 +46,8 @@ import * as crd from './handlers/crd';
 import * as openapi from './handlers/openapi';
 import * as logs from './handlers/logs';
 import * as terminal from './handlers/terminal';
+import * as debug from './handlers/debug';
+import * as nodeShell from './handlers/node-shell';
 import * as portforward from './handlers/portforward';
 import * as watch from './handlers/watch';
 import * as updater from './handlers/updater';
@@ -306,6 +308,8 @@ function buildHandlerModules(): HandlerModule[] {
     // --- Phase 2: streaming subsystems ---
     logs, // stream_pod_logs, stream_multi_pod_logs, stop_log_stream
     terminal, // start_terminal_exec, send_terminal_input, resize_terminal, stop_terminal_exec
+    debug, // debug_pod (ephemeral debug containers)
+    nodeShell, // start_node_shell, stop_node_shell
     portforward, // start_port_forward, stop_port_forward
     watch, // start_resource_watch, stop_resource_watch
     updater, // __updater_check, __updater_download (+ background update-available notice)

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -294,7 +294,15 @@
 {/if}
 
 {#if dialogStore.compareOpen && dialogStore.compareResource}
-  <CompareDialog bind:open={dialogStore.compareOpen} resource={dialogStore.compareResource} />
+  <!-- Function binding: closing must go through closeCompare() so the stored
+       resource is cleared along with the open flag. -->
+  <CompareDialog
+    bind:open={
+      () => dialogStore.compareOpen,
+      (v) => { if (!v) dialogStore.closeCompare(); }
+    }
+    resource={dialogStore.compareResource}
+  />
 {/if}
 
 {#if dialogStore.deleteOpen && dialogStore.deleteResource}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,6 +18,7 @@
   import ConnectionErrorOverlay from "$lib/components/common/ConnectionErrorOverlay.svelte";
   import ScaleDialog from "$lib/components/details/ScaleDialog.svelte";
   import DrainDialog from "$lib/components/details/DrainDialog.svelte";
+  import CompareDialog from "$lib/components/details/CompareDialog.svelte";
   import ConfirmDialog from "$lib/components/common/ConfirmDialog.svelte";
   import { extensions } from "$lib/extensions";
   import { k8sStore } from "$lib/stores/k8s.svelte";
@@ -290,6 +291,10 @@
 
 {#if dialogStore.drainOpen && dialogStore.drainNodeName}
   <DrainDialog bind:open={dialogStore.drainOpen} nodeName={dialogStore.drainNodeName} />
+{/if}
+
+{#if dialogStore.compareOpen && dialogStore.compareResource}
+  <CompareDialog bind:open={dialogStore.compareOpen} resource={dialogStore.compareResource} />
 {/if}
 
 {#if dialogStore.deleteOpen && dialogStore.deleteResource}

--- a/src/lib/actions/registry.ts
+++ b/src/lib/actions/registry.ts
@@ -1,7 +1,7 @@
 import {
   FileText, Terminal, Scale, RotateCcw, History, Trash2,
   ClipboardCopy, GitFork, Pencil, Copy, FileJson,
-  ExternalLink, Pin, PinOff, Ban, CircleCheck, Droplets,
+  ExternalLink, Pin, PinOff, Ban, CircleCheck, Droplets, GitCompare,
 } from "lucide-svelte";
 import type { ActionDef, BulkActionDef } from "./types";
 import type { Resource } from "$lib/types";
@@ -130,6 +130,17 @@ export const resourceActions: ActionDef[] = [
     appliesTo: () => true,
     execute: () => uiStore.showYamlEditor(),
   },
+  {
+    id: "compare-namespaces",
+    label: "Compare Across Namespaces...",
+    icon: GitCompare,
+    tier: "green",
+    group: "navigate",
+    priority: 50,
+    // Only namespaced resources have siblings to diff against.
+    appliesTo: (_rt, resource) => !!resource?.metadata.namespace,
+    execute: (resource) => dialogStore.openCompare(resource),
+  },
   // --- Operations group ---
   {
     id: "scale",
@@ -205,6 +216,37 @@ export const resourceActions: ActionDef[] = [
         await setNodeSchedulable(resource.metadata.name, true);
       } catch (err) {
         toastStore.error("Uncordon failed", String(err));
+      }
+    },
+  },
+  {
+    id: "node-shell",
+    label: "Node Shell",
+    icon: Terminal,
+    tier: "yellow",
+    group: "operations",
+    priority: 33,
+    appliesTo: (rt) => rt === "nodes",
+    execute: async (resource) => {
+      const node = resource.metadata.name;
+      const toastId = toastStore.info("Starting node shell", `Creating a host shell pod on "${node}"…`);
+      try {
+        const { name, namespace } = await invoke<{ name: string; namespace: string }>(
+          "start_node_shell",
+          { nodeName: node },
+        );
+        const pod = await invoke<Resource>("get_resource", {
+          kind: "pod",
+          name,
+          namespace,
+        });
+        uiStore.showDetails(name, "pods", namespace, pod);
+        k8sStore.selectResource(pod);
+        uiStore.detailSubtab = "shell";
+      } catch (err) {
+        toastStore.error("Node shell failed", String(err));
+      } finally {
+        toastStore.dismiss(toastId);
       }
     },
   },

--- a/src/lib/components/common/StatusBadge.svelte
+++ b/src/lib/components/common/StatusBadge.svelte
@@ -31,6 +31,9 @@
     "false": "error",
     terminating: "orange",
     unknown: "muted",
+    // core/v1 Event types (global Events view)
+    normal: "muted",
+    warning: "warning",
   };
 
   const categoryColors: Record<StatusCategory, string> = {

--- a/src/lib/components/details/CompareDialog.svelte
+++ b/src/lib/components/details/CompareDialog.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { invoke } from "$lib/ipc/core";
+  import { Dialog, DialogContent } from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
+  import { SelectMenu } from "$lib/components/ui/select-menu";
+  import { FolderOpen } from "lucide-svelte";
+  import { k8sStore } from "$lib/stores/k8s.svelte";
+  import type { Resource } from "$lib/types";
+  import { loadCodeMirror, type CodeMirrorModules } from "$lib/utils/codemirror-lazy";
+  import { getExtensions } from "./codemirror-extensions";
+  import type { MergeView as MergeViewType } from "@codemirror/merge";
+
+  let { open = $bindable(false), resource }: {
+    open: boolean;
+    resource: Resource;
+  } = $props();
+
+  let targetNamespace = $state("");
+  let targetName = $state("");
+  let loading = $state(false);
+  let error = $state("");
+  let diffContainer: HTMLDivElement | undefined = $state();
+  let mergeView: MergeViewType | null = null;
+  let cm: CodeMirrorModules | null = null;
+  let hasDiff = $state(false);
+
+  // Candidate namespaces: everything the user can read, minus the source's own.
+  const namespaces = $derived(
+    k8sStore.namespaces.filter((ns) => ns !== (resource.metadata.namespace ?? "")),
+  );
+
+  $effect(() => {
+    if (open && resource) {
+      targetName = resource.metadata.name;
+      if (!targetNamespace || targetNamespace === resource.metadata.namespace) {
+        targetNamespace = namespaces[0] ?? "";
+      }
+      error = "";
+      hasDiff = false;
+      destroyMergeView();
+    }
+  });
+
+  function destroyMergeView() {
+    mergeView?.destroy();
+    mergeView = null;
+  }
+
+  async function fetchYaml(name: string, namespace: string): Promise<string> {
+    return invoke<string>("get_resource_yaml", {
+      kind: resource.kind,
+      name,
+      namespace,
+    });
+  }
+
+  async function compare() {
+    if (!targetNamespace || !targetName) return;
+    loading = true;
+    error = "";
+    try {
+      if (!cm) cm = await loadCodeMirror();
+      const [sourceYaml, targetYaml] = await Promise.all([
+        fetchYaml(resource.metadata.name, resource.metadata.namespace ?? ""),
+        fetchYaml(targetName, targetNamespace),
+      ]);
+      destroyMergeView();
+      hasDiff = true;
+      // The container renders with hasDiff — wait a tick for the bind.
+      await Promise.resolve();
+      if (!diffContainer) return;
+      const modules = cm;
+      const readOnlyExts = [
+        ...getExtensions(modules, "", () => {}, true),
+        modules.EditorView.editable.of(false),
+      ];
+      mergeView = new modules.MergeView({
+        a: { doc: sourceYaml, extensions: readOnlyExts },
+        b: { doc: targetYaml, extensions: readOnlyExts },
+        parent: diffContainer,
+        highlightChanges: true,
+        gutter: true,
+      });
+      mergeView.dom.style.height = "100%";
+      mergeView.dom.style.minHeight = "0";
+      mergeView.dom.style.overflowY = "auto";
+    } catch (err) {
+      hasDiff = false;
+      error = String(err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    if (!open) destroyMergeView();
+  });
+</script>
+
+<Dialog bind:open>
+  <DialogContent
+    class="flex h-[80vh] max-h-[80vh] flex-col sm:max-w-[1100px]"
+    aria-labelledby="compare-dialog-title"
+    aria-describedby="compare-dialog-desc"
+  >
+    <div class="flex min-h-0 flex-1 flex-col gap-3 p-1">
+      <div>
+        <h3 id="compare-dialog-title" class="text-[13px] font-semibold text-[var(--text-primary)]">
+          Compare {resource.kind}
+        </h3>
+        <p id="compare-dialog-desc" class="mt-1 text-[11px] text-[var(--text-muted)]">
+          {resource.metadata.namespace}/{resource.metadata.name} (left) against a sibling in another namespace (right)
+        </p>
+      </div>
+
+      <div class="flex items-center gap-2">
+        {#if namespaces.length > 0}
+          <SelectMenu
+            title="Target namespace"
+            value={targetNamespace}
+            items={namespaces.map((ns) => ({ value: ns, label: ns, onSelect: () => (targetNamespace = ns) }))}
+            contentClass="min-w-[180px]"
+          >
+            {#snippet icon()}<FolderOpen class="h-3 w-3 text-[var(--text-muted)]" />{/snippet}
+          </SelectMenu>
+        {:else}
+          <span class="text-[11px] text-[var(--text-muted)]">No other namespace available</span>
+        {/if}
+        <input
+          class="h-7 w-[220px] rounded-sm border border-[var(--border-color)] bg-[var(--bg-secondary)] px-2 font-mono text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+          bind:value={targetName}
+          placeholder="Target name"
+          aria-label="Target resource name"
+        />
+        <Button size="sm" mono onclick={compare} disabled={loading || !targetNamespace || !targetName}>
+          {loading ? "Comparing…" : "Compare"}
+        </Button>
+      </div>
+
+      {#if error}
+        <p class="text-[12px] text-[var(--status-failed)]">{error}</p>
+      {/if}
+
+      <div
+        class="min-h-0 flex-1 overflow-hidden rounded-sm border border-[var(--border-color)]"
+        class:hidden={!hasDiff}
+      >
+        <div bind:this={diffContainer} class="h-full"></div>
+      </div>
+      {#if !hasDiff && !error}
+        <div class="flex min-h-0 flex-1 items-center justify-center rounded-sm border border-dashed border-[var(--border-color)] text-[12px] text-[var(--text-muted)]">
+          Pick a target namespace and press Compare
+        </div>
+      {/if}
+    </div>
+  </DialogContent>
+</Dialog>

--- a/src/lib/components/table/ResourceTable.test.ts
+++ b/src/lib/components/table/ResourceTable.test.ts
@@ -324,6 +324,15 @@ describe("ResourceTable — events", () => {
       .toEqual(["old", "mid", "new"]);
   });
 
+  test("eventLastSeen compares parsed times, not strings (fractional seconds)", () => {
+    // Lexically "…00.500Z" < "…00Z", but it is the newer instant.
+    const items = [
+      makeEvent("whole", { eventTime: "2026-06-01T00:00:00Z" }),
+      makeEvent("fractional", { eventTime: "2026-06-01T00:00:00.500Z" }),
+    ];
+    expect(sortResources(items, "eventLastSeen", "asc")[0].metadata.name).toBe("fractional");
+  });
+
   test("eventLastSeen falls back to creation timestamp when unobserved", () => {
     const items = [
       makeEvent("observed", { lastTimestamp: "2026-06-01T00:00:00Z" }),

--- a/src/lib/components/table/ResourceTable.test.ts
+++ b/src/lib/components/table/ResourceTable.test.ts
@@ -306,6 +306,52 @@ describe("ResourceTable — sorting by type", () => {
   });
 });
 
+describe("ResourceTable — events", () => {
+  const makeEvent = (name: string, spec: Record<string, unknown>): Resource => ({
+    ...makeResource({ name, kind: "Event" }),
+    spec,
+  });
+
+  test("eventLastSeen sorts newest first on asc, oldest first on desc", () => {
+    const items = [
+      makeEvent("old", { lastTimestamp: "2026-01-01T00:00:00Z" }),
+      makeEvent("new", { lastTimestamp: "2026-06-01T00:00:00Z" }),
+      makeEvent("mid", { lastTimestamp: "2026-03-01T00:00:00Z" }),
+    ];
+    expect(sortResources(items, "eventLastSeen", "asc").map((r) => r.metadata.name))
+      .toEqual(["new", "mid", "old"]);
+    expect(sortResources(items, "eventLastSeen", "desc").map((r) => r.metadata.name))
+      .toEqual(["old", "mid", "new"]);
+  });
+
+  test("eventLastSeen falls back to creation timestamp when unobserved", () => {
+    const items = [
+      makeEvent("observed", { lastTimestamp: "2026-06-01T00:00:00Z" }),
+      { ...makeEvent("bare", {}), metadata: { ...makeResource({ name: "bare" }).metadata, name: "bare", creation_timestamp: "2026-07-01T00:00:00Z" } },
+    ];
+    expect(sortResources(items, "eventLastSeen", "asc")[0].metadata.name).toBe("bare");
+  });
+
+  test("eventReason sorts alphabetically", () => {
+    const items = [
+      makeEvent("b", { reason: "Pulled" }),
+      makeEvent("a", { reason: "BackOff" }),
+    ];
+    expect(sortResources(items, "eventReason", "asc")[0].metadata.name).toBe("a");
+  });
+
+  test("filter matches event reason and message, but only for Events", () => {
+    const items = [
+      makeEvent("ev-1", { reason: "BackOff", message: "Back-off restarting container" }),
+      makeEvent("ev-2", { reason: "Pulled", message: "Container image pulled" }),
+      { ...makeResource({ name: "pod-1" }), spec: { reason: "BackOff" } },
+    ];
+    const hits = filterResources(items, "backoff");
+    expect(hits.map((r) => r.metadata.name)).toEqual(["ev-1"]);
+    expect(filterResources(items, "image pulled").map((r) => r.metadata.name)).toEqual(["ev-2"]);
+  });
+});
+
 describe("ResourceTable — unknown sort column falls back to name", () => {
   test("sorts by name when column is unrecognised", () => {
     const items = [

--- a/src/lib/components/table/TableRow.svelte
+++ b/src/lib/components/table/TableRow.svelte
@@ -11,6 +11,8 @@
   import { costStore } from "$lib/stores/cost.svelte";
   import { metricsStore } from "$lib/stores/metrics.svelte";
   import { extensions } from "$lib/extensions";
+  import { KIND_TO_RESOURCE_TYPE } from "$lib/resource-catalog";
+  import { openRelatedResourceTab } from "$lib/actions/navigation";
   import {
     getCellValue,
     isContainersColumn,
@@ -120,6 +122,20 @@
   // Cells used to copy their value on double-click. That path was
   // unreachable: the row's own single click already opened the detail tab and
   // unmounted the table, so the second click never landed here.
+
+  // Events: the Object column deep-links to the involved resource when its
+  // Kind is one the catalog can navigate to (built-in kinds only — a CRD kind
+  // renders as plain text).
+  let eventObjectTarget = $derived.by(() => {
+    if (resourceType !== "events") return null;
+    const ref = resource.spec?.involvedObject as
+      | { kind?: string; name?: string; namespace?: string }
+      | undefined;
+    if (!ref?.kind || !ref.name) return null;
+    const type = KIND_TO_RESOURCE_TYPE[ref.kind];
+    if (!type) return null;
+    return { type, name: ref.name, namespace: ref.namespace ?? resource.metadata.namespace ?? undefined };
+  });
 </script>
 
 <tr
@@ -201,7 +217,7 @@
           </div>
         </div>
       {:else if isStatusColumn(column.key)}
-        {@const val = getCellValue(resource, "status", cellCtx)}
+        {@const val = getCellValue(resource, column.key, cellCtx)}
         {#if val !== "-"}
           <StatusBadge status={val} />
         {:else}
@@ -219,6 +235,18 @@
                 : "text-[var(--text-muted)]"
           )}
         >{restarts}</span>
+      {:else if column.key === "eventObject" && eventObjectTarget}
+        {@const label = getCellValue(resource, column.key, cellCtx)}
+        {@const target = eventObjectTarget}
+        <button
+          type="button"
+          class="block max-w-full truncate font-mono text-[12px] text-[var(--accent)] hover:underline"
+          title={label}
+          onclick={(e) => {
+            e.stopPropagation();
+            void openRelatedResourceTab(target.type, target.name, target.namespace);
+          }}
+        >{label}</button>
       {:else if isTagColumn(column.key)}
         {@const tagValue = getCellValue(resource, column.key, cellCtx)}
         {#if tagValue && tagValue !== "-" && tagValue !== "<none>"}

--- a/src/lib/components/table/cell-values.test.ts
+++ b/src/lib/components/table/cell-values.test.ts
@@ -182,6 +182,37 @@ describe("getCellValue — nodes", () => {
   });
 });
 
+describe("getCellValue — events", () => {
+  const event = (spec: Record<string, unknown>) => res({ spec });
+
+  test("eventType / eventReason / eventMessage read the synthetic spec", () => {
+    const e = event({ type: "Warning", reason: "BackOff", message: "Back-off restarting container" });
+    expect(getCellValue(e, "eventType")).toBe("Warning");
+    expect(getCellValue(e, "eventReason")).toBe("BackOff");
+    expect(getCellValue(e, "eventMessage")).toBe("Back-off restarting container");
+  });
+
+  test("eventObject renders Kind/name from involvedObject", () => {
+    const e = event({ involvedObject: { kind: "Pod", name: "web-0" } });
+    expect(getCellValue(e, "eventObject")).toBe("Pod/web-0");
+    expect(getCellValue(event({}), "eventObject")).toBe("-");
+  });
+
+  test("eventCount prefers count, falls back to series.count, then 1", () => {
+    expect(getCellValue(event({ count: 7 }), "eventCount")).toBe("7");
+    expect(getCellValue(event({ series: { count: 3 } }), "eventCount")).toBe("3");
+    expect(getCellValue(event({}), "eventCount")).toBe("1");
+  });
+
+  test("eventLastSeen prefers lastTimestamp over the other observation fields", () => {
+    const recent = new Date(Date.now() - 60_000).toISOString();
+    const old = new Date(Date.now() - 3_600_000).toISOString();
+    expect(getCellValue(event({ lastTimestamp: recent, firstTimestamp: old }), "eventLastSeen")).toBe("1m");
+    expect(getCellValue(event({ series: { lastObservedTime: recent } }), "eventLastSeen")).toBe("1m");
+    expect(getCellValue(event({ eventTime: recent }), "eventLastSeen")).toBe("1m");
+  });
+});
+
 describe("column families", () => {
   test("every usage column is routed to the meter renderer", () => {
     for (const key of ["cpuUsage", "memUsage", "podCpu", "podMemory"]) {

--- a/src/lib/components/table/cell-values.ts
+++ b/src/lib/components/table/cell-values.ts
@@ -57,6 +57,19 @@ function count(value: unknown): string {
 }
 
 /**
+ * When an Event was last observed: lastTimestamp for classic events, then the
+ * series / eventTime fields the events.k8s.io shapes use, then firstTimestamp.
+ * Null when the object carries none of them (caller falls back to creation).
+ */
+export function eventLastTimestamp(resource: Resource): string | null {
+  const spec = (resource.spec ?? {}) as Json;
+  const series = spec.series as { lastObservedTime?: string } | undefined;
+  const candidate =
+    spec.lastTimestamp ?? series?.lastObservedTime ?? spec.eventTime ?? spec.firstTimestamp;
+  return typeof candidate === "string" && candidate !== "" ? candidate : null;
+}
+
+/**
  * The value shown in `key`'s cell. Unknown keys render as "-", which is what
  * lets a resource type ship a column before its accessor exists.
  */
@@ -206,6 +219,26 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
     case "vaAttached":
       return bool(status.attached);
 
+    // --- Events -------------------------------------------------------------
+    // core/v1 Event fields ride in the synthetic spec (see kinds.ts `synth`).
+    case "eventLastSeen": {
+      void ctx.ageTick;
+      return formatAge(eventLastTimestamp(resource) ?? meta.creation_timestamp);
+    }
+    case "eventType":
+      return str(spec.type);
+    case "eventReason":
+      return str(spec.reason);
+    case "eventObject":
+      return refLabel(spec.involvedObject as { kind?: string; name?: string });
+    case "eventMessage":
+      return str(spec.message);
+    case "eventCount": {
+      const series = spec.series as { count?: number } | undefined;
+      const n = (spec.count as number) ?? series?.count;
+      return typeof n === "number" ? n.toString() : "1";
+    }
+
     // --- Scheduling / policy -----------------------------------------------
     case "pcValue":
       return spec.value === undefined ? NONE : String(spec.value);
@@ -247,6 +280,7 @@ const MONO_COLUMNS = new Set([
   "sliceEndpoints", "slicePorts", "scProvisioner", "vaAttacher", "vaVolume",
   "vaNode", "pcValue", "leaseHolder", "webhookCount", "webhookNames",
   "ingressController", "csiModes",
+  "eventLastSeen", "eventReason", "eventObject", "eventCount",
 ]);
 
 /** Short classifier cells, rendered as tag pills. */
@@ -262,7 +296,8 @@ const USAGE_COLUMNS = new Set(["cpuUsage", "memUsage", "podCpu", "podMemory"]);
 export const isMonoColumn = (key: string): boolean => MONO_COLUMNS.has(key);
 export const isTagColumn = (key: string): boolean => TAG_COLUMNS.has(key);
 export const isUsageColumn = (key: string): boolean => USAGE_COLUMNS.has(key);
-export const isStatusColumn = (key: string): boolean => key === "status" || key === "phase";
+export const isStatusColumn = (key: string): boolean =>
+  key === "status" || key === "phase" || key === "eventType";
 export const isContainersColumn = (key: string): boolean => key === "containers";
 
 // ---------------------------------------------------------------------------

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -90,13 +90,13 @@ export function sortResources(
       aVal = (a.spec?.type as string) ?? a.type ?? "";
       bVal = (b.spec?.type as string) ?? b.type ?? "";
     } else if (sortColumn === "eventLastSeen") {
-      aVal = eventLastTimestamp(a) ?? a.metadata.creation_timestamp;
-      bVal = eventLastTimestamp(b) ?? b.metadata.creation_timestamp;
+      // Parsed, not string-compared: eventTime is a MicroTime, and RFC 3339
+      // strings with and without fractional seconds do not sort lexically.
+      const aTime = Date.parse(eventLastTimestamp(a) ?? a.metadata.creation_timestamp);
+      const bTime = Date.parse(eventLastTimestamp(b) ?? b.metadata.creation_timestamp);
       // Like age: newest first when "asc", so the default view leads with
       // what the cluster did most recently.
-      return sortDirection === "asc"
-        ? bVal.localeCompare(aVal)
-        : aVal.localeCompare(bVal);
+      return sortDirection === "asc" ? bTime - aTime : aTime - bTime;
     } else if (sortColumn === "eventReason") {
       aVal = (a.spec?.reason as string) ?? "";
       bVal = (b.spec?.reason as string) ?? "";

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -1,4 +1,5 @@
 import type { Resource } from "$lib/types";
+import { eventLastTimestamp } from "./cell-values";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -23,15 +24,28 @@ export function clampColumnWidth(width: number): number {
   return Math.max(MIN_COL_WIDTH, width);
 }
 
-/** Text filtering — matches resource name or namespace case-insensitively. */
+/**
+ * Text filtering — matches resource name or namespace case-insensitively.
+ * Events additionally match on reason/message: their names are hashes the
+ * table does not even show, so name-only filtering would find nothing.
+ */
 export function filterResources(items: Resource[], filterText: string): Resource[] {
   if (!filterText) return items;
   const lower = filterText.toLowerCase();
-  return items.filter(
-    (r) =>
+  return items.filter((r) => {
+    if (
       r.metadata.name.toLowerCase().includes(lower) ||
-      (r.metadata.namespace ?? "").toLowerCase().includes(lower),
-  );
+      (r.metadata.namespace ?? "").toLowerCase().includes(lower)
+    ) {
+      return true;
+    }
+    if (r.kind !== "Event") return false;
+    const spec = r.spec as { reason?: unknown; message?: unknown } | undefined;
+    return (
+      (typeof spec?.reason === "string" && spec.reason.toLowerCase().includes(lower)) ||
+      (typeof spec?.message === "string" && spec.message.toLowerCase().includes(lower))
+    );
+  });
 }
 
 /** Sort resources by a given column and direction. */
@@ -72,9 +86,20 @@ export function sortResources(
       const aCount = aData && typeof aData === "object" ? Object.keys(aData).length : 0;
       const bCount = bData && typeof bData === "object" ? Object.keys(bData).length : 0;
       return sortDirection === "asc" ? aCount - bCount : bCount - aCount;
-    } else if (sortColumn === "type") {
+    } else if (sortColumn === "type" || sortColumn === "eventType") {
       aVal = (a.spec?.type as string) ?? a.type ?? "";
       bVal = (b.spec?.type as string) ?? b.type ?? "";
+    } else if (sortColumn === "eventLastSeen") {
+      aVal = eventLastTimestamp(a) ?? a.metadata.creation_timestamp;
+      bVal = eventLastTimestamp(b) ?? b.metadata.creation_timestamp;
+      // Like age: newest first when "asc", so the default view leads with
+      // what the cluster did most recently.
+      return sortDirection === "asc"
+        ? bVal.localeCompare(aVal)
+        : aVal.localeCompare(bVal);
+    } else if (sortColumn === "eventReason") {
+      aVal = (a.spec?.reason as string) ?? "";
+      bVal = (b.spec?.reason as string) ?? "";
     } else {
       aVal = a.metadata.name;
       bVal = b.metadata.name;

--- a/src/lib/components/table/table-columns.ts
+++ b/src/lib/components/table/table-columns.ts
@@ -229,6 +229,17 @@ export const columnsByType: Record<string, Column[]> = {
     { key: "webhookNames", label: "Names", sortable: false },
     { key: "age", label: "Age", sortable: true, width: "80px" },
   ],
+  // kubectl-style event listing: no Name column (event names are hashes), the
+  // message carries the signal. Default sort is eventLastSeen (see ui.logic).
+  events: [
+    { key: "eventLastSeen", label: "Last Seen", sortable: true, width: "90px" },
+    { key: "eventType", label: "Type", sortable: true, width: "100px" },
+    { key: "eventReason", label: "Reason", sortable: true, width: "160px" },
+    { key: "eventObject", label: "Object", sortable: false, width: "220px" },
+    { key: "eventMessage", label: "Message", sortable: false },
+    { key: "eventCount", label: "Count", sortable: false, width: "70px" },
+    { key: "namespace", label: "Namespace", sortable: true, width: "150px" },
+  ],
   validatingwebhookconfigurations: [
     { key: "name", label: "Name", sortable: true },
     { key: "webhookCount", label: "Webhooks", sortable: false, width: "100px" },

--- a/src/lib/components/terminal/TerminalView.svelte
+++ b/src/lib/components/terminal/TerminalView.svelte
@@ -33,17 +33,50 @@
   let initPromise: Promise<void> | null = null;
   let initError = $state<string | null>(null);
 
-  // Debug containers started this session — the selected resource is a
+  // Debug containers started on the current pod — the selected resource is a
   // snapshot, so freshly added ephemeral containers are not in its status yet.
+  // Cleared when the selection moves to another resource (see the identity
+  // effect below); they belong to one pod only.
   let debugContainers = $state<string[]>([]);
   let debugStarting = $state(false);
 
   // Node-shell pods (start_node_shell) are transient privileged pods that only
   // sleep; the real shell comes from nsenter-ing the host namespaces. The label
   // is set by electron/handlers/node-shell.ts.
+  const NODE_SHELL_LABEL = "kdashboard.io/node-shell";
   const isNodeShell = $derived(
-    k8sStore.selectedResource?.metadata.labels?.["kdashboard.io/node-shell"] === "true",
+    k8sStore.selectedResource?.metadata.labels?.[NODE_SHELL_LABEL] === "true",
   );
+
+  // The node-shell pod this view currently owns. It is a leaked privileged pod
+  // the moment its terminal is gone, so it is deleted when the selection moves
+  // away AND on unmount (the backend's activeDeadlineSeconds is only the
+  // fallback reaper). Plain variable: only the identity effect writes it.
+  let activeNodeShell: { name: string; namespace: string } | null = null;
+
+  function stopNodeShell(pod: { name: string; namespace: string }) {
+    invoke("stop_node_shell", pod).catch(() => {});
+  }
+
+  // React to the selected resource's identity, not a mount-time snapshot:
+  // reset per-pod debug containers and release the previous node-shell pod.
+  let selectedUid: string | undefined;
+  $effect(() => {
+    const resource = k8sStore.selectedResource;
+    const uid = resource?.metadata.uid;
+    if (uid === selectedUid) return;
+    selectedUid = uid;
+
+    debugContainers = [];
+
+    const next = isNodeShell && resource
+      ? { name: resource.metadata.name, namespace: resource.metadata.namespace ?? "" }
+      : null;
+    if (activeNodeShell && activeNodeShell.name !== next?.name) {
+      stopNodeShell(activeNodeShell);
+    }
+    activeNodeShell = next;
+  });
 
   const containers = $derived.by(() => {
     const resource = k8sStore.selectedResource;
@@ -284,21 +317,12 @@
   let autoStarted = false;
 
   onMount(() => {
-    // Captured on mount: the selection can change before the cleanup runs.
-    const mounted = k8sStore.selectedResource;
-    const mountedIsNodeShell =
-      mounted?.metadata.labels?.["kdashboard.io/node-shell"] === "true";
     return () => {
       destroyed = true;
       disconnect();
-      // A node-shell pod is a leaked privileged pod once its terminal is gone —
-      // delete it with the view (the backend's activeDeadlineSeconds is only
-      // the fallback reaper).
-      if (mountedIsNodeShell && mounted) {
-        invoke("stop_node_shell", {
-          name: mounted.metadata.name,
-          namespace: mounted.metadata.namespace ?? "",
-        }).catch(() => {});
+      if (activeNodeShell) {
+        stopNodeShell(activeNodeShell);
+        activeNodeShell = null;
       }
       // destroy() disconnects the internal ResizeObserver and the input handler.
       terminal?.destroy();

--- a/src/lib/components/terminal/TerminalView.svelte
+++ b/src/lib/components/terminal/TerminalView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Box, Trash2, TerminalSquare } from "lucide-svelte";
+  import { Box, Trash2, TerminalSquare, Bug } from "lucide-svelte";
+  import { toastStore } from "$lib/stores/toast.svelte";
   import { Button } from "$lib/components/ui";
   import { SelectMenu } from "$lib/components/ui/select-menu";
   import { listen } from "$lib/ipc/event";
@@ -32,13 +33,31 @@
   let initPromise: Promise<void> | null = null;
   let initError = $state<string | null>(null);
 
+  // Debug containers started this session — the selected resource is a
+  // snapshot, so freshly added ephemeral containers are not in its status yet.
+  let debugContainers = $state<string[]>([]);
+  let debugStarting = $state(false);
+
+  // Node-shell pods (start_node_shell) are transient privileged pods that only
+  // sleep; the real shell comes from nsenter-ing the host namespaces. The label
+  // is set by electron/handlers/node-shell.ts.
+  const isNodeShell = $derived(
+    k8sStore.selectedResource?.metadata.labels?.["kdashboard.io/node-shell"] === "true",
+  );
+
   const containers = $derived.by(() => {
     const resource = k8sStore.selectedResource;
+    const names: string[] = [];
     if (resource && resource.kind.toLowerCase() === "pod") {
       const statuses = resource.status?.containerStatuses as Array<{ name: string }> | undefined;
-      if (statuses) return statuses.map((c) => c.name);
+      if (statuses) names.push(...statuses.map((c) => c.name));
+      const ephemeral = resource.status?.ephemeralContainerStatuses as Array<{ name: string }> | undefined;
+      if (ephemeral) names.push(...ephemeral.map((c) => c.name));
     }
-    return [] as string[];
+    for (const name of debugContainers) {
+      if (!names.includes(name)) names.push(name);
+    }
+    return names;
   });
 
   $effect(() => {
@@ -188,7 +207,11 @@
         name: k8sStore.selectedResource.metadata.name,
         namespace: k8sStore.selectedResource.metadata.namespace ?? "",
         container: selectedContainer,
-        command: [selectedShell],
+        // Node-shell pods sleep in a privileged hostPID container; the shell
+        // itself runs in the HOST namespaces via nsenter (busybox applet).
+        command: isNodeShell
+          ? ["nsenter", "-t", "1", "-m", "-u", "-i", "-n", "-p", "--", selectedShell]
+          : [selectedShell],
       });
 
       // Send initial resize and focus after connection is established
@@ -219,6 +242,35 @@
     terminal?.write(CLEAR_SEQUENCE);
   }
 
+  /**
+   * kubectl debug: add an ephemeral debug container (busybox) targeting the
+   * selected container's process namespace, then connect the shell to it.
+   * Ephemeral containers cannot be removed — they die with the pod.
+   */
+  async function startDebugContainer() {
+    const resource = k8sStore.selectedResource;
+    if (!resource || debugStarting) return;
+    debugStarting = true;
+    try {
+      const result = await invoke<{ container: string }>("debug_pod", {
+        name: resource.metadata.name,
+        namespace: resource.metadata.namespace ?? "",
+        target: selectedContainer || undefined,
+      });
+      debugContainers = [...debugContainers, result.container];
+      selectedContainer = result.container;
+      toastStore.success(
+        "Debug container started",
+        `${result.container} attached to ${resource.metadata.name}. It lives until the pod is deleted.`,
+      );
+      await connect();
+    } catch (err) {
+      toastStore.error("Debug container failed", String(err));
+    } finally {
+      debugStarting = false;
+    }
+  }
+
   function handleContainerSelect(container: string) {
     selectedContainer = container;
     if (isConnected) connect();
@@ -232,9 +284,22 @@
   let autoStarted = false;
 
   onMount(() => {
+    // Captured on mount: the selection can change before the cleanup runs.
+    const mounted = k8sStore.selectedResource;
+    const mountedIsNodeShell =
+      mounted?.metadata.labels?.["kdashboard.io/node-shell"] === "true";
     return () => {
       destroyed = true;
       disconnect();
+      // A node-shell pod is a leaked privileged pod once its terminal is gone —
+      // delete it with the view (the backend's activeDeadlineSeconds is only
+      // the fallback reaper).
+      if (mountedIsNodeShell && mounted) {
+        invoke("stop_node_shell", {
+          name: mounted.metadata.name,
+          namespace: mounted.metadata.namespace ?? "",
+        }).catch(() => {});
+      }
       // destroy() disconnects the internal ResizeObserver and the input handler.
       terminal?.destroy();
       terminal = null;
@@ -339,6 +404,18 @@
     >
       {#snippet icon()}<TerminalSquare class="h-3 w-3 text-[var(--text-muted)]" />{/snippet}
     </SelectMenu>
+
+    <Button
+      variant="toolbar"
+      size="sm"
+      mono
+      title="Attach an ephemeral debug container (kubectl debug) and open a shell in it"
+      onclick={startDebugContainer}
+      disabled={debugStarting || !k8sStore.selectedResource}
+    >
+      <Bug class="h-3 w-3" />
+      <span>{debugStarting ? "Starting…" : "Debug"}</span>
+    </Button>
 
     <Button
       variant="toolbar"

--- a/src/lib/resource-catalog.ts
+++ b/src/lib/resource-catalog.ts
@@ -113,6 +113,7 @@ export const RESOURCE_SECTIONS: CatalogSection[] = [
     items: [
       { name: "Nodes", type: "nodes", kind: "Node", short: "no" },
       { name: "Namespaces", type: "namespaces", kind: "Namespace", short: "ns" },
+      { name: "Events", type: "events", kind: "Event", short: "ev" },
       { name: "Priority Classes", type: "priorityclasses", kind: "PriorityClass", short: "pc" },
       { name: "Runtime Classes", type: "runtimeclasses", kind: "RuntimeClass", short: "runtimeclass" },
       { name: "Leases", type: "leases", kind: "Lease", short: "lease" },

--- a/src/lib/resource-icons.ts
+++ b/src/lib/resource-icons.ts
@@ -8,7 +8,7 @@ import {
   HardDrive, HardDriveDownload, Archive, Key, Link, KeyRound, Users,
   Shield, ShieldCheck, ShieldAlert, PieChart, SlidersHorizontal, Share2,
   Plug, Route, UserCircle, Cable, Timer, Filter, CheckCircle2, ArrowUpNarrowWide,
-  Cog, Package,
+  Cog, Package, Activity,
 } from "lucide-svelte";
 import type { IconComponent } from "$lib/actions/types";
 
@@ -57,6 +57,7 @@ export const RESOURCE_ICONS: Record<string, IconComponent> = {
   // Cluster
   nodes: Server,
   namespaces: FolderOpen,
+  events: Activity,
   priorityclasses: ArrowUpNarrowWide,
   runtimeclasses: Cog,
   leases: Timer,

--- a/src/lib/stores/dialogs.logic.ts
+++ b/src/lib/stores/dialogs.logic.ts
@@ -23,6 +23,10 @@ export class DialogStoreLogic {
   // Upsell dialog (feature gate)
   upsellOpen = false;
 
+  // Compare dialog (diff a resource against its sibling in another namespace)
+  compareOpen = false;
+  compareResource: Resource | null = null;
+
   openScale(resource: Resource): void {
     this.scaleResource = {
       kind: resource.kind,
@@ -60,6 +64,16 @@ export class DialogStoreLogic {
 
   openUpsell(): void {
     this.upsellOpen = true;
+  }
+
+  openCompare(resource: Resource): void {
+    this.compareResource = resource;
+    this.compareOpen = true;
+  }
+
+  closeCompare(): void {
+    this.compareOpen = false;
+    this.compareResource = null;
   }
 
   closeUpsell(): void {

--- a/src/lib/stores/dialogs.svelte.ts
+++ b/src/lib/stores/dialogs.svelte.ts
@@ -14,6 +14,12 @@ class DialogStore extends DialogStoreLogic {
 
   upsellOpen = $state(false);
 
+  drainOpen = $state(false);
+  drainNodeName = $state<string | null>(null);
+
+  compareOpen = $state(false);
+  compareResource = $state<Resource | null>(null);
+
   constructor() {
     super();
     unshadowState(this);

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -64,6 +64,15 @@ export interface Tab {
 
 const EMPTY_SELECTED_ROWS: Set<string> = new Set();
 
+/**
+ * Sort column a tab starts on before the user picks one. Events lead with the
+ * most recent activity (their table has no Name column to sort by); everything
+ * else keeps the historical name sort.
+ */
+export function defaultSortColumn(tab: Tab | undefined | null): string {
+  return tab?.resourceType === "events" ? "eventLastSeen" : "name";
+}
+
 let _tabCounter = 0;
 function nextTabId(): string {
   return `tab-${++_tabCounter}`;
@@ -167,7 +176,7 @@ export class UiStoreLogic {
   }
 
   get sortColumn(): string {
-    return this.activeTab?.sortColumn ?? "name";
+    return this.activeTab?.sortColumn ?? defaultSortColumn(this.activeTab);
   }
   set sortColumn(v: string) {
     const t = this.activeTab;
@@ -452,7 +461,7 @@ export class UiStoreLogic {
   setSort(column: string): void {
     const t = this.activeTab;
     if (!t) return;
-    const currentCol = t.sortColumn ?? "name";
+    const currentCol = t.sortColumn ?? defaultSortColumn(t);
     const currentDir = t.sortDirection ?? "asc";
     if (currentCol === column) {
       t.sortDirection = currentDir === "asc" ? "desc" : "asc";

--- a/src/lib/utils/workload-stats.ts
+++ b/src/lib/utils/workload-stats.ts
@@ -467,6 +467,30 @@ export function computePVCStats(items: Resource[]): WorkloadStatsResult {
   };
 }
 
+export function computeEventStats(items: Resource[]): WorkloadStatsResult {
+  let normal = 0, warning = 0;
+
+  for (const item of items) {
+    // Event.type rides in the synthetic spec (see kinds.ts `synth`).
+    const type = (item.spec?.type as string) ?? "Normal";
+    if (type === "Warning") warning++;
+    else normal++;
+  }
+
+  const total = items.length;
+  return {
+    stats: [
+      { key: "total", label: "Total", value: total, color: "var(--accent)", subtitle: "events", filterable: false },
+      { key: "normal", label: "Normal", value: normal, color: "var(--status-running)", filterable: true },
+      { key: "warning", label: "Warning", value: warning, color: "var(--status-pending)", filterable: true },
+    ],
+    healthSegments: [
+      { key: "normal", value: normal, color: "var(--status-running)" },
+      { key: "warning", value: warning, color: "var(--status-pending)" },
+    ],
+  };
+}
+
 function computeDefaultStats(items: Resource[], resourceType: string): WorkloadStatsResult {
   return {
     stats: [
@@ -491,6 +515,7 @@ const computeByType: Record<string, (items: Resource[]) => WorkloadStatsResult> 
   secrets: computeSecretStats,
   namespaces: computeNamespaceStats,
   persistentvolumeclaims: computePVCStats,
+  events: computeEventStats,
 };
 
 export function computeWorkloadStats(resourceType: string, items: Resource[]): WorkloadStatsResult {
@@ -562,6 +587,12 @@ export function matchesStatFilter(resource: Resource, resourceType: string, filt
       if (filterKey === "active") return replicas > 0 && hasOwner && ready >= replicas;
       if (filterKey === "orphaned") return replicas > 0 && !hasOwner;
       if (filterKey === "mismatched") return replicas > 0 && ready < replicas;
+      return false;
+    }
+    case "events": {
+      const type = (resource.spec?.type as string) ?? "Normal";
+      if (filterKey === "warning") return type === "Warning";
+      if (filterKey === "normal") return type !== "Warning";
       return false;
     }
     case "secrets": {


### PR DESCRIPTION
## Summary

Four features closing gaps against Lens / k9s / Headlamp, plus one latent reactivity bugfix.

### Global Events view
- New `events` row in the resource registry (`electron/k8s/kinds.ts`): core/v1 Events keep everything top-level, so table fields ride in via `synth`. Replaces the old ad-hoc `out.event` kind entry.
- kubectl-style columns (Last Seen, Type, Reason, Object, Message, Count, Namespace) with no Name column — event names are hashes.
- Newest-first default sort via `eventLastTimestamp` (lastTimestamp → series.lastObservedTime → eventTime → firstTimestamp).
- Filtering also matches event reason/message; Object column deep-links to the involved resource; Normal/Warning stat tiles.

### Ephemeral debug containers (kubectl debug)
- New `debug_pod` handler: strategic-merge patch on the pod's `ephemeralcontainers` subresource, then polls until the container runs (image-pull failures and terminations fail fast with the real reason).
- Debug button in the pod terminal attaches a busybox container targeting the selected container's process namespace and opens a shell in it.

### Node shell (kubectl-node-shell style)
- New `start_node_shell`/`stop_node_shell` handlers: transient privileged hostPID/hostIPC/hostNetwork pod pinned to the node (tolerates all taints, `activeDeadlineSeconds: 3600` as a fallback reaper).
- The terminal execs `nsenter -t 1 -m -u -i -n -p -- <shell>` into the host namespaces; the pod is deleted when the terminal view closes.

### Compare Across Namespaces
- New resource action opening a dialog that fetches both YAMLs and renders a read-only CodeMirror MergeView (lazy-loaded) of the resource against its sibling in another namespace.

### Bugfix
- `drainOpen`/`drainNodeName` lacked `$state` overrides in `dialogs.svelte.ts`, so the drain dialog was not reactive. Fixed while adding the compare dialog state.

## Test plan
- Unit: `bun test` — 1157 frontend + 130 electron pass (new coverage for kinds row, event cell values, event sorting/filtering, debug patch/state classification, node-shell pod spec).
- e2e: new `events-view.spec.ts` and `compare-dialog.spec.ts` pass; preexisting `resource-table`/`detail-panel` failures verified unrelated (same on clean tree).
- Manual: events feed, debug container attach, node shell, and namespace compare exercised against a GKE cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes Events view with live updates, newest-first sorting, Normal/Warning summaries, search, filtering, and links to involved resources.
  * Added read-only YAML comparison across namespaces for namespaced resources.
  * Added node shell access with automatic startup and cleanup.
  * Added ephemeral debug-container support from terminal views, including status feedback and failure reporting.
* **Documentation**
  * Documented the Events feed and its filtering and summary features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->