### PR TITLE
perf: cut CPU, memory, network and IPC costs across main process and renderer

### DIFF
--- a/electron/handlers/connection.ts
+++ b/electron/handlers/connection.ts
@@ -230,6 +230,7 @@ async function filterNamespacesByAccess(names: string[]): Promise<string[]> {
   }
 
   const auth = getAuthorizationV1Api();
+  let degraded = false;
   const allowed = await mapWithConcurrency(names, ACCESS_REVIEW_CONCURRENCY, async (namespace) => {
     try {
       const review = await auth.createSelfSubjectAccessReview({
@@ -241,12 +242,19 @@ async function filterNamespacesByAccess(names: string[]): Promise<string[]> {
       });
       return review.status?.allowed ? namespace : null;
     } catch {
+      degraded = true;
       return namespace;
     }
   });
   const filtered = allowed.filter((n): n is string => n !== null);
   const visible = filtered.length > 0 ? filtered : names;
-  accessReviewCache.set(cacheKey, { at: now, inputKey, visible });
+  // Only cache clean verdicts: both fail-open paths (a failed review, or a
+  // filter that would hide everything) are transient degradations — pinning
+  // them for the whole TTL would keep the wrong list after the apiserver
+  // recovers.
+  if (!degraded && filtered.length > 0) {
+    accessReviewCache.set(cacheKey, { at: now, inputKey, visible });
+  }
   return visible;
 }
 

--- a/electron/handlers/connection.ts
+++ b/electron/handlers/connection.ts
@@ -31,11 +31,14 @@ import { load as yamlLoad, dump as yamlDump } from 'js-yaml';
 
 import type { HandlerCtx, HandlerMap } from '../dispatch';
 import {
+  getActiveContextName,
   getAuthorizationV1Api,
   getCoreV1Api,
   getKubeconfigPath,
+  onConfigChange,
   setActiveContext,
 } from '../k8s/client';
+import { mapWithConcurrency } from '../util/concurrency';
 
 // ---------------------------------------------------------------------------
 // Return-type aliases — these mirror the Rust `Result<T, String>` payloads.
@@ -88,15 +91,33 @@ interface KubeconfigYaml {
   [key: string]: unknown;
 }
 
+/**
+ * Parsed-kubeconfig cache keyed by (path, mtime, size): get_contexts and
+ * get_current_context both run on the boot path and on every context refresh,
+ * and a multi-cluster kubeconfig is a non-trivial synchronous YAML parse. A
+ * stat per call is cheap and catches external edits immediately.
+ */
+let kubeconfigCache: { file: string; mtimeMs: number; size: number; yaml: KubeconfigYaml } | null =
+  null;
+
 function readKubeconfigYaml(): KubeconfigYaml {
   const file = resolveKubeconfigPath();
+  const stat = fs.statSync(file);
+  if (
+    kubeconfigCache &&
+    kubeconfigCache.file === file &&
+    kubeconfigCache.mtimeMs === stat.mtimeMs &&
+    kubeconfigCache.size === stat.size
+  ) {
+    return kubeconfigCache.yaml;
+  }
   const contents = fs.readFileSync(file, 'utf8');
   const parsed = yamlLoad(contents);
-  if (parsed === null || typeof parsed !== 'object') {
-    // Mirror serde_yaml: an empty/scalar doc has no contexts / current-context.
-    return {};
-  }
-  return parsed as KubeconfigYaml;
+  // Mirror serde_yaml: an empty/scalar doc has no contexts / current-context.
+  const yaml =
+    parsed !== null && typeof parsed === 'object' ? (parsed as KubeconfigYaml) : {};
+  kubeconfigCache = { file, mtimeMs: stat.mtimeMs, size: stat.size, yaml };
+  return yaml;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +198,15 @@ async function listNamespaces(): Promise<NameList> {
   return filterNamespacesByAccess(names);
 }
 
+const ACCESS_REVIEW_TTL_MS = 5 * 60_000;
+// 16 matches the typed client's keepAlive maxSockets: enough parallelism to
+// keep the first namespace load fast, without the old N-simultaneous-requests
+// stampede on big clusters.
+const ACCESS_REVIEW_CONCURRENCY = 16;
+
+const accessReviewCache = new Map<string, { at: number; inputKey: string; visible: string[] }>();
+onConfigChange(() => accessReviewCache.clear());
+
 /**
  * Keep only namespaces the current user can actually work in, probed with a
  * SelfSubjectAccessReview for `list pods` per namespace (the minimal verb the
@@ -186,26 +216,40 @@ async function listNamespaces(): Promise<NameList> {
  */
 async function filterNamespacesByAccess(names: string[]): Promise<string[]> {
   if (names.length === 0) return names;
+
+  // One SelfSubjectAccessReview POST per namespace is an N+1 hot spot on big
+  // clusters (hundreds of simultaneous requests on every namespace refresh).
+  // RBAC changes are rare: cache the verdict per context for a few minutes and
+  // bound the concurrency of the misses.
+  const cacheKey = getActiveContextName() ?? '';
+  const now = Date.now();
+  const hit = accessReviewCache.get(cacheKey);
+  const inputKey = names.join('\n');
+  if (hit && now - hit.at < ACCESS_REVIEW_TTL_MS && hit.inputKey === inputKey) {
+    return hit.visible;
+  }
+
   const auth = getAuthorizationV1Api();
-  const allowed = await Promise.all(
-    names.map(async (namespace) => {
-      try {
-        const review = await auth.createSelfSubjectAccessReview({
-          body: {
-            spec: {
-              resourceAttributes: { namespace, verb: 'list', resource: 'pods' },
-            },
+  const allowed = await mapWithConcurrency(names, ACCESS_REVIEW_CONCURRENCY, async (namespace) => {
+    try {
+      const review = await auth.createSelfSubjectAccessReview({
+        body: {
+          spec: {
+            resourceAttributes: { namespace, verb: 'list', resource: 'pods' },
           },
-        });
-        return review.status?.allowed ? namespace : null;
-      } catch {
-        return namespace;
-      }
-    }),
-  );
-  const visible = allowed.filter((n): n is string => n !== null);
-  return visible.length > 0 ? visible : names;
+        },
+      });
+      return review.status?.allowed ? namespace : null;
+    } catch {
+      return namespace;
+    }
+  });
+  const filtered = allowed.filter((n): n is string => n !== null);
+  const visible = filtered.length > 0 ? filtered : names;
+  accessReviewCache.set(cacheKey, { at: now, inputKey, visible });
+  return visible;
 }
+
 
 // ---------------------------------------------------------------------------
 // check_connection — probe the apiserver with a limit=1 namespace list.

--- a/electron/handlers/helm.test.ts
+++ b/electron/handlers/helm.test.ts
@@ -51,7 +51,7 @@ describe('decodeRelease', () => {
       Buffer.from('"just a string"', 'utf8').toString('base64'),
       'utf8',
     ).toString('base64');
-    expect(decodeRelease(notAnObject)).rejects.toThrow('not a JSON object');
+    await expect(decodeRelease(notAnObject)).rejects.toThrow('not a JSON object');
   });
 });
 

--- a/electron/handlers/helm.test.ts
+++ b/electron/handlers/helm.test.ts
@@ -29,29 +29,29 @@ function encodeAsSecretData(obj: unknown): string {
 }
 
 describe('decodeRelease', () => {
-  test('unwraps base64 -> base64 -> gzip -> JSON', () => {
-    expect(decodeRelease(encodeAsSecretData(RELEASE))).toEqual(RELEASE);
+  test('unwraps base64 -> base64 -> gzip -> JSON', async () => {
+    expect(await decodeRelease(encodeAsSecretData(RELEASE))).toEqual(RELEASE);
   });
 
-  test('accepts a payload with only helm\'s gzip layer (no second base64)', () => {
+  test('accepts a payload with only helm\'s gzip layer (no second base64)', async () => {
     const singleLayer = gzipSync(Buffer.from(JSON.stringify(RELEASE), 'utf8')).toString('base64');
-    expect(decodeRelease(singleLayer)).toEqual(RELEASE);
+    expect(await decodeRelease(singleLayer)).toEqual(RELEASE);
   });
 
-  test('accepts an uncompressed JSON payload', () => {
+  test('accepts an uncompressed JSON payload', async () => {
     const plain = Buffer.from(
       Buffer.from(JSON.stringify(RELEASE), 'utf8').toString('base64'),
       'utf8',
     ).toString('base64');
-    expect(decodeRelease(plain)).toEqual(RELEASE);
+    expect(await decodeRelease(plain)).toEqual(RELEASE);
   });
 
-  test('throws on a payload that is not a release object', () => {
+  test('throws on a payload that is not a release object', async () => {
     const notAnObject = Buffer.from(
       Buffer.from('"just a string"', 'utf8').toString('base64'),
       'utf8',
     ).toString('base64');
-    expect(() => decodeRelease(notAnObject)).toThrow('not a JSON object');
+    expect(decodeRelease(notAnObject)).rejects.toThrow('not a JSON object');
   });
 });
 

--- a/electron/handlers/helm.ts
+++ b/electron/handlers/helm.ts
@@ -15,11 +15,17 @@
 // helm binary and no extra RBAC beyond "get secrets" in the namespace. Nothing
 // here writes: install/upgrade/rollback stay out of scope.
 
-import { gunzipSync } from 'node:zlib';
+import { gunzip } from 'node:zlib';
+import { promisify } from 'node:util';
+
+// Async gunzip: release payloads carry the full rendered manifest (often MBs);
+// gunzipSync would block the main-process event loop once per release.
+const gunzipAsync = promisify(gunzip);
 
 import { getCoreV1Api } from '../k8s/client.js';
 import { apiGet, META_ACCEPT } from '../k8s/api.js';
 import { k8sErrorMessage } from '../k8s/errors.js';
+import { mapWithConcurrency } from '../util/concurrency.js';
 import type { HandlerMap } from '../dispatch.js';
 
 const HELM_OWNER_SELECTOR = 'owner=helm';
@@ -83,7 +89,7 @@ interface RawRelease {
  * Exported for the tests: this is the one piece of real logic in the module and
  * the double-base64 is exactly the part that silently breaks.
  */
-export function decodeRelease(data: string): RawRelease {
+export async function decodeRelease(data: string): Promise<RawRelease> {
   // Layer 1: the Kubernetes API's own base64 of the Secret value.
   let buf = Buffer.from(data, 'base64');
   // Layer 2: helm's base64, present unless something already unwrapped it.
@@ -93,7 +99,7 @@ export function decodeRelease(data: string): RawRelease {
   // Layer 3: gzip, which helm has used for every release since v3.
   const json =
     buf[0] === GZIP_MAGIC[0] && buf[1] === GZIP_MAGIC[1]
-      ? gunzipSync(buf).toString('utf8')
+      ? (await gunzipAsync(buf)).toString('utf8')
       : buf.toString('utf8');
 
   const parsed = JSON.parse(json) as unknown;
@@ -230,6 +236,10 @@ export function latestPerRelease(secrets: SecretMeta[]): SecretMeta[] {
   return [...best.values()];
 }
 
+/** Cap on simultaneous release-secret reads: N releases used to mean N
+ * parallel requests + N decompressions all at once. */
+const READ_RELEASE_CONCURRENCY = 8;
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -238,16 +248,14 @@ async function listHelmReleases(args: Record<string, unknown>): Promise<HelmRele
   const namespace = optNamespace(args);
   const latest = latestPerRelease(await listReleaseSecrets(namespace));
 
-  const releases = await Promise.all(
-    latest.map(async (s) => {
-      try {
-        return releaseSummary(await readRelease(s.namespace, s.name));
-      } catch {
-        // A single unreadable/corrupt release must not blank the whole list.
-        return null;
-      }
-    }),
-  );
+  const releases = await mapWithConcurrency(latest, READ_RELEASE_CONCURRENCY, async (s) => {
+    try {
+      return releaseSummary(await readRelease(s.namespace, s.name));
+    } catch {
+      // A single unreadable/corrupt release must not blank the whole list.
+      return null;
+    }
+  });
 
   return releases
     .filter((r): r is HelmRelease => r !== null)
@@ -275,15 +283,13 @@ async function listHelmReleaseHistory(args: Record<string, unknown>): Promise<He
   const namespace = reqStr(args, 'namespace');
 
   const secrets = await listReleaseSecrets(namespace, name);
-  const revisions = await Promise.all(
-    secrets.map(async (s) => {
-      try {
-        return releaseSummary(await readRelease(s.namespace, s.name));
-      } catch {
-        return null;
-      }
-    }),
-  );
+  const revisions = await mapWithConcurrency(secrets, READ_RELEASE_CONCURRENCY, async (s) => {
+    try {
+      return releaseSummary(await readRelease(s.namespace, s.name));
+    } catch {
+      return null;
+    }
+  });
 
   return revisions
     .filter((r): r is HelmRelease => r !== null)

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -150,16 +150,15 @@ function makeLineSink(
 
   return new Writable({
     write(chunk: Buffer, _enc, cb) {
-      partial += chunk.toString('utf8');
-      let idx = partial.indexOf('\n');
-      while (idx !== -1) {
-        // Strip the trailing '\n' (and a preceding '\r' if present) — the
-        // renderer expects complete lines with no trailing newline.
-        let line = partial.slice(0, idx);
+      // Single split per chunk — re-slicing `partial` per line is O(n²) on
+      // chunks with many lines. The last piece (no trailing '\n') carries over.
+      const pieces = (partial + chunk.toString('utf8')).split('\n');
+      partial = pieces.pop() ?? '';
+      for (let line of pieces) {
+        // Strip a preceding '\r' if present — the renderer expects complete
+        // lines with no trailing newline.
         if (line.endsWith('\r')) line = line.slice(0, -1);
         pushLine(line);
-        partial = partial.slice(idx + 1);
-        idx = partial.indexOf('\n');
       }
       cb();
     },

--- a/electron/handlers/metrics.ts
+++ b/electron/handlers/metrics.ts
@@ -13,7 +13,7 @@
 
 import { Metrics, type PodMetric } from '@kubernetes/client-node';
 
-import { kc } from '../k8s/client.js';
+import { kc, onConfigChange } from '../k8s/client.js';
 import { parseCpu, parseMemory } from '../k8s/quantity.js';
 import { getPrometheusUrl } from '../k8s/runtime-config.js';
 import type { HandlerMap } from '../dispatch.js';
@@ -87,8 +87,28 @@ export function podUsageFrom(pm: PodMetric): PodUsageInfo {
   };
 }
 
+/**
+ * Short-lived coalescing cache: two views (pods table + usage card) can ask
+ * for the same namespace's metrics in the same window; metrics-server only
+ * rescrapes every ~60s, so serving the same promise for a few seconds dedupes
+ * the request without visible staleness. Cleared on context switch.
+ */
+const POD_METRICS_COALESCE_MS = 5_000;
+const podMetricsCache = new Map<string, { at: number; promise: Promise<PodMetricsResult> }>();
+onConfigChange(() => podMetricsCache.clear());
+
 async function getPodMetrics(args: Record<string, unknown>): Promise<PodMetricsResult> {
   const namespace = optStr(args, 'namespace');
+  const key = namespace ?? '';
+  const now = Date.now();
+  const hit = podMetricsCache.get(key);
+  if (hit && now - hit.at < POD_METRICS_COALESCE_MS) return hit.promise;
+  const promise = fetchPodMetrics(namespace);
+  podMetricsCache.set(key, { at: now, promise });
+  return promise;
+}
+
+async function fetchPodMetrics(namespace: string | undefined): Promise<PodMetricsResult> {
   try {
     const response = await new Metrics(kc()).getPodMetrics(namespace);
     return { available: true, reason: '', pods: response.items.map(podUsageFrom) };

--- a/electron/handlers/terminal.ts
+++ b/electron/handlers/terminal.ts
@@ -88,12 +88,16 @@ const TERMINAL_FLUSH_BYTES = 64 * 1024;
 
 interface OutputCoalescer {
   push: (text: string) => void;
-  flush: () => void;
+  /** Flush what's buffered and drop anything that arrives afterwards — the
+   *  WebSocket close is not immediate, so late in-flight writes must not leak
+   *  a previous pod's output into a replacement session. */
+  close: () => void;
 }
 
 function makeOutputCoalescer(emit: (chunk: string) => void): OutputCoalescer {
   let buf = '';
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
   const flush = (): void => {
     if (timer) {
       clearTimeout(timer);
@@ -106,6 +110,7 @@ function makeOutputCoalescer(emit: (chunk: string) => void): OutputCoalescer {
   };
   return {
     push(text: string): void {
+      if (closed) return;
       buf += text;
       if (buf.length >= TERMINAL_FLUSH_BYTES) {
         flush();
@@ -113,7 +118,10 @@ function makeOutputCoalescer(emit: (chunk: string) => void): OutputCoalescer {
         timer = setTimeout(flush, TERMINAL_FLUSH_MS);
       }
     },
-    flush,
+    close(): void {
+      flush();
+      closed = true;
+    },
   };
 }
 
@@ -133,9 +141,10 @@ function endSession(notify: boolean, ctx: HandlerCtx | null): void {
   if (!current) return;
   session = null;
 
-  // Deliver any buffered output before the exit event.
+  // Deliver any buffered output before the exit event, then seal the
+  // coalescer so late in-flight writes can't emit into a replacement session.
   try {
-    current.output.flush();
+    current.output.close();
   } catch {
     /* ignore */
   }

--- a/electron/handlers/terminal.ts
+++ b/electron/handlers/terminal.ts
@@ -76,10 +76,52 @@ class OutputStream extends Writable {
   }
 }
 
+/**
+ * Coalesce PTY output into one IPC send per flush window. Without this every
+ * WebSocket chunk becomes its own structured-clone `webContents.send` — a
+ * `cat bigfile` produces thousands of IPC messages per second. 8 ms keeps
+ * keystroke echo imperceptible while capping sends at ~125/s; the byte cap
+ * bounds renderer message size under heavy output.
+ */
+const TERMINAL_FLUSH_MS = 8;
+const TERMINAL_FLUSH_BYTES = 64 * 1024;
+
+interface OutputCoalescer {
+  push: (text: string) => void;
+  flush: () => void;
+}
+
+function makeOutputCoalescer(emit: (chunk: string) => void): OutputCoalescer {
+  let buf = '';
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const flush = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (buf.length === 0) return;
+    const out = buf;
+    buf = '';
+    emit(out);
+  };
+  return {
+    push(text: string): void {
+      buf += text;
+      if (buf.length >= TERMINAL_FLUSH_BYTES) {
+        flush();
+      } else if (!timer) {
+        timer = setTimeout(flush, TERMINAL_FLUSH_MS);
+      }
+    },
+    flush,
+  };
+}
+
 interface Session {
   ws: WebSocket;
   stdin: PassThrough;
   stdout: OutputStream;
+  output: OutputCoalescer;
 }
 
 /** Single active session (matches the Rust OnceLock<Option<...>> single slot). */
@@ -91,6 +133,12 @@ function endSession(notify: boolean, ctx: HandlerCtx | null): void {
   if (!current) return;
   session = null;
 
+  // Deliver any buffered output before the exit event.
+  try {
+    current.output.flush();
+  } catch {
+    /* ignore */
+  }
   try {
     current.stdin.end();
   } catch {
@@ -132,10 +180,11 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
     endSession(false, ctx);
 
     const stdin = new PassThrough();
-    const stdout = new OutputStream((text) => ctx.emit(TERMINAL_OUTPUT, text), 80, 24);
+    const output = makeOutputCoalescer((text) => ctx.emit(TERMINAL_OUTPUT, text));
+    const stdout = new OutputStream((text) => output.push(text), 80, 24);
     // stderr shares the same channel — interactive shells multiplex onto stdout
     // anyway, but a TTY-less write to stderr must still reach the user.
-    const stderr = new OutputStream((text) => ctx.emit(TERMINAL_OUTPUT, text), 80, 24);
+    const stderr = new OutputStream((text) => output.push(text), 80, 24);
 
     const exec = new Exec(kc());
 
@@ -162,7 +211,7 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
       throw new Error(`Failed to start terminal exec: ${(err as Error).message}`);
     }
 
-    session = { ws, stdin, stdout };
+    session = { ws, stdin, stdout, output };
 
     // If the socket dies for any reason (server close, network error), make sure
     // we clean up and tell the renderer the session ended.

--- a/electron/handlers/topology.ts
+++ b/electron/handlers/topology.ts
@@ -16,17 +16,15 @@
 // root_ids, has_cycles, total_resources, cluster_groups, ...). The Svelte types
 // in src/lib/types/cluster.ts depend on exactly these names.
 
-import { AutoscalingV2Api } from '@kubernetes/client-node';
-
 import type { HandlerCtx, HandlerMap } from '../dispatch';
 import {
   getActiveContextName,
   getCoreV1Api,
   getAppsV1Api,
   getBatchV1Api,
-  getNetworkingV1Api,
-  makeApiClient,
+  onConfigChange,
 } from '../k8s/client';
+import { apiGet, META_ACCEPT } from '../k8s/api';
 import {
   asObject,
   asArray,
@@ -496,13 +494,31 @@ interface TopologyCacheEntry {
   promise: Promise<TopologyGraph>;
 }
 
+/** Bounded: each entry pins a full graph; without a cap the map grows with
+ * every namespace/context ever visited and the stale graphs are never GC'd. */
+const TOPOLOGY_CACHE_MAX_ENTRIES = 8;
+
 const topologyCache = new Map<string, TopologyCacheEntry>();
+
+// A context switch invalidates everything (keys embed the context, but stale
+// graphs for other contexts would otherwise sit in memory indefinitely).
+onConfigChange(() => topologyCache.clear());
 
 async function getNamespaceTopology(namespace: string | null): Promise<TopologyGraph> {
   const key = `${getActiveContextName() ?? ''}|${namespace ?? ''}`;
   const now = Date.now();
   const hit = topologyCache.get(key);
   if (hit && now - hit.at < TOPOLOGY_CACHE_TTL_MS) return hit.promise;
+
+  // Evict expired entries, then the oldest if still at capacity.
+  for (const [k, v] of topologyCache) {
+    if (now - v.at >= TOPOLOGY_CACHE_TTL_MS) topologyCache.delete(k);
+  }
+  while (topologyCache.size >= TOPOLOGY_CACHE_MAX_ENTRIES) {
+    const oldest = topologyCache.keys().next().value;
+    if (oldest === undefined) break;
+    topologyCache.delete(oldest);
+  }
 
   const promise = fetchNamespaceTopology(namespace);
   topologyCache.set(key, { at: now, promise });
@@ -513,15 +529,32 @@ async function getNamespaceTopology(namespace: string | null): Promise<TopologyG
   return promise;
 }
 
+/**
+ * Metadata-only list via content negotiation. Kinds whose graph node needs no
+ * status/spec field (see extractStatusStr) fetch a PartialObjectMetadataList —
+ * uid/name/namespace/ownerReferences are all in metadata, and the payload is a
+ * tiny fraction of the full body (listing every Secret/ConfigMap cluster-wide
+ * with full bodies was the dominant cost of building the graph). The Accept
+ * header falls back to a normal list server-side if the kind doesn't support
+ * the projection.
+ */
+async function listMeta(group: string, version: string, plural: string, ns: string | null): Promise<JsonValue[]> {
+  const base = group === '' ? `/api/${version}` : `/apis/${group}/${version}`;
+  const path = ns
+    ? `${base}/namespaces/${encodeURIComponent(ns)}/${plural}`
+    : `${base}/${plural}`;
+  const list = await apiGet<{ items?: JsonValue[] }>(path, undefined, META_ACCEPT);
+  return list.items ?? [];
+}
+
 async function fetchNamespaceTopology(namespace: string | null): Promise<TopologyGraph> {
   const core = getCoreV1Api();
   const apps = getAppsV1Api();
   const batch = getBatchV1Api();
-  const net = getNetworkingV1Api();
-  const autoscaling = makeApiClient(AutoscalingV2Api);
 
   // Each entry mirrors one fetch_typed! arm in queries.rs (kind + apiVersion +
-  // namespaced/all-namespaces list fn).
+  // namespaced/all-namespaces list fn). Kinds needing a status/spec field keep
+  // the typed full-body list; the rest go metadata-only (listMeta above).
   const fetches: Array<Promise<RawResource[]>> = [
     fetchTyped(
       (ns) =>
@@ -541,15 +574,7 @@ async function fetchNamespaceTopology(namespace: string | null): Promise<Topolog
       'Deployment',
       'apps/v1',
     ),
-    fetchTyped(
-      (ns) =>
-        ns
-          ? apps.listNamespacedReplicaSet({ namespace: ns }).then(itemsOf)
-          : apps.listReplicaSetForAllNamespaces().then(itemsOf),
-      namespace,
-      'ReplicaSet',
-      'apps/v1',
-    ),
+    fetchTyped((ns) => listMeta('apps', 'v1', 'replicasets', ns), namespace, 'ReplicaSet', 'apps/v1'),
     fetchTyped(
       (ns) =>
         ns
@@ -577,15 +602,7 @@ async function fetchNamespaceTopology(namespace: string | null): Promise<Topolog
       'Job',
       'batch/v1',
     ),
-    fetchTyped(
-      (ns) =>
-        ns
-          ? batch.listNamespacedCronJob({ namespace: ns }).then(itemsOf)
-          : batch.listCronJobForAllNamespaces().then(itemsOf),
-      namespace,
-      'CronJob',
-      'batch/v1',
-    ),
+    fetchTyped((ns) => listMeta('batch', 'v1', 'cronjobs', ns), namespace, 'CronJob', 'batch/v1'),
     fetchTyped(
       (ns) =>
         ns
@@ -596,37 +613,15 @@ async function fetchNamespaceTopology(namespace: string | null): Promise<Topolog
       'v1',
     ),
     fetchTyped(
-      (ns) =>
-        ns
-          ? net.listNamespacedIngress({ namespace: ns }).then(itemsOf)
-          : net.listIngressForAllNamespaces().then(itemsOf),
+      (ns) => listMeta('networking.k8s.io', 'v1', 'ingresses', ns),
       namespace,
       'Ingress',
       'networking.k8s.io/v1',
     ),
+    fetchTyped((ns) => listMeta('', 'v1', 'configmaps', ns), namespace, 'ConfigMap', 'v1'),
+    fetchTyped((ns) => listMeta('', 'v1', 'secrets', ns), namespace, 'Secret', 'v1'),
     fetchTyped(
-      (ns) =>
-        ns
-          ? core.listNamespacedConfigMap({ namespace: ns }).then(itemsOf)
-          : core.listConfigMapForAllNamespaces().then(itemsOf),
-      namespace,
-      'ConfigMap',
-      'v1',
-    ),
-    fetchTyped(
-      (ns) =>
-        ns
-          ? core.listNamespacedSecret({ namespace: ns }).then(itemsOf)
-          : core.listSecretForAllNamespaces().then(itemsOf),
-      namespace,
-      'Secret',
-      'v1',
-    ),
-    fetchTyped(
-      (ns) =>
-        ns
-          ? autoscaling.listNamespacedHorizontalPodAutoscaler({ namespace: ns }).then(itemsOf)
-          : autoscaling.listHorizontalPodAutoscalerForAllNamespaces().then(itemsOf),
+      (ns) => listMeta('autoscaling', 'v2', 'horizontalpodautoscalers', ns),
       namespace,
       'HorizontalPodAutoscaler',
       'autoscaling/v2',

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -38,6 +38,7 @@
 import { Watch } from '@kubernetes/client-node';
 
 import { kc } from '../k8s/client';
+import { apiGet, META_ACCEPT } from '../k8s/api';
 import type { RawObject, Resource } from '../k8s/resource-types';
 import { dynamicToResource, listProjectionFor } from '../k8s/resource-mapping';
 import { apiVersionOf, resolveResourceType } from '../k8s/kinds';
@@ -242,6 +243,17 @@ async function startResourceWatch(
     }
   };
 
+  /** Tell the renderer to do a full relist (covers deltas a watch can't replay). */
+  const emitResync = (): void => {
+    ctx.emit(WATCH_CHANNEL, [
+      {
+        event_type: 'Resync',
+        resource_type: resourceType,
+        resource: { api_version: '', kind: '', metadata: {} },
+      } satisfies WatchEvent,
+    ]);
+  };
+
   const watch = new Watch(kc());
 
   // The start invoke resolves/rejects with the FIRST connection attempt only:
@@ -268,6 +280,28 @@ async function startResourceWatch(
       }
     };
 
+    /**
+     * Reconnecting with NO resourceVersion makes the apiserver replay the
+     * whole collection as ADDED — N projections + N/20 IPC batches that the
+     * renderer's Resync relist duplicates anyway. When the RV expired (410),
+     * grab a fresh one from a metadata-only limit=1 list instead: the list's
+     * RV is a valid watch start point, and the Resync relist covers anything
+     * missed in between. Falls back to the classic replay on failure.
+     */
+    const seedRV = async (): Promise<void> => {
+      try {
+        const list = await apiGet<{ metadata?: { resourceVersion?: string } }>(
+          path,
+          { limit: '1' },
+          META_ACCEPT,
+        );
+        const rv = list?.metadata?.resourceVersion;
+        if (rv && isCurrent() && !state.lastRV) state.lastRV = rv;
+      } catch {
+        // keep lastRV unset — the reconnect replays and the Resync path holds
+      }
+    };
+
     /** Schedule a reconnect with exponential backoff + jitter (0.5x-1x the delay). */
     const scheduleReconnect = (): void => {
       if (!isCurrent()) return;
@@ -275,7 +309,11 @@ async function startResourceWatch(
       state.backoffMs = Math.min(state.backoffMs * 2, BACKOFF_MAX_MS);
       state.reconnectTimer = setTimeout(() => {
         state.reconnectTimer = null;
-        connect();
+        if (!state.lastRV && state.hadInitialSync) {
+          void seedRV().then(connect);
+        } else {
+          connect();
+        }
       }, delay);
     };
 
@@ -361,17 +399,7 @@ async function startResourceWatch(
               // relist in a loop.
               if (!state.lastRV && (healthy || rvExpired)) {
                 rvExpired = false;
-                ctx.emit(WATCH_CHANNEL, [
-                  {
-                    event_type: 'Resync',
-                    resource_type: resourceType,
-                    resource: {
-                      api_version: '',
-                      kind: '',
-                      metadata: {},
-                    },
-                  } satisfies WatchEvent,
-                ]);
+                emitResync();
               }
             } else {
               // First connection's natural close (e.g. the 30s server window)
@@ -402,12 +430,16 @@ async function startResourceWatch(
             `[watch] failed to open watch for ${resourceType} (hadInitialSync=${state.hadInitialSync})`,
             err instanceof Error ? err.message : err,
           );
-          // A 410 at open means our resume RV already expired: drop it so the
-          // retry does a fresh replay, and force a Resync on the next close.
+          // A 410 at open means our resume RV already expired. Drop it (the
+          // retry seeds a fresh RV, or replays if that fails) and tell the
+          // renderer to relist NOW: deletes that happened past the expired RV
+          // can never be replayed, so without this Resync stale rows would
+          // linger until some later healthy-close resync.
           const status = (err as { code?: number; statusCode?: number } | undefined);
           if (status?.code === 410 || status?.statusCode === 410) {
             state.lastRV = undefined;
-            rvExpired = true;
+            rvExpired = false;
+            if (state.hadInitialSync && isCurrent()) emitResync();
           }
           // Failed to OPEN the watch. If this is the first attempt, tear down
           // and reject the start invoke; otherwise keep the loop alive with

--- a/electron/k8s/api.ts
+++ b/electron/k8s/api.ts
@@ -5,7 +5,7 @@
 // list used by every kind), and content negotiation for metadata-only lists.
 // Both live here so handlers share one implementation of auth + TLS + headers.
 
-import { kc } from './client';
+import { kc, clusterAuthHeaders, expireClusterAuth } from './client';
 
 /**
  * Metadata-only content negotiation: the apiserver returns a
@@ -17,7 +17,14 @@ import { kc } from './client';
 export const META_ACCEPT =
   'application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json';
 
-/** Issue an authenticated GET against the active cluster, returning parsed JSON. */
+/**
+ * Issue an authenticated GET against the active cluster, returning parsed JSON.
+ *
+ * Auth headers come from the shared per-cluster cache in client.ts (the same
+ * one the typed clients use — one TTL, one single-flight, one invalidation);
+ * TLS is handled by the undici dispatcher installed there. A 401 expires the
+ * cache and retries once in case the token rotated inside the TTL window.
+ */
 export async function apiGet<T>(
   path: string,
   query?: Record<string, string>,
@@ -33,34 +40,21 @@ export async function apiGet<T>(
     for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
   }
 
-  // applyToFetchOptions injects auth headers + the TLS agent (client certs/CA).
-  const opts = await cfg.applyToFetchOptions({});
-  opts.method = 'GET';
-  if (accept) {
-    // Content negotiation (e.g. PartialObjectMetadataList for counts) — far
-    // smaller payloads, much faster to transfer + JSON.parse.
-    //
-    // applyToFetchOptions hands back a Headers INSTANCE, whose entries live
-    // behind a symbol key: spreading it produced `{[Symbol(map)]: …}`, which
-    // fetch rejects ("Key Symbol(map) … cannot be converted to a ByteString").
-    // Every counted request threw and get_resource_counts swallowed it as 0,
-    // so the sidebar counts were silently always zero. Go through Headers.
-    const merged: Record<string, string> = {};
-    const existing: unknown = opts.headers;
-    if (existing instanceof Headers) {
-      existing.forEach((value, key) => {
-        merged[key] = value;
-      });
-    } else if (existing && typeof existing === 'object') {
-      for (const [key, value] of Object.entries(existing as Record<string, string>)) {
-        merged[key] = String(value);
-      }
+  const doFetch = async (): Promise<Response> => {
+    const headers: Record<string, string> = { ...(await clusterAuthHeaders()) };
+    if (accept) {
+      // Content negotiation (e.g. PartialObjectMetadataList for counts) — far
+      // smaller payloads, much faster to transfer + JSON.parse.
+      headers.Accept = accept;
     }
-    merged.Accept = accept;
-    opts.headers = merged;
-  }
+    return fetch(url.toString(), { method: 'GET', headers });
+  };
 
-  const resp = await fetch(url.toString(), opts as RequestInit);
+  let resp = await doFetch();
+  if (resp.status === 401) {
+    expireClusterAuth();
+    resp = await doFetch();
+  }
   if (!resp.ok) {
     const body = await resp.text().catch(() => '');
     throw new Error(`${resp.status} ${resp.statusText}${body ? `: ${body}` : ''}`);

--- a/electron/k8s/api.ts
+++ b/electron/k8s/api.ts
@@ -52,6 +52,8 @@ export async function apiGet<T>(
 
   let resp = await doFetch();
   if (resp.status === 401) {
+    // Release the discarded body — unread, it pins the pooled connection.
+    await resp.body?.cancel().catch(() => {});
     expireClusterAuth();
     resp = await doFetch();
   }

--- a/electron/k8s/client.ts
+++ b/electron/k8s/client.ts
@@ -274,9 +274,15 @@ class CachedClusterAuth {
       return this.#cached;
     }
     // Single-flight: concurrent calls during a refresh share one rebuild.
-    this.#pending ??= this.#build().finally(() => {
-      this.#pending = null;
-    });
+    if (!this.#pending) {
+      const p = this.#build();
+      this.#pending = p;
+      // Guarded clear: expire() may have replaced #pending with a fresher
+      // build by the time this one settles — never null out someone else's.
+      void p.finally(() => {
+        if (this.#pending === p) this.#pending = null;
+      });
+    }
     const fresh = await this.#pending;
     if (this.#cached && this.#cached !== fresh) this.#destroyAgent(this.#cached);
     this.#cached = fresh;
@@ -313,8 +319,11 @@ class CachedClusterAuth {
   }
 
   /** Force the next getAuth() to rebuild (e.g. after a 401), without leaking
-   *  the current agent — the rebuild swap destroys it. */
+   *  the current agent — the rebuild swap destroys it. Also drops an in-flight
+   *  rebuild: it started BEFORE the 401, so its material may be the very token
+   *  that just got rejected; the next getAuth() starts a fresh build. */
   expire(): void {
+    this.#pending = null;
     if (this.#cached) this.#cached = { ...this.#cached, at: 0 };
   }
 

--- a/electron/k8s/client.ts
+++ b/electron/k8s/client.ts
@@ -10,12 +10,17 @@
 //   - allow switching the active context at runtime (switch_context)
 
 import * as fs from 'node:fs';
+import * as https from 'node:https';
 import * as tls from 'node:tls';
 
 import { Agent, setGlobalDispatcher, type Dispatcher } from 'undici';
 
 import {
   KubeConfig,
+  createConfiguration,
+  ServerConfiguration,
+  type Configuration,
+  type RequestContext,
   CoreV1Api,
   AppsV1Api,
   CustomObjectsApi,
@@ -230,6 +235,143 @@ function installTlsDispatcher(cfg: KubeConfig): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Typed-client auth caching + connection reuse.
+//
+// KubeConfig.makeApiClient wires the KubeConfig itself in as the request
+// authenticator, and its applySecurityAuthentication re-reads ca/cert/key
+// FILES synchronously and builds a brand-new `https.Agent` (keepAlive: false)
+// on EVERY request — a full TCP+TLS handshake per typed API call. This wrapper
+// runs that work once, swaps the agent for a shared keepAlive one, and replays
+// the recorded headers/agent onto each request. A short TTL keeps rotating
+// tokens working; a config change tears everything down.
+// ---------------------------------------------------------------------------
+
+const AUTH_CACHE_TTL_MS = 30_000;
+
+interface RecordedAuth {
+  at: number;
+  headers: Record<string, string>;
+  agent: unknown;
+}
+
+class CachedClusterAuth {
+  #cfg: KubeConfig;
+  #cached: RecordedAuth | null = null;
+  #pending: Promise<RecordedAuth> | null = null;
+
+  constructor(cfg: KubeConfig) {
+    this.#cfg = cfg;
+  }
+
+  getName(): string {
+    return 'default';
+  }
+
+  /** The cached auth material, rebuilt (single-flight) when the TTL lapses. */
+  async getAuth(): Promise<RecordedAuth> {
+    if (this.#cached && Date.now() - this.#cached.at < AUTH_CACHE_TTL_MS) {
+      return this.#cached;
+    }
+    // Single-flight: concurrent calls during a refresh share one rebuild.
+    this.#pending ??= this.#build().finally(() => {
+      this.#pending = null;
+    });
+    const fresh = await this.#pending;
+    if (this.#cached && this.#cached !== fresh) this.#destroyAgent(this.#cached);
+    this.#cached = fresh;
+    return fresh;
+  }
+
+  async applySecurityAuthentication(context: RequestContext): Promise<void> {
+    const auth = await this.getAuth();
+    for (const [k, v] of Object.entries(auth.headers)) context.setHeaderParam(k, v);
+    context.setAgent(auth.agent as Parameters<RequestContext['setAgent']>[0]);
+  }
+
+  async #build(): Promise<RecordedAuth> {
+    const headers: Record<string, string> = {};
+    let agent: unknown;
+    // Record what the real implementation would have applied to the request.
+    const recorder = {
+      setHeaderParam: (key: string, value: string): void => {
+        headers[key] = value;
+      },
+      setAgent: (a: unknown): void => {
+        agent = a;
+      },
+    };
+    await this.#cfg.applySecurityAuthentication(recorder as unknown as RequestContext);
+    // Rebuild plain https agents with keepAlive so sockets are reused across
+    // calls. Proxy agents (constructor !== https.Agent) are kept verbatim.
+    if (agent && (agent as object).constructor === https.Agent) {
+      const opts = (agent as https.Agent).options ?? {};
+      (agent as https.Agent).destroy();
+      agent = new https.Agent({ ...opts, keepAlive: true, maxSockets: 16 });
+    }
+    return { at: Date.now(), headers, agent };
+  }
+
+  /** Force the next getAuth() to rebuild (e.g. after a 401), without leaking
+   *  the current agent — the rebuild swap destroys it. */
+  expire(): void {
+    if (this.#cached) this.#cached = { ...this.#cached, at: 0 };
+  }
+
+  #destroyAgent(entry: RecordedAuth): void {
+    const agent = entry.agent as { destroy?: () => void } | undefined;
+    try {
+      agent?.destroy?.();
+    } catch {
+      // ignore
+    }
+  }
+
+  destroy(): void {
+    if (this.#cached) this.#destroyAgent(this.#cached);
+    this.#cached = null;
+  }
+}
+
+let typedAuth: CachedClusterAuth | null = null;
+let typedConfiguration: Configuration | null = null;
+
+onConfigChange(() => {
+  typedAuth?.destroy();
+  typedAuth = null;
+  typedConfiguration = null;
+});
+
+function typedConfigFor(cfg: KubeConfig): Configuration {
+  if (!typedConfiguration) {
+    const cluster = cfg.getCurrentCluster();
+    if (!cluster) {
+      throw new Error('No active cluster!');
+    }
+    typedAuth = new CachedClusterAuth(cfg);
+    typedConfiguration = createConfiguration({
+      baseServer: new ServerConfiguration(cluster.server, {}),
+      authMethods: { default: typedAuth },
+    });
+  }
+  return typedConfiguration;
+}
+
+/**
+ * Cached auth headers for the active cluster, shared with the typed clients
+ * (one TTL, one single-flight, one invalidation path). The raw fetch path
+ * (api.ts) uses these — its TLS is handled by the undici dispatcher above.
+ */
+export async function clusterAuthHeaders(): Promise<Record<string, string>> {
+  typedConfigFor(kc());
+  return (await typedAuth!.getAuth()).headers;
+}
+
+/** Force the next auth read to rebuild — call on a 401 (token likely rotated). */
+export function expireClusterAuth(): void {
+  typedAuth?.expire();
+}
+
 /**
  * Generic typed Api factory. Prefer the named getters below; reach for this
  * only when you need an Api class not covered by a dedicated getter.
@@ -237,41 +379,42 @@ function installTlsDispatcher(cfg: KubeConfig): void {
  *   const metrics = makeApiClient(MetricsV1beta1Api)
  */
 export function makeApiClient<T extends ApiType>(apiClientType: ApiConstructor<T>): T {
-  return kc().makeApiClient(apiClientType);
+  const cfg = kc();
+  return new apiClientType(typedConfigFor(cfg));
 }
 
 export function getCoreV1Api(): CoreV1Api {
-  return kc().makeApiClient(CoreV1Api);
+  return makeApiClient(CoreV1Api);
 }
 
 export function getAppsV1Api(): AppsV1Api {
-  return kc().makeApiClient(AppsV1Api);
+  return makeApiClient(AppsV1Api);
 }
 
 export function getCustomObjectsApi(): CustomObjectsApi {
-  return kc().makeApiClient(CustomObjectsApi);
+  return makeApiClient(CustomObjectsApi);
 }
 
 export function getApiextensionsV1Api(): ApiextensionsV1Api {
-  return kc().makeApiClient(ApiextensionsV1Api);
+  return makeApiClient(ApiextensionsV1Api);
 }
 
 export function getBatchV1Api(): BatchV1Api {
-  return kc().makeApiClient(BatchV1Api);
+  return makeApiClient(BatchV1Api);
 }
 
 export function getNetworkingV1Api(): NetworkingV1Api {
-  return kc().makeApiClient(NetworkingV1Api);
+  return makeApiClient(NetworkingV1Api);
 }
 
 export function getRbacAuthorizationV1Api(): RbacAuthorizationV1Api {
-  return kc().makeApiClient(RbacAuthorizationV1Api);
+  return makeApiClient(RbacAuthorizationV1Api);
 }
 
 export function getAuthorizationV1Api(): AuthorizationV1Api {
-  return kc().makeApiClient(AuthorizationV1Api);
+  return makeApiClient(AuthorizationV1Api);
 }
 
 export function getVersionApi(): VersionApi {
-  return kc().makeApiClient(VersionApi);
+  return makeApiClient(VersionApi);
 }

--- a/electron/util/concurrency.ts
+++ b/electron/util/concurrency.ts
@@ -1,0 +1,24 @@
+// Small shared async utilities for the main process.
+
+/**
+ * Map `items` through `fn` with at most `limit` promises in flight, preserving
+ * input order. Used to bound fan-outs against the apiserver (access reviews,
+ * helm secret reads) that would otherwise fire N simultaneous requests.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/src/lib/components/command-palette/CommandPalette.svelte
+++ b/src/lib/components/command-palette/CommandPalette.svelte
@@ -292,6 +292,14 @@
 
   let orderedGroups = $derived.by(() => orderGroups(groupedItems, categoryOrder));
 
+  // O(1) index lookup for the template — `filteredItems.indexOf(item)` per
+  // rendered item was O(N²) per keystroke on clusters with many CRDs/namespaces.
+  let itemIndex = $derived.by(() => {
+    const map = new Map<(typeof filteredItems)[number], number>();
+    filteredItems.forEach((item, i) => map.set(item, i));
+    return map;
+  });
+
   $effect(() => {
     query;
     selectedIndex = 0;
@@ -374,7 +382,7 @@
             {/if}
             <CommandGroup heading={category}>
               {#each items as item}
-                {@const globalIndex = filteredItems.indexOf(item)}
+                {@const globalIndex = itemIndex.get(item) ?? -1}
                 {@const IconComp = getItemIcon(item)}
                 <CommandItem
                   class={cn(

--- a/src/lib/components/details/DetailPanel.svelte
+++ b/src/lib/components/details/DetailPanel.svelte
@@ -36,12 +36,21 @@
   // re-fetches the full object on demand. Other types carry full data in the
   // list already and need no hydration.
   let hydrated = $state<Resource | null>(null);
+  // Keyed on uid+resourceVersion: selectedResource is reassigned on every
+  // Applied watch event for this uid, and the initial watch replay re-applies
+  // the same version — without the key each of those fired another get_resource
+  // IPC round-trip serializing the full object.
+  let hydratedKey = "";
   $effect(() => {
     const li = listItem;
     if (!li || (li.kind ?? "").toLowerCase() !== "pod") {
       hydrated = null;
+      hydratedKey = "";
       return;
     }
+    const key = `${li.metadata?.uid ?? ""}@${li.metadata?.resource_version ?? ""}`;
+    if (key === hydratedKey) return;
+    hydratedKey = key;
     const uid = li.metadata?.uid;
     invoke<Resource>("get_resource", {
       kind: li.kind,

--- a/src/lib/components/details/YamlEditor.svelte
+++ b/src/lib/components/details/YamlEditor.svelte
@@ -137,8 +137,18 @@
     }
   });
 
+  // Key the reload on the resource's IDENTITY, not the object reference:
+  // selectedResource is reassigned on every Applied watch event for this uid,
+  // and reloading then would tear down and rebuild the whole CodeMirror editor
+  // (plus an IPC round-trip) per status churn — discarding in-progress edits.
+  let loadedKey: string | undefined;
   $effect(() => {
-    if (resource) {
+    if (!resource) return;
+    const key =
+      resource.metadata?.uid ??
+      `${resource.kind}/${resource.metadata?.namespace ?? ""}/${resource.metadata?.name ?? ""}`;
+    if (key !== loadedKey) {
+      loadedKey = key;
       loadYaml(resource);
     }
   });

--- a/src/lib/components/details/YamlEditor.svelte
+++ b/src/lib/components/details/YamlEditor.svelte
@@ -223,6 +223,10 @@
       error = `Failed to load YAML: ${err}`;
       originalYaml = "";
       currentContent = "";
+      // A failed load must stay retryable: clear the identity key so the next
+      // watch event (or re-selection) for this resource triggers a fresh load
+      // instead of being skipped as "already loaded".
+      loadedKey = undefined;
     } finally {
       isLoading = false;
     }

--- a/src/lib/components/logs/LogViewer.svelte
+++ b/src/lib/components/logs/LogViewer.svelte
@@ -31,7 +31,11 @@
   import LogDetailSheet from "./LogDetailSheet.svelte";
 
   // --- Core state ---
-  let logs = $state<LogLine[]>([]);
+  // $state.raw: at streaming rates a deep proxy would wrap every LogLine (and
+  // the template's _jsonHighlightedCache writes through the proxy would
+  // invalidate the very render effect that reads them, double-rendering JSON
+  // rows). The array is only ever replaced wholesale, never mutated in place.
+  let logs = $state.raw<LogLine[]>([]);
   let filterText = $state("");
   let showTimestamps = $state(true);
   let selectedContainer = $state("");
@@ -91,11 +95,11 @@
     const shouldScroll = !userScrolledAway;
 
     if (pendingLogs.length > 0) {
-      logs.push(...pendingLogs);
+      // Reassign (never push): `logs` is $state.raw, in-place mutation would
+      // not be tracked.
+      const merged = logs.length > 0 ? logs.concat(pendingLogs) : pendingLogs;
+      logs = merged.length > tailLines ? merged.slice(-tailLines) : merged;
       pendingLogs = [];
-      if (logs.length > tailLines) {
-        logs = logs.slice(-tailLines);
-      }
     }
     flushScheduled = false;
 
@@ -108,8 +112,17 @@
     }
   }
 
+  // Coalesce to one layout read per frame: isAtBottom() reads
+  // scrollHeight/scrollTop synchronously, and scroll events fire far more
+  // often than frames during a fast wheel/drag.
+  let scrollCheckScheduled = false;
   function handleScroll() {
-    userScrolledAway = !isAtBottom();
+    if (scrollCheckScheduled) return;
+    scrollCheckScheduled = true;
+    requestAnimationFrame(() => {
+      scrollCheckScheduled = false;
+      userScrolledAway = !isAtBottom();
+    });
   }
 
   function jumpToBottom() {

--- a/src/lib/components/table/ResourceTable.svelte
+++ b/src/lib/components/table/ResourceTable.svelte
@@ -65,6 +65,9 @@
     // previous one and must not be treated as fresh.
     void metricsStore.loadPodMetrics(ns, true);
     const timer = setInterval(() => {
+      // A minimized/hidden window doesn't need fresh metrics — skip the IPC +
+      // cluster fetch; the next visible tick (or re-entry) refreshes.
+      if (document.hidden) return;
       void metricsStore.loadPodMetrics(ns);
     }, POD_METRICS_TTL_MS);
     return () => clearInterval(timer);
@@ -257,11 +260,9 @@
 
   let workloadStats = $derived(computeWorkloadStats(k8sStore.selectedResourceType, k8sStore.resources.items));
 
-  let needsAttentionCount = $derived(
-    k8sStore.selectedResourceType === "pods"
-      ? k8sStore.resources.items.filter(isPodNeedingAttention).length
-      : 0
-  );
+  // Folded into computePodStats' single pass over the items (walking every
+  // containerStatus twice per flush was measurable on big namespaces).
+  let needsAttentionCount = $derived(workloadStats.needsAttention ?? 0);
 
   // Auto-clear stat filter on resource type change.
   // prevResourceType is a plain `let` so the effect only tracks selectedResourceType.

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -13,11 +13,17 @@ export const MIN_COL_WIDTH = 40;
 
 export type SortDirection = "asc" | "desc";
 
-// NOTE: we use String.prototype.localeCompare directly here, NOT a cached
-// Intl.Collator. A micro-benchmark on 3000 names showed the cached collator is
-// ~1.5-2x SLOWER than localeCompare in JavaScriptCore (the Tauri webview engine
-// on macOS/Linux) and also changes ordering semantics — so the "cache a
-// collator" optimization is a regression for this runtime. See the perf audit.
+// Cached collator: the sort re-runs over the full list on every watch flush,
+// and in V8 (Electron) a cached Intl.Collator.compare is several times faster
+// than per-call localeCompare (which re-resolves the locale each time). The
+// old note here favoring localeCompare benchmarked JavaScriptCore under Tauri
+// and no longer applies. Timestamps (RFC 3339, uniform format) sort with plain
+// string comparison — no locale semantics needed.
+const collator = new Intl.Collator();
+
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
 
 /** Clamp a column width to the minimum allowed value. */
 export function clampColumnWidth(width: number): number {
@@ -69,8 +75,8 @@ export function sortResources(
       bVal = b.metadata.creation_timestamp;
       // Note: age sort is inverted — newer (larger timestamp) first when "asc"
       return sortDirection === "asc"
-        ? bVal.localeCompare(aVal)
-        : aVal.localeCompare(bVal);
+        ? compareStrings(bVal, aVal)
+        : compareStrings(aVal, bVal);
     } else if (sortColumn === "status") {
       aVal = (a.status?.phase as string) ?? "";
       bVal = (b.status?.phase as string) ?? "";
@@ -105,7 +111,7 @@ export function sortResources(
       bVal = b.metadata.name;
     }
 
-    const cmp = aVal.localeCompare(bVal);
+    const cmp = collator.compare(aVal, bVal);
     return sortDirection === "asc" ? cmp : -cmp;
   });
 }

--- a/src/lib/extensions/registry.svelte.ts
+++ b/src/lib/extensions/registry.svelte.ts
@@ -55,6 +55,7 @@ class ExtensionRegistry {
       throw new Error(`Duplicate mount id: ${mount.id}`);
     }
     this.#mounts.push(mount as unknown as SlotMount);
+    this.#mountsBySlot.clear();
   }
 
   registerKbdHint(hint: KbdHint): void {
@@ -97,11 +98,20 @@ class ExtensionRegistry {
     return this.#hints.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   }
 
+  // Memoized per slot: called from every rendered table row, and mounts are
+  // sealed at startup — three array allocations per row per render for a
+  // static answer. Registration clears the memo, so pre-seal reads stay fresh.
+  #mountsBySlot = new Map<SlotName, ReadonlyArray<SlotMount>>();
+
   mountsFor<S extends SlotName>(slot: S): ReadonlyArray<SlotMount<S>> {
-    const filtered = this.#mounts
-      .filter((m) => m.slot === slot)
-      .slice()
-      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    let filtered = this.#mountsBySlot.get(slot);
+    if (!filtered) {
+      filtered = this.#mounts
+        .filter((m) => m.slot === slot)
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      this.#mountsBySlot.set(slot, filtered);
+    }
     return filtered as unknown as ReadonlyArray<SlotMount<S>>;
   }
 

--- a/src/lib/stores/async-load.svelte.ts
+++ b/src/lib/stores/async-load.svelte.ts
@@ -10,7 +10,11 @@ import { unshadowState } from "./_unshadow.js";
  *   class CostStore extends AsyncLoadStore<CostOverview> { ... }
  */
 export class AsyncLoadStore<T> extends AsyncLoadStoreLogic<T> {
-  override data = $state<T | null>(null);
+  // $state.raw: these payloads (topology graph, cost/security overviews) are
+  // large nested backend objects, always replaced wholesale and never
+  // field-mutated — deep-proxying them costs a Proxy + signal per object the
+  // renderers walk, for reactivity nothing uses.
+  override data = $state.raw<T | null>(null);
   override isLoading = $state(false);
   override error = $state<string | null>(null);
 

--- a/src/lib/stores/cost.svelte.ts
+++ b/src/lib/stores/cost.svelte.ts
@@ -8,11 +8,12 @@ class CostStore extends AsyncLoadStore<CostOverview> {
   /** Alias for readability in templates */
   get overview() { return this.data; }
 
-  /** Node costs keyed by node name for O(1) lookup from table rows */
-  nodeCosts = $state<Record<string, NodeCostInfo>>({});
+  /** Node costs keyed by node name for O(1) lookup from table rows.
+   *  $state.raw: both records are replaced wholesale, never field-mutated. */
+  nodeCosts = $state.raw<Record<string, NodeCostInfo>>({});
   private _nodeLoading = false;
 
-  nodeMetrics = $state<Record<string, NodeMetricsInfo>>({});
+  nodeMetrics = $state.raw<Record<string, NodeMetricsInfo>>({});
   private _metricsLoading = false;
   private _metricsFetchedAt = 0;
 

--- a/src/lib/stores/metrics.svelte.ts
+++ b/src/lib/stores/metrics.svelte.ts
@@ -4,7 +4,9 @@ import type { PodMetricsResult, PodUsageInfo, PrometheusResult } from "$lib/type
 import { MetricsStoreLogic, POD_METRICS_TTL_MS } from "./metrics.logic";
 
 class MetricsStore extends MetricsStoreLogic {
-  override podUsage = $state<Record<string, PodUsageInfo>>({});
+  // $state.raw: replaced wholesale every poll (applyPodUsage builds a fresh
+  // map); deep-proxying thousands of per-pod entries buys nothing.
+  override podUsage = $state.raw<Record<string, PodUsageInfo>>({});
   override podMetricsAvailable = $state(true);
   override unavailableReason = $state("");
 

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -24,6 +24,19 @@ export type ActiveView = "table" | "details" | "logs" | "terminal" | "portforwar
  *    read the new tab's state. No explicit reset of filter/sort/etc — each
  *    tab owns its UI state and survives round-trips.
  */
+/**
+ * Box for a tab's cached resource list. A CLASS on purpose: `tabs` is deep
+ * `$state`, and Svelte 5's proxy wraps plain objects/arrays it encounters —
+ * assigning `k8sStore.resources.items` (deliberately `$state.raw`) straight
+ * onto a tab would deep-proxy every cached resource, and restoring the tab
+ * would feed that proxied array back into the raw store, re-paying per-field
+ * Proxy/signal allocation on every filter/sort/render pass. Class instances
+ * are exempt from Svelte's proxying, so the array inside stays raw.
+ */
+export class CachedItems {
+  constructor(readonly items: Resource[]) {}
+}
+
 export interface Tab {
   id: string;
   type: ActiveView;
@@ -38,7 +51,7 @@ export interface Tab {
   /** Resource count for table/crd tabs */
   count?: number;
   /** Cached resource data — avoids reload on tab switch */
-  cachedItems?: Resource[];
+  cachedItems?: CachedItems;
   /** True once a load has completed for this tab; distinguishes a legitimately
    *  empty result from an in-flight/uninitialized load. */
   cacheReady?: boolean;
@@ -167,12 +180,28 @@ export class UiStoreLogic {
     if (t) t.filter = v;
   }
 
+  // Memoized: these getters are read per visible table row per render, and a
+  // fresh toLowerCase() per read allocates on every one of those reads.
+  #filterLowerSrc = "";
+  #filterLowerVal = "";
   get filterLower(): string {
-    return this.filter.toLowerCase();
+    const src = this.filter;
+    if (src !== this.#filterLowerSrc) {
+      this.#filterLowerSrc = src;
+      this.#filterLowerVal = src.toLowerCase();
+    }
+    return this.#filterLowerVal;
   }
 
+  #debouncedLowerSrc = "";
+  #debouncedLowerVal = "";
   get debouncedFilterLower(): string {
-    return (this.activeTab?._debouncedFilter ?? "").toLowerCase();
+    const src = this.activeTab?._debouncedFilter ?? "";
+    if (src !== this.#debouncedLowerSrc) {
+      this.#debouncedLowerSrc = src;
+      this.#debouncedLowerVal = src.toLowerCase();
+    }
+    return this.#debouncedLowerVal;
   }
 
   get sortColumn(): string {

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -7,6 +7,7 @@ import {
   restoreTab,
   maxTabIdSuffix,
   TABS_STORAGE_VERSION,
+  CachedItems,
   type ActiveView,
   type Tab,
 } from "./ui.logic.js";
@@ -562,7 +563,7 @@ describe("UiStore", () => {
       store.selectedRowIndex = 3;
       // Simulate cache population
       const tab = store.activeTab!;
-      tab.cachedItems = [];
+      tab.cachedItems = new CachedItems([]);
       tab.cacheReady = true;
       tab.count = 42;
 

--- a/src/lib/utils/tabLifecycle.test.ts
+++ b/src/lib/utils/tabLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, mock } from "bun:test";
 import type { Resource, ResourceList } from "$lib/types";
 import type { Tab } from "$lib/stores/ui.logic";
+import { CachedItems } from "$lib/stores/ui.logic";
 import { handleTabSwitch, type TabLifecycleK8sStore } from "./tabLifecycle";
 
 function mkResource(name: string, namespace = "default"): Resource {
@@ -80,7 +81,7 @@ describe("handleTabSwitch", () => {
 
     handleTabSwitch(fromTab, toTab, k8s);
 
-    expect(fromTab.cachedItems).toBe(items);
+    expect(fromTab.cachedItems?.items).toBe(items);
     expect(fromTab.count).toBe(2);
     expect(fromTab.cacheReady).toBe(true);
   });
@@ -120,7 +121,7 @@ describe("handleTabSwitch", () => {
       type: "table",
       resourceType: "pods",
       namespace: "kube-system",
-      cachedItems,
+      cachedItems: new CachedItems(cachedItems),
       cacheReady: true,
     });
     const restoreResources = mock((_type: string, _items: Resource[]) => {
@@ -150,7 +151,7 @@ describe("handleTabSwitch", () => {
       type: "table",
       resourceType: "pods",
       namespace: "default",
-      cachedItems: [],
+      cachedItems: new CachedItems([]),
       cacheReady: true,
     });
     const k8s = mkStore({ currentNamespace: "default" });
@@ -234,7 +235,7 @@ describe("handleTabSwitch", () => {
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(toTab.cachedItems).toBe(loaded);
+    expect(toTab.cachedItems?.items).toBe(loaded);
     expect(toTab.count).toBe(2);
     expect(toTab.cacheReady).toBe(true);
   });
@@ -396,7 +397,7 @@ describe("handleTabSwitch — crd-table path", () => {
       closable: true,
       resourceType: "foos.example.com",
       namespace: "default",
-      cachedItems: items,
+      cachedItems: new CachedItems(items),
       cacheReady: true,
     };
     const restoreResources = mock((_type: string, _items: Resource[]) => {});

--- a/src/lib/utils/tabLifecycle.ts
+++ b/src/lib/utils/tabLifecycle.ts
@@ -1,6 +1,6 @@
 import type { Resource, ResourceList } from "$lib/types";
 import type { Tab } from "$lib/stores/ui.logic";
-import { RESOURCE_TAB_TYPES } from "$lib/stores/ui.logic";
+import { CachedItems, RESOURCE_TAB_TYPES } from "$lib/stores/ui.logic";
 
 /**
  * Minimal k8s store surface used by the tab lifecycle. Kept narrow so the
@@ -68,7 +68,7 @@ function saveOutgoingTabState(
   // Skip save when store holds a different resource_type (in-flight load).
   if (isTableTab(fromTab) && fromTab.resourceType) {
     if (k8s.resources.resource_type === fromTab.resourceType) {
-      fromTab.cachedItems = k8s.resources.items;
+      fromTab.cachedItems = new CachedItems(k8s.resources.items);
       fromTab.count = k8s.resources.items.length;
       fromTab.cacheReady = true;
     }
@@ -125,7 +125,7 @@ function restoreFromCache(toTab: Tab, k8s: TabLifecycleK8sStore): void {
     k8s.currentNamespace = toTab.namespace;
   }
   // resourceType guaranteed by caller guard in handleTabSwitch.
-  k8s.restoreResources(toTab.resourceType!, toTab.cachedItems!);
+  k8s.restoreResources(toTab.resourceType!, toTab.cachedItems!.items);
 }
 
 function triggerLoad(toTab: Tab, k8s: TabLifecycleK8sStore): void {
@@ -151,7 +151,7 @@ function triggerLoad(toTab: Tab, k8s: TabLifecycleK8sStore): void {
   loadPromise
     .then(() => {
       if (k8s.selectedResourceType === expectedType && !k8s.error) {
-        toTab.cachedItems = k8s.resources.items;
+        toTab.cachedItems = new CachedItems(k8s.resources.items);
         toTab.count = k8s.resources.items.length;
         toTab.cacheReady = true;
       }

--- a/src/lib/utils/workload-stats.ts
+++ b/src/lib/utils/workload-stats.ts
@@ -12,6 +12,9 @@ export interface WorkloadStat {
 export interface WorkloadStatsResult {
   stats: WorkloadStat[];
   healthSegments: HealthSegment[];
+  /** Pods only: count of pods matching isPodNeedingAttention. Folded into the
+   *  stats pass so the table doesn't walk every containerStatus twice. */
+  needsAttention?: number;
 }
 
 export interface HealthSegment {
@@ -65,7 +68,7 @@ export function isPodNeedingAttention(resource: Resource): boolean {
 }
 
 export function computePodStats(items: Resource[]): WorkloadStatsResult {
-  let running = 0, pending = 0, failed = 0, succeeded = 0, totalRestarts = 0;
+  let running = 0, pending = 0, failed = 0, succeeded = 0, totalRestarts = 0, needsAttention = 0;
 
   for (const item of items) {
     const status = classifyPodStatus(item);
@@ -74,6 +77,7 @@ export function computePodStats(items: Resource[]): WorkloadStatsResult {
     else if (status === "failed") failed++;
     else if (status === "succeeded") succeeded++;
     totalRestarts += getTotalRestarts(item);
+    if (isPodNeedingAttention(item)) needsAttention++;
   }
 
   const total = items.length;
@@ -90,6 +94,7 @@ export function computePodStats(items: Resource[]): WorkloadStatsResult {
       { key: "pending", value: pending, color: "var(--status-pending)" },
       { key: "failed", value: failed, color: "var(--status-failed)" },
     ],
+    needsAttention,
   };
 }
 


### PR DESCRIPTION
## Summary

Broad performance pass over both processes, driven by two audits (main process + renderer) and validated with a purpose-built measurement harness: a mock Kubernetes apiserver (HTTPS, records TCP connections / requests / bytes / disk cert reads) exercising the real handler code paths, plus real-Chromium heap sampling via CDP for the renderer. All numbers below are baseline (`main`) vs this branch.

## Main process

**Shared cluster auth cache (`k8s/client.ts`, `k8s/api.ts`)** — client-node rebuilds auth on *every* request: 3 synchronous cert/ca/key file reads plus a fresh `https.Agent` with `keepAlive: false` (a full TCP+TLS handshake per typed API call; on the raw fetch path the agent was built and then ignored entirely). Auth material (headers + a shared keepAlive agent) is now recorded once per context with a 30s TTL and single-flight rebuild, shared by the typed clients and the raw `apiGet` path, expired on 401 with one retry.
- 30 sequential typed calls: **30 connections → 1**, **90 cert file reads → 3**, wall 61ms → 29ms
- 25-call `apiGet` burst (sidebar counts): **75 cert reads → 0** (shares the warm cache)

**Topology (`handlers/topology.ts`)** — 6 of the 12 list calls (ReplicaSets, CronJobs, Ingresses, ConfigMaps, Secrets, HPAs) only need metadata for the graph, but fetched full bodies — including every Secret and ConfigMap payload cluster-wide. They now use `PartialObjectMetadataList` content negotiation. The per-namespace graph cache is also bounded (8 entries) and cleared on context switch (it previously grew forever).
- Mock cluster (~2,100 objects, modest 3KB secrets): **7.2MB → 4.3MB transferred (−41%)**, retained heap 0.94MB → 0.23MB, 12 connections → 0 (pool reuse). Real clusters with fat Secrets/ConfigMaps gain more.

**Namespace access reviews (`handlers/connection.ts`)** — one `SelfSubjectAccessReview` POST per namespace, all fired simultaneously, on every refresh, with no cache. Verdicts are now cached per context (5min TTL) and misses run at concurrency 16 (matching the keepAlive agent's socket cap). Kubeconfig YAML parsing is also cached by file mtime.
- First load (150 namespaces): 151 connections → 15, wall on par. Subsequent refreshes: **151 requests / 178ms → 1 request / 3ms**

**Streaming** — terminal PTY output is coalesced (8ms / 64KB flush) instead of one structured-clone IPC send per WebSocket chunk (`yes` / `cat bigfile` produced thousands of sends per second); log line splitting does one `split` per chunk instead of re-slicing the buffer per line; helm release decoding switches `gunzipSync` (blocked the event loop on multi-MB manifests) to async with reads bounded at 8 concurrent; pod-metrics requests are coalesced for 5s so two views asking for the same namespace share one fetch.

**Watch 410 handling (`handlers/watch.ts`)** — on `410 Gone` the watch reconnected with no resourceVersion, making the apiserver replay the entire collection as ADDED (N projections + N/20 IPC batches) — and the renderer then did a full relist anyway. It now seeds a fresh RV from a metadata-only `limit=1` list, so reconnects resume without replay. Also fixes a pre-existing bug: a 410 at watch *open* never emitted a Resync, so deletes missed during the gap could leave stale rows indefinitely.

## Renderer

**Tab cache proxy leak (`ui.logic.ts`, `tabLifecycle.ts`)** — the resource list store is deliberately `$state.raw`, but caching `items` on the deep-`$state` tabs array wrapped them in Svelte's deep proxy, and restoring the tab fed the *proxied* array back into the raw store. Every subsequent field read allocated a signal + child proxy. `cachedItems` is now a class box (exempt from Svelte proxying). Measured with 10k pods, forced GC:
- Heap after switch-away-and-back: **+78.9MB → +0.3MB**
- Switch-back time: **165ms → 27ms**
- Filter on the restored list: 63–70ms → 52–57ms (48ms of that is the fixed debounce, so the actual work drops ~4×); per-filter heap churn 1.95MB → 0.09MB

**`$state.raw` for wholesale-replaced payloads** — log lines (also fixes JSON rows rendering twice: the highlight cache wrote through the proxy during render), async-load payloads (topology graph, cost/security overviews), pod usage and node cost/metrics records.

**Effect keying** — YamlEditor reloads only when the selected resource *identity* changes; previously every watch event for the selected pod tore down and rebuilt the whole CodeMirror editor, did an IPC round-trip, and silently discarded in-progress user edits. DetailPanel re-hydrates only on uid/resourceVersion change instead of per watch event.

**Smaller wins** — cached `Intl.Collator` for table sort (the old comment favoring `localeCompare` benchmarked JavaScriptCore under Tauri; V8 is the opposite); needs-attention count folded into the single stats pass; command palette index lookup O(N²) → O(1) per keystroke; memoized `filterLower` / `mountsFor` (read per visible row per render); log scroll handler throttled to one layout read per frame; pod-metrics polling paused while the window is hidden.

## Validation

- `tsc` (electron) clean; 1,158 unit tests + 130 electron tests green; full Playwright e2e suite green (44 passed)
- Frontend perf bench (virtualized table): 10k-row scroll frame mean 4.09ms → 3.67ms, 2k rows 2.15ms → 1.74ms, 0 frames over budget
- Honest negatives: the log line-splitting rewrite is CPU-neutral in practice (V8's SlicedString already made the old code non-quadratic); first-load namespace filtering is on par (bounded concurrency trades the stampede for equal wall time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Faster Kubernetes resource loading, Helm history/list views, log streaming, terminal output, and metrics updates.
  - Reduced redundant refreshes when switching resources or when the app is hidden.
  - Smoother command palette filtering, table sorting, scrolling, and tab navigation.

- **Reliability**
  - Improved Kubernetes authentication recovery and connection handling.
  - More consistent watch resynchronization after reconnects.
  - Safer handling of malformed configurations and incomplete log output.

- **Bug Fixes**
  - Prevented unnecessary YAML and pod detail reloads during routine status updates.
  - Improved namespace permission filtering and workload attention counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->