### PR TITLE
docs: drop stale Tauri and Rust references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+kdashboard — an Electron + Svelte 5 desktop IDE for Kubernetes. Three processes:
+the sandboxed renderer (`src/`), the preload bridge (`electron/preload.ts`), and
+the Node main process (`electron/`) which talks to clusters via
+`@kubernetes/client-node`. No in-cluster agent, no HTTP server on the host.
+
+## Commands
+
+```bash
+bun install                  # electron is in trustedDependencies — Bun would
+                             # otherwise skip the postinstall that downloads the
+                             # ~211 MB Electron binary and dev:electron dies
+
+bun run dev:electron         # full app (main + preload + renderer, HMR + restart)
+bun run dev                  # renderer only, in a browser — NO window.electronAPI,
+                             # so every invoke() rejects. This is the e2e target.
+bun run build:electron       # electron-vite build -> out/, electron-builder -> release/
+
+bun run typecheck:electron   # tsc on electron/ (the only typecheck script)
+bunx svelte-check            # renderer typecheck — no npm script, run it directly
+```
+
+### Tests
+
+`bunfig.toml` pins the bun test root to `src`, so the two unit suites are
+separate invocations:
+
+```bash
+bun run test                 # both unit suites (bun test && bun test ./electron)
+bun test                     # frontend only (src/)
+bun test ./electron          # Electron backend only
+bun test src/lib/stores/ui.test.ts          # single file
+bun test ./electron -t "drain"              # single test by name
+
+bun run test:integration     # node:test via tsx against a real cluster
+bun run test:e2e             # Playwright (starts `bun run dev` itself)
+bunx playwright test e2e/resource-table.spec.ts -g "sorts"   # single e2e test
+bun run benchmark            # Playwright perf benchmarks
+```
+
+Integration tests run under **Node, not Bun** — the apiserver TLS bridge uses
+undici's global dispatcher, which Bun's `fetch` ignores. They skip entirely
+unless `KDASH_TEST_CONTEXT` is set:
+
+```bash
+./scripts/dev-cluster.sh                    # seeded Kind cluster for manual testing
+KDASH_TEST_CONTEXT=kind-kdash-dev bun run test:integration
+node --import tsx --test electron/integration/k8s.itest.ts   # one integration file
+```
+
+`RENDERER_PORT` overrides the dev/e2e port (default 1420). Set it when several
+worktrees of this repo are running — `strictPort` plus `reuseExistingServer`
+otherwise lets a sibling checkout's dev server silently become the system under
+test. `playwright.bench.config.ts` is the same suite pinned to 1421 with reuse
+disabled.
+
+## Architecture
+
+### The IPC seam
+
+Everything crosses on **one** channel. `src/lib/ipc/core.ts` `invoke(cmd, args)`
+→ `window.electronAPI.invoke` (preload) → `ipcMain.handle('k8s:invoke')` →
+`buildDispatcher` in `electron/dispatch.ts` → a handler from the map. Commands
+are addressed by snake_case name (`list_resources`, `get_pod_metrics`,
+`start_resource_watch`). Streams go the other way on five event channels:
+`terminal-output`, `terminal-exit`, `log-lines`, `port-forward-closed`,
+`resource-watch-event`, subscribed through `src/lib/ipc/event.ts` `listen()`.
+
+The only synchronous call in the bridge is `bootSettings()` (`k8s:boot-settings`),
+which exists so the persisted theme is applied before first paint. Keep it that
+way.
+
+**Adding a backend command:** add `handlers.set('snake_case_name', fn)` in the
+relevant `electron/handlers/*.ts` `register()`, and — if the module is new —
+import it into the module list in `electron/main.ts` and, when it should be
+integration-tested, into `electron/integration/setup.ts`. Only `Error.message`
+crosses the boundary, so throw messages a user could act on; `dispatch` runs
+them through `describeInvokeError` (`electron/k8s/errors.ts`).
+
+### Wire casing (the renderer stores depend on this — do not "normalize" it)
+
+- `Resource`, `ResourceMetadata`, `ResourceList`, `EventItem`, `WatchEvent`:
+  **snake_case** top-level keys (`api_version`, `resource_version`,
+  `creation_timestamp`, `owner_references`, `event_type`, `type`).
+- Everything *inside* `spec`/`status`/`involvedObject` stays **camelCase**, as
+  the k8s API returns it.
+
+Handler args are whatever the frontend sends, usually camelCase. `invoke()`
+JSON round-trips args that contain objects, because Svelte 5 `$state` proxies
+throw on structured clone.
+
+### Kind registry
+
+`electron/k8s/kinds.ts` is the single source of truth for built-in kinds — API
+coordinates, scope, aliases, and the per-kind LIST field projection.
+`resources.ts`, `watch.ts`, `resource-mapping.ts`, and diagnostics all read from
+it, so **adding a built-in kind is one row**. The renderer's navigable list is
+`src/lib/resource-catalog.ts`; its `type` values must exist in `RESOURCE_TYPES`
+unless flagged `virtual` (app views like topology/security/port-forwards).
+
+List paths use lean projections (`listProjectionFor`, `listMetaFrom` — which
+strips `last-applied-configuration`); detail paths (`get_resource`,
+`get_resource_yaml`) keep the full object. Watch events reuse the *list*
+projection because they replace list rows wholesale.
+
+All k8s access goes through the factories in `electron/k8s/client.ts` — never
+construct a `KubeConfig` in a handler. Register `onConfigChange` to drop
+per-cluster caches on context switch.
+
+### Renderer stores: the `.logic.ts` / `.svelte.ts` split
+
+Every store in `src/lib/stores/` is a pair:
+
+- `x.logic.ts` — a plain class holding all state fields and logic. Unit-testable
+  under `bun test` with no Svelte runtime. This is where behavior belongs.
+- `x.svelte.ts` — a subclass that `override`s each field with `$state(...)` and
+  exports the singleton.
+
+Because `useDefineForClassFields` is on, base-class field declarations create
+own data properties that shadow the compiled `$state` accessors. Every
+`.svelte.ts` subclass constructor **must** call `unshadowState(this)`
+(`stores/_unshadow.ts`) — in the leaf constructor, after `super()`, before any
+hydration. Omitting it produces a store that looks fine and is silently
+non-reactive.
+
+Use `$state.raw` for backend payloads (resource lists, CRD rows, topology/cost/
+security overviews). They are immutable snapshots replaced wholesale; deep
+proxying allocates a Proxy per object across thousands of items. The
+consequence: writers must **reassign** rather than mutate.
+
+### Tabs and views
+
+`ui.logic.ts` owns the tab system. Global state (sidebar, palette, tabs,
+activeTabId) lives on the store; per-tab state (filter, sort, selection, cached
+items/resource, namespace) lives on the `Tab` and is reached through getters
+that read `activeTab`. Tab switching restores cache synchronously via
+`utils/tabLifecycle.ts` to avoid an empty-state flash. Cached lists are boxed in
+the `CachedItems` class specifically to escape Svelte's proxying.
+
+### Performance invariants
+
+These are deliberate and easy to regress: virtualized tables (TanStack Virtual),
+lean list projections, batched watch deltas (20 events / 50 ms in `watch.ts`),
+`scheduleFlush` in `utils/frame-scheduler.ts` (rAF raced against a timeout so a
+backgrounded window still drains), `LazyView` for CodeMirror/terminal/detail
+panels, and the `vendorChunks` split in `vite.shared.ts`.
+
+### UI
+
+Read `src/lib/components/ui/README.md` before touching components. Tokens in
+`src/app.css` (never a literal color), fixed height/type/radius/tone scales, and
+primitives imported from `$lib/components/ui`. If you're writing
+`class="h-7"` on a `Button`, fix the scale, not the call site. Themes are listed
+in `THEME_CHROME` in `electron/main.ts` and must stay in sync with the
+`[data-theme=…]` palettes in `app.css`.
+
+`src/lib/extensions/` is an optional-capability registry (named UI slots,
+actions, palette commands, settings tabs, startup hooks). Core must render
+correctly with nothing registered.
+
+## Build config gotchas
+
+- The preload bundles to **CJS** (`out/preload/index.cjs`). The renderer runs
+  sandboxed, and Electron's sandboxed-preload loader only understands CommonJS.
+- Main/preload deliberately skip `externalizeDepsPlugin` and bundle all deps —
+  `@kubernetes/client-node` is ESM-only and externalizing it reintroduces
+  `ERR_REQUIRE_ESM` at runtime. Only `electron` and Node built-ins are external.
+- `codemirrorDedupe` in `vite.shared.ts` prevents "Unrecognized extension value"
+  from duplicated CodeMirror copies.
+- Two Vite configs on purpose: `electron.vite.config.ts` (app) and
+  `vite.config.ts` (renderer-only, used by `dev` and the Playwright webServer).
+  Shared renderer settings live in `vite.shared.ts`.
+
+## Conventions
+
+Conventional Commits, imperative subject under 72 chars, scoped where useful
+(`fix(topology): …`). Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`,
+`perf`, `ci`. Behavior changes need tests — the codebase's `.logic.ts` split
+exists to make that cheap.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,14 @@ copyright on everything you write.
 
 ## Development setup
 
-kdashboard is a Tauri 2 desktop application with a Rust backend and a Svelte 5
-frontend.
+kdashboard is an Electron desktop application with a TypeScript main process
+and a Svelte 5 frontend.
 
 Requirements:
 
-- Rust stable (see `rust-toolchain.toml` if present; otherwise current stable)
 - Node.js 20 or later, plus [Bun](https://bun.sh)
-- Platform build dependencies per the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
+- A reachable cluster — `scripts/dev-cluster.sh` spins up a seeded
+  [Kind](https://kind.sigs.k8s.io) cluster for manual testing
 
 Setup:
 
@@ -44,23 +44,24 @@ Setup:
 git clone https://github.com/folio-pro/kdashboard.git
 cd kdashboard
 bun install
-cargo fetch --manifest-path src-tauri/Cargo.toml
-bun run tauri dev
+bun run dev:electron
 ```
 
 Tests:
 
 ```bash
-bun test                  # Frontend unit tests
-cargo test --manifest-path src-tauri/Cargo.toml
+bun run test              # Frontend + Electron backend unit tests
+bun run test:integration  # Backend integration tests (needs KDASH_TEST_CONTEXT)
+bun run test:e2e          # Playwright E2E
 ```
 
-Before submitting a pull request, run both test suites locally and verify
-that a release build completes:
+Before submitting a pull request, run the unit suites and the backend
+typecheck locally, and verify that a release build completes:
 
 ```bash
-bun run build
-cargo build --manifest-path src-tauri/Cargo.toml --release
+bun run test
+bun run typecheck:electron
+bun run build:electron
 ```
 
 ## Licensing
@@ -93,9 +94,9 @@ We use Conventional Commits with a short, imperative subject:
 feat: add pod log filtering by regex
 fix(topology): handle deployments without replicas
 docs: clarify kubeconfig lookup order
-refactor(k8s): split resources.rs into per-domain modules
+refactor(k8s): split resources.ts into per-domain modules
 test: add integration coverage for cost enricher
-chore: bump kube to 0.98
+chore: bump @kubernetes/client-node to 1.4
 ```
 
 Valid types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.

--- a/e2e/cluster-unavailable.spec.ts
+++ b/e2e/cluster-unavailable.spec.ts
@@ -1,7 +1,7 @@
 /**
  * End-to-end specs that exercise the UI's behavior when the Kubernetes cluster
- * is not reachable. Each test installs a Tauri IPC mock via addInitScript BEFORE
- * the app boots, so the connection error path runs from the very first invoke()
+ * is not reachable. Each test installs an IPC mock via addInitScript BEFORE the
+ * app boots, so the connection error path runs from the very first invoke()
  * call. No real cluster is required.
  *
  * These tests require the dev server to be running (the webServer block in

--- a/electron/dispatch.ts
+++ b/electron/dispatch.ts
@@ -1,10 +1,10 @@
 // Central command dispatcher for the Electron backend.
 //
-// The renderer (Svelte UI) calls invoke(cmd, args) through the Tauri shim,
+// The renderer (Svelte UI) calls invoke(cmd, args) through src/lib/ipc/core.ts,
 // which forwards to window.electronAPI.invoke -> ipcMain.handle('k8s:invoke').
 // That handler delegates here. Each handler module under electron/handlers/
-// exports a `register(handlers, ctx)` function that populates the Map with
-// the EXACT Tauri command strings (snake_case) used by the frontend.
+// exports a `register(handlers, ctx)` function that populates the Map with the
+// EXACT command strings (snake_case) the frontend uses.
 
 import type { BrowserWindow } from 'electron';
 
@@ -24,8 +24,8 @@ export interface HandlerCtx {
 /**
  * A single command handler. Receives the args object the renderer passed to
  * invoke() (keys are exactly what the frontend sends — often camelCase) plus
- * the shared ctx. Must return a JSON-serializable value matching the Rust
- * return shape, or throw new Error(message) to reject the renderer promise.
+ * the shared ctx. Must return a JSON-serializable value in the shape the
+ * renderer expects, or throw new Error(message) to reject its promise.
  */
 export type Handler = (args: Record<string, unknown>, ctx: HandlerCtx) => Promise<unknown> | unknown;
 

--- a/electron/handlers/app.ts
+++ b/electron/handlers/app.ts
@@ -1,19 +1,16 @@
 // App / settings / metadata / benchmark / kubectl command handlers.
 //
-// Ports src-tauri/src/commands/app_commands.rs (+ settings.rs, state.rs, and
-// the metadata cache helpers in lib.rs) to the Electron Node backend.
-//
 // Commands implemented here:
 //   - get_settings
-//   - save_settings        (mirrors Rust: updates kubeconfig override on change)
+//   - save_settings        (updates the kubeconfig override on change)
 //   - get_app_metadata     (cached hostname / os version / k8s server version)
 //   - run_kubectl          (spawns the kubectl binary; same flag blocklist)
-//   - bench_config         (env-driven; matches BenchConfig serde shape)
+//   - bench_config         (env-driven)
 //   - write_bench_results  (path must match KDASH_BENCH_OUT)
 //
-// NOTE: `close_splashscreen` is a genuine Tauri command but is already owned by
-// the internal module in electron/main.ts (it needs the window-reveal logic
-// that lives there). We deliberately do NOT re-register it here.
+// NOTE: `close_splashscreen` is owned by the internal module in
+// electron/main.ts (it needs the window-reveal logic that lives there). We
+// deliberately do NOT re-register it here.
 
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -27,14 +24,13 @@ import { getKubeconfigPath, setKubeconfigPath, getVersionApi } from '../k8s/clie
 import { setPrometheusUrl } from '../k8s/runtime-config.js';
 
 // ===========================================================================
-// Settings — shape mirrors src-tauri/src/settings.rs AppSettings (serde
-// keeps snake_case; all fields optional via #[serde(default)]).
+// Settings — snake_case keys, every field optional.
 //
-// The renderer's TS type (src/lib/types/settings.ts -> AppSettings) also carries
-// `pinned_resources`, which the Rust struct does not model. Because we persist
-// exactly the object the renderer sends and echo it back on read, any extra
-// keys (like pinned_resources) round-trip transparently — matching the
-// renderer's expectations without us hard-coding them.
+// The renderer's TS type (src/lib/types/settings.ts -> AppSettings) carries
+// keys this interface does not model, `pinned_resources` among them. Because we
+// persist exactly the object the renderer sends and echo it back on read, any
+// extra key round-trips transparently — matching the renderer's expectations
+// without us hard-coding them.
 // ===========================================================================
 
 interface ContextCustomization {
@@ -54,16 +50,15 @@ interface AppSettings {
   [key: string]: unknown;
 }
 
-/** Path to the settings file under Electron's userData dir (replaces the Rust
- *  ~/.config/kdashboard/settings.json location). */
+/** Path to the settings file under Electron's userData dir. */
 function settingsPath(): string {
   return path.join(app.getPath('userData'), 'settings.json');
 }
 
-/** In-memory mirror of persisted settings (parallels the Rust AppState mutex). */
+/** In-memory mirror of persisted settings. */
 let settingsState: AppSettings | null = null;
 
-/** Load settings from disk; returns {} (the serde Default) if absent/unreadable. */
+/** Load settings from disk; returns {} if absent/unreadable. */
 function loadSettings(): AppSettings {
   const file = settingsPath();
   if (!fs.existsSync(file)) {
@@ -77,7 +72,7 @@ function loadSettings(): AppSettings {
     }
     return {};
   } catch {
-    // Tolerate a corrupt file the same way Rust's load() falls back to default.
+    // Tolerate a corrupt file: fall back to defaults rather than failing boot.
     return {};
   }
 }
@@ -89,8 +84,7 @@ function persistSettings(settings: AppSettings): void {
 }
 
 /** Lazily get the current in-memory settings, hydrating from disk once.
- *  Also applies the kubeconfig override at first load (Rust does this at
- *  startup in AppState::new + the bootstrap path). */
+ *  Also applies the kubeconfig override at first load. */
 function currentSettings(): AppSettings {
   if (settingsState === null) {
     settingsState = loadSettings();
@@ -122,9 +116,8 @@ export function getSettingsSync(): AppSettings {
 }
 
 // ===========================================================================
-// App metadata — replicates the cached values from src-tauri/src/lib.rs
-// (hostname + os version never change; k8s version cached, cleared elsewhere
-// on context switch). AppMetadata serde shape = snake_case below.
+// App metadata — hostname and os version never change; the k8s version is
+// cached and cleared elsewhere on context switch. Wire shape is snake_case.
 // ===========================================================================
 
 interface AppMetadata {
@@ -158,7 +151,7 @@ function getOsVersion(): string {
     return cachedOsVersion;
   }
   // os.release() is the kernel/OS release across platforms — a faithful,
-  // dependency-free stand-in for the Rust sw_vers / /etc/os-release lookups.
+  // dependency-free stand-in for the sw_vers / /etc/os-release lookups.
   try {
     const release = os.release();
     cachedOsVersion = release && release.trim().length > 0 ? release.trim() : 'unknown';
@@ -168,7 +161,7 @@ function getOsVersion(): string {
   return cachedOsVersion;
 }
 
-/** Map Node's process.platform to the Rust std::env::consts::OS string. */
+/** Map Node's process.platform to the OS name reported in app metadata. */
 function getOsName(): string {
   switch (process.platform) {
     case 'darwin':
@@ -176,11 +169,11 @@ function getOsName(): string {
     case 'win32':
       return 'windows';
     default:
-      return process.platform; // 'linux', 'freebsd', etc. — matches Rust naming.
+      return process.platform; // 'linux', 'freebsd', etc.
   }
 }
 
-/** Map Node's process.arch to the Rust std::env::consts::ARCH string. */
+/** Map Node's process.arch to the arch name reported in app metadata. */
 function getArch(): string {
   switch (process.arch) {
     case 'x64':
@@ -215,12 +208,12 @@ async function getK8sVersionCached(): Promise<string | null> {
 }
 
 function appVersion(): string {
-  // app.getVersion() reads package.json "version" (= Rust CARGO_PKG_VERSION).
+  // app.getVersion() reads package.json "version".
   return app.getVersion();
 }
 
 // ===========================================================================
-// Benchmark mode — env-driven, matching BenchConfig serde shape exactly.
+// Benchmark mode — env-driven.
 // ===========================================================================
 
 interface BenchConfig {
@@ -246,7 +239,7 @@ function optEnv(key: string): string | null {
 }
 
 // ===========================================================================
-// kubectl — same security blocklist + timeout semantics as the Rust command.
+// kubectl — security blocklist + timeout semantics.
 // ===========================================================================
 
 interface KubectlResult {
@@ -256,7 +249,7 @@ interface KubectlResult {
 }
 
 /** Flags that could redirect kubectl to a different cluster or read arbitrary
- *  files. Mirrors BLOCKED_KUBECTL_FLAGS in app_commands.rs (9 entries). */
+ *  files. */
 const BLOCKED_KUBECTL_FLAGS = [
   '--kubeconfig',
   '--server',
@@ -330,7 +323,7 @@ function runKubectl(args: string[]): Promise<KubectlResult> {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      // ENOENT etc. — same message prefix as the Rust spawn-failure branch.
+      // ENOENT etc.
       reject(new Error(`Failed to run kubectl: ${e.message}`));
     });
 
@@ -341,8 +334,7 @@ function runKubectl(args: string[]): Promise<KubectlResult> {
       resolve({
         stdout,
         stderr,
-        // Rust uses output.status.code().unwrap_or(-1) — null (killed by signal)
-        // maps to -1 here.
+        // null (killed by signal) maps to -1.
         exit_code: code ?? -1,
       });
     });
@@ -368,8 +360,8 @@ export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
     }
     const next = incoming as AppSettings;
 
-    // Mirror the Rust behaviour: when kubeconfig_path changes, push the override
-    // into the shared k8s client so subsequent Api calls use the new file.
+    // When kubeconfig_path changes, push the override into the shared k8s
+    // client so subsequent Api calls use the new file.
     const old = currentSettings();
     const oldPath = (old.kubeconfig_path ?? null) as string | null;
     const newPath = (next.kubeconfig_path ?? null) as string | null;

--- a/electron/handlers/connection.ts
+++ b/electron/handlers/connection.ts
@@ -1,15 +1,6 @@
-// Connection handler group — ports the Tauri "connection" commands to
-// @kubernetes/client-node.
+// Connection handler group — kubeconfig contexts, namespaces, reachability.
 //
-// Rust sources ported (faithful 1:1):
-//   - src-tauri/src/k8s/context.rs   (list_contexts, get_current_context,
-//                                      set_context, list_namespaces)
-//   - src-tauri/src/k8s/client.rs    (resolve_kubeconfig_path / reset)
-//   - src-tauri/src/commands/k8s_commands.rs
-//       get_contexts / get_current_context / get_namespaces /
-//       switch_context / check_connection
-//
-// Commands implemented (EXACT Tauri command strings):
+// Commands implemented:
 //   - get_contexts        -> string[]   (context names from the kubeconfig file)
 //   - get_current_context -> string     (the `current-context` field)
 //   - get_namespaces      -> string[]   (namespace names via CoreV1Api)
@@ -20,8 +11,8 @@
 // Wire-casing notes:
 //   - The frontend calls invoke('switch_context', { context }) — the arg key is
 //     `context` (see src/lib/stores/k8s.svelte.ts + src/lib/benchmark/e2e-runner.ts).
-//   - All five commands return bare scalars / string arrays — no serde struct
-//     wrapping in the Rust originals, so no field-casing concerns here.
+//   - All five commands return bare scalars / string arrays — no struct
+//     wrapping, so there are no field-casing concerns here.
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -41,8 +32,8 @@ import {
 import { mapWithConcurrency } from '../util/concurrency';
 
 // ---------------------------------------------------------------------------
-// Return-type aliases — these mirror the Rust `Result<T, String>` payloads.
-// The renderer consumes them via invoke<string[]> / invoke<string> /
+// Return-type aliases. The renderer consumes them via
+// invoke<string[]> / invoke<string> /
 // invoke<boolean> (grep src/lib/stores/k8s.svelte.ts + benchmark/e2e-runner.ts).
 // ---------------------------------------------------------------------------
 
@@ -56,9 +47,8 @@ type ContextName = string;
 type Connected = boolean;
 
 // ---------------------------------------------------------------------------
-// Kubeconfig file resolution — faithful port of Rust resolve_kubeconfig_path().
-// Rust uses the persisted override (with ~ expansion) or ~/.kube/config.
-// It deliberately ignores $KUBECONFIG for path resolution, so we do too here:
+// Kubeconfig file resolution — the persisted override (with ~ expansion), else
+// ~/.kube/config. $KUBECONFIG is deliberately ignored for path resolution here:
 // `getKubeconfigPath()` returns the persisted override (settings) or null.
 // ---------------------------------------------------------------------------
 
@@ -113,7 +103,7 @@ function readKubeconfigYaml(): KubeconfigYaml {
   }
   const contents = fs.readFileSync(file, 'utf8');
   const parsed = yamlLoad(contents);
-  // Mirror serde_yaml: an empty/scalar doc has no contexts / current-context.
+  // An empty or scalar document has no contexts / current-context.
   const yaml =
     parsed !== null && typeof parsed === 'object' ? (parsed as KubeconfigYaml) : {};
   kubeconfigCache = { file, mtimeMs: stat.mtimeMs, size: stat.size, yaml };
@@ -122,8 +112,8 @@ function readKubeconfigYaml(): KubeconfigYaml {
 
 // ---------------------------------------------------------------------------
 // list_contexts — read context names from the kubeconfig file.
-// Faithful to context.rs::list_contexts: parse the YAML, pull each
-// contexts[].name, skip entries without a name, default to [].
+// Parse the YAML, pull each contexts[].name, skip entries without a name,
+// default to [].
 // ---------------------------------------------------------------------------
 function listContexts(): NameList {
   const yaml = readKubeconfigYaml();
@@ -145,7 +135,7 @@ function listContexts(): NameList {
 
 // ---------------------------------------------------------------------------
 // get_current_context — read the `current-context` field from the file.
-// context.rs errors with "No current-context found in kubeconfig" when absent.
+// Errors with "No current-context found in kubeconfig" when absent.
 // ---------------------------------------------------------------------------
 function getCurrentContext(): ContextName {
   const yaml = readKubeconfigYaml();
@@ -160,14 +150,14 @@ function getCurrentContext(): ContextName {
 // set_context — write `current-context` back to the kubeconfig FILE, then
 // re-point the shared in-memory KubeConfig so subsequent Api calls use it.
 //
-// Rust context.rs::set_context writes the file and reset_client()s. We persist
-// to the same file (the benchmark relies on this — it restores the original
-// current-context afterwards) AND call setActiveContext() so the cached
-// KubeConfig is invalidated and re-points immediately (the Electron analogue of
-// reset_client()). Note: Rust does NOT validate the context exists before
-// writing, but setActiveContext() throws 'Context not found: <name>' if absent —
-// so we write the file first (matching Rust) and only then sync the in-memory
-// context, swallowing a not-found there to keep file-write behavior identical.
+// We persist to the kubeconfig file (the benchmark relies on this — it restores
+// the original current-context afterwards) AND call setActiveContext() so the
+// cached KubeConfig is invalidated and re-points immediately.
+//
+// Order matters: setActiveContext() throws 'Context not found: <name>' for an
+// unknown context, so the file is written FIRST and the in-memory sync runs
+// after, swallowing a not-found. Writing an as-yet-unknown context name is
+// deliberate — the file stays the source of truth.
 // ---------------------------------------------------------------------------
 function setContext(context: string): void {
   const file = resolveKubeconfigPath();
@@ -187,7 +177,7 @@ function setContext(context: string): void {
 
 // ---------------------------------------------------------------------------
 // list_namespaces — namespace names via the Kubernetes API (CoreV1Api).
-// context.rs::list_namespaces: Api::all + ListParams::default, project .name.
+// Lists across all namespaces and projects .metadata.name.
 // ---------------------------------------------------------------------------
 async function listNamespaces(): Promise<NameList> {
   const core = getCoreV1Api();
@@ -261,7 +251,7 @@ async function filterNamespacesByAccess(names: string[]): Promise<string[]> {
 
 // ---------------------------------------------------------------------------
 // check_connection — probe the apiserver with a limit=1 namespace list.
-// k8s_commands.rs::check_connection: get_client() then ns list limit(1).
+// Build the client, then list namespaces with limit=1:
 //   - client build failure  -> "Failed to create client: <e>"
 //   - list failure          -> "Cluster unreachable: <e>"
 //   - success               -> true
@@ -312,10 +302,9 @@ export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
         throw new Error('switch_context requires a `context` string argument');
       }
       setContext(context);
-      // Rust also calls clear_k8s_version_cache() here; that cache is owned by
-      // the observability handler group. Re-pointing the shared KubeConfig via
-      // setActiveContext() already invalidates the connection; the version cache
-      // is cleared by that group's switch hook. Return () -> null.
+      // Re-pointing the shared KubeConfig via setActiveContext() already
+      // invalidates the connection; the cached k8s version is owned by the
+      // observability handler group and cleared by that group's switch hook.
       return null;
     },
   );

--- a/electron/handlers/connection.ts
+++ b/electron/handlers/connection.ts
@@ -154,10 +154,11 @@ function getCurrentContext(): ContextName {
 // the original current-context afterwards) AND call setActiveContext() so the
 // cached KubeConfig is invalidated and re-points immediately.
 //
-// Order matters: setActiveContext() throws 'Context not found: <name>' for an
-// unknown context, so the file is written FIRST and the in-memory sync runs
-// after, swallowing a not-found. Writing an as-yet-unknown context name is
-// deliberate — the file stays the source of truth.
+// Order matters: the file is written FIRST, the in-memory sync runs after.
+// setActiveContext() throws 'Context not found: <name>' for a context absent
+// from the file, and that error is NOT caught — switch_context rejects, but
+// only after the write has already landed. The file stays the source of truth
+// either way.
 // ---------------------------------------------------------------------------
 function setContext(context: string): void {
   const file = resolveKubeconfigPath();
@@ -302,9 +303,9 @@ export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
         throw new Error('switch_context requires a `context` string argument');
       }
       setContext(context);
-      // Re-pointing the shared KubeConfig via setActiveContext() already
-      // invalidates the connection; the cached k8s version is owned by the
-      // observability handler group and cleared by that group's switch hook.
+      // setContext() re-points the shared KubeConfig, which invalidates the
+      // cached config and fires the onConfigChange listeners (namespace access
+      // review, cost caches).
       return null;
     },
   );

--- a/electron/handlers/cost.ts
+++ b/electron/handlers/cost.ts
@@ -1,18 +1,14 @@
-// Cost handlers — port of src-tauri/src/k8s/cost/* to @kubernetes/client-node.
+// Cost handlers — node pricing, pod usage, and the per-namespace cost overview.
 //
 // Commands: get_cost_overview, get_node_costs, get_node_metrics, refresh_pricing
 //
-// Faithful port notes (Rust is the contract for shapes; frontend is the
-// contract for arg keys + return casing — see src/lib/types/cost.ts):
+// Notes:
 //   - Wire shapes (CostOverview / NamespaceCostSummary / ResourceCost /
-//     NodeCostInfo / NodeMetricsInfo) use snake_case field names because the
-//     Rust serde structs do NOT set rename_all — the renderer's TS interfaces
-//     in src/lib/types/cost.ts mirror that snake_case exactly.
+//     NodeCostInfo / NodeMetricsInfo) use snake_case field names; the renderer's
+//     TS interfaces in src/lib/types/cost.ts mirror that casing exactly.
 //   - Pricing datasets fetched from the GitHub release assets with If-None-Match
 //     conditional GET; cached in memory (24h TTL) + on disk under userData.
-//   - get_node_metrics uses metrics.k8s.io NodeMetrics via the client-node
-//     Metrics helper (equivalent to the raw /apis/metrics.k8s.io/... request the
-//     Rust issues through kube::api::Request).
+//   - get_node_metrics reads metrics.k8s.io NodeMetrics.
 //   - get_cost_overview joins node costs + pod usage (or pod requests fallback).
 
 import { promises as fs } from 'node:fs';
@@ -32,7 +28,7 @@ import { getCoreV1Api, kc, onConfigChange } from '../k8s/client';
 import { parseCpu, parseMemory } from '../k8s/quantity';
 
 // ---------------------------------------------------------------------------
-// Public wire types (match src/lib/types/cost.ts + the Rust serde structs).
+// Public wire types (match src/lib/types/cost.ts).
 // ---------------------------------------------------------------------------
 
 interface ResourceCost {
@@ -109,7 +105,7 @@ interface PodUsage {
 }
 
 // ---------------------------------------------------------------------------
-// Constants (mirrors calculations.rs / nodes.rs)
+// Constants
 // ---------------------------------------------------------------------------
 
 const HOURS_PER_MONTH = 730.0;
@@ -118,7 +114,7 @@ const FALLBACK_MEM_RATE = 0.0044; // $/GB/hr
 const COST_CACHE_TTL_MS = 300_000; // 5 minutes
 
 // ---------------------------------------------------------------------------
-// metrics-availability backoff (port of metrics_availability.rs)
+// metrics-availability backoff
 // ---------------------------------------------------------------------------
 
 type MetricsKind = 'pods' | 'nodes';
@@ -157,7 +153,7 @@ function markMetricsUnavailable(kind: MetricsKind): number {
 }
 
 // ---------------------------------------------------------------------------
-// Node info retrieval (port of nodes.rs get_node_info + detect_provider)
+// Node info retrieval
 // ---------------------------------------------------------------------------
 
 function detectProvider(labels: Record<string, string>, instanceType: string): string {
@@ -253,8 +249,8 @@ async function fetchNodeInfo(): Promise<NodeInfo[]> {
 }
 
 /**
- * Derive per-core and per-GB rates from cloud pricing (port of
- * nodes.rs resolve_node_rates). Splits node price 60/40 CPU/memory.
+ * Derive per-core and per-GB rates from cloud pricing. Splits the node price
+ * 60/40 across CPU and memory.
  */
 function resolveNodeRates(
   nodes: NodeInfo[],
@@ -276,7 +272,7 @@ function resolveNodeRates(
 }
 
 // ---------------------------------------------------------------------------
-// Pod usage retrieval (metrics-server + requests fallback) — port of metrics.rs
+// Pod usage retrieval (metrics-server + requests fallback)
 // ---------------------------------------------------------------------------
 
 async function fetchPodMetrics(namespace: string | undefined): Promise<PodUsage[]> {
@@ -330,7 +326,7 @@ async function getPodRequests(namespace: string | undefined): Promise<PodUsage[]
 }
 
 // ---------------------------------------------------------------------------
-// Pricing resolver (port of pricing.rs)
+// Pricing resolver
 // ---------------------------------------------------------------------------
 
 const PRICING_BASE_URL =
@@ -393,7 +389,7 @@ function nowEpochSeconds(): number {
 }
 
 function metaIsFresh(meta: DatasetMeta): boolean {
-  // Rust uses saturating_sub: a future fetched_at clamps age to 0 (treated fresh).
+  // A future fetched_at clamps the age to 0, i.e. it counts as fresh.
   const age = Math.max(0, nowEpochSeconds() - meta.fetched_at);
   return age < DATASET_TTL_MS / 1000;
 }
@@ -513,7 +509,7 @@ function memoryHasFresh(provider: string): boolean {
   return ds !== undefined && ds.expiresAt > Date.now();
 }
 
-// --- ensure_dataset_loaded main path (port of pricing.rs) ---
+// --- ensure_dataset_loaded main path ---
 
 async function ensureDatasetLoaded(provider: string): Promise<boolean> {
   if (memoryHasFresh(provider)) return true;
@@ -583,7 +579,7 @@ async function ensureDatasetLoaded(provider: string): Promise<boolean> {
 /**
  * Resolve `(provider, region, instance_type) -> $/hour` for the requested
  * nodes. Returns null when nothing usable could be loaded (caller falls back to
- * hardcoded rates). Port of pricing.rs resolve_pricing + lookup_prices.
+ * hardcoded rates).
  */
 async function resolvePricing(nodes: NodeInfo[]): Promise<Map<string, number> | null> {
   if (nodes.length === 0) return null;
@@ -618,7 +614,7 @@ async function resolvePricing(nodes: NodeInfo[]): Promise<Map<string, number> | 
 }
 
 // ---------------------------------------------------------------------------
-// Cost overview build + cache (port of calculations.rs)
+// Cost overview build + cache
 // ---------------------------------------------------------------------------
 
 interface CostCacheEntry {
@@ -781,7 +777,7 @@ async function getCostOverview(namespace: string | null | undefined): Promise<Co
 }
 
 // ---------------------------------------------------------------------------
-// Node metrics (port of node_metrics.rs get_node_metrics)
+// Node metrics
 // ---------------------------------------------------------------------------
 
 async function getNodeMetrics(): Promise<NodeMetricsInfo[]> {
@@ -830,7 +826,7 @@ async function getNodeMetrics(): Promise<NodeMetricsInfo[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Node costs (port of node_metrics.rs get_node_costs)
+// Node costs
 // ---------------------------------------------------------------------------
 
 async function getNodeCosts(): Promise<NodeCostInfo[]> {
@@ -852,7 +848,7 @@ async function getNodeCosts(): Promise<NodeCostInfo[]> {
 }
 
 // ---------------------------------------------------------------------------
-// refresh_pricing (port of pricing.rs refresh_pricing)
+// refresh_pricing
 // ---------------------------------------------------------------------------
 
 function refreshPricing(): void {
@@ -863,10 +859,9 @@ function refreshPricing(): void {
 }
 
 /**
- * Background pricing revalidation — port of pricing.rs spawn_periodic_refresh.
- * Every 24h, conditionally re-fetch each ALREADY-CACHED provider's dataset
- * (cheap 304 when unchanged) so pricing never goes stale. Providers that were
- * never loaded are skipped (mirrors Rust known_providers()), so a GCP-only
+ * Background pricing revalidation. Every 24h, conditionally re-fetch each
+ * ALREADY-CACHED provider's dataset (cheap 304 when unchanged) so pricing never
+ * goes stale. Providers that were never loaded are skipped, so a GCP-only
  * cluster never fetches aws/azure. The first tick is at +24h; startup itself
  * loads lazily on the first cost request. Returns a stop function.
  */
@@ -915,7 +910,7 @@ export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
 
   handlers.set('refresh_pricing', async () => {
     refreshPricing();
-    // Rust returns Result<(), String> -> unit; the renderer ignores the value.
+    // The renderer ignores the value.
     return null;
   });
 }

--- a/electron/handlers/crd.ts
+++ b/electron/handlers/crd.ts
@@ -1,14 +1,6 @@
-// CRD handler group — ports the Tauri "crd" commands to @kubernetes/client-node.
+// CRD handler group — custom resource discovery, listing, counts, conditions.
 //
-// Rust sources ported (faithful 1:1):
-//   - src-tauri/src/k8s/crd/discovery.rs   (discover_crds + sensitive-field deny list)
-//   - src-tauri/src/k8s/crd/listing.rs     (list_crd_resources + paging)
-//   - src-tauri/src/k8s/crd/counts.rs      (get_crd_counts, concurrency-limited)
-//   - src-tauri/src/k8s/crd/schema.rs      (additionalPrinterColumns + heuristics)
-//   - src-tauri/src/k8s/crd/types.rs       (extract_conditions)
-//   - src-tauri/src/commands/k8s_commands.rs (the #[tauri::command] wrappers)
-//
-// Commands implemented (EXACT Tauri command strings):
+// Commands implemented:
 //   - discover_crds          (args: {})
 //   - list_crd_resources     (args: { group, version, kind, plural, scope, namespace? })
 //   - get_crd_counts         (args: { crds: CrdInfo[], namespace?: string | null })
@@ -19,8 +11,8 @@
 //       { group, version, kind, plural, scope, namespace } — namespace is `null`
 //       for Cluster-scoped CRDs.
 //   - get_crd_counts: sends { crds, namespace }; result keyed `group/kind`.
-//   - get_crd_conditions: returns StatusCondition[] (serde renames `type`,
-//       optional reason/message/last_transition_time omitted when absent).
+//   - get_crd_conditions: returns StatusCondition[] (optional reason / message
+//       / last_transition_time are omitted when absent).
 //
 // Resource projection (meta_from + dynamicToResource) is shared with the
 // resources and watch paths — see electron/k8s/resource-mapping.ts.
@@ -38,10 +30,9 @@ import { dynamicToResource } from '../k8s/resource-mapping';
 import { apiGet } from '../k8s/api';
 
 // ===========================================================================
-// Result types — mirror the serde wire-casing of the Rust crd/types.rs structs.
+// Result types — snake_case wire casing, consumed by the renderer CRD stores.
 // ===========================================================================
 
-/** crd/types.rs CrdInfo. */
 interface CrdInfo {
   group: string;
   version: string;
@@ -51,13 +42,11 @@ interface CrdInfo {
   short_names: string[];
 }
 
-/** crd/types.rs CrdGroup. */
 interface CrdGroup {
   group: string;
   resources: CrdInfo[];
 }
 
-/** crd/types.rs CrdColumn. */
 interface CrdColumn {
   name: string;
   json_path: string;
@@ -65,15 +54,14 @@ interface CrdColumn {
   description: string;
 }
 
-/** crd/types.rs CrdResourceList. */
 interface CrdResourceList {
   items: Resource[];
   columns: CrdColumn[];
 }
 
 /**
- * crd/types.rs StatusCondition — `type_` renames to `type`; reason / message /
- * last_transition_time are `skip_serializing_if = Option::is_none` (omitted).
+ * A resource's status condition. reason / message / last_transition_time are
+ * omitted when absent.
  */
 interface StatusCondition {
   type: string;
@@ -84,7 +72,7 @@ interface StatusCondition {
 }
 
 // ===========================================================================
-// Sensitive-field deny list (mirror discovery.rs).
+// Sensitive-field deny list.
 // ===========================================================================
 
 const SENSITIVE_FIELD_PATTERNS = [
@@ -108,11 +96,11 @@ function isSensitiveField(name: string): boolean {
 // discover_crds — list CustomResourceDefinitions grouped by API group.
 // ===========================================================================
 //
-// The Rust used kube::discovery::Discovery (which enumerates ALL groups and
-// then filters out the built-in ones via a deny-list). Listing CRD objects via
-// apiextensions.k8s.io is the faithful @kubernetes/client-node analog: CRD
-// objects are by definition the user-defined groups, so no built-in deny-list
-// is needed. We emit one CrdInfo per CRD using its storage/served version.
+// Listing CRD objects via apiextensions.k8s.io is the primary path: CRD objects
+// are by definition the user-defined groups, so no built-in deny-list is needed
+// here. We emit one CrdInfo per CRD using its storage/served version. The
+// discovery-API fallback below does need a deny-list, since /apis enumerates
+// every group including the built-ins.
 
 interface CrdSpecVersion {
   name?: string;
@@ -131,9 +119,9 @@ function preferredVersion(crd: V1CustomResourceDefinition): string | undefined {
   return versions[0]?.name;
 }
 
-// Built-in API groups excluded from discovery-based CRD listing (mirror of the
-// Rust discovery.rs deny-list). Only used by the discovery fallback — the CRD
-// object path is by definition user-defined groups.
+// Built-in API groups excluded from discovery-based CRD listing. Only used by
+// the discovery fallback — the CRD object path is by definition user-defined
+// groups.
 const BUILTIN_GROUPS = new Set([
   '',
   'apps',
@@ -182,10 +170,9 @@ interface DiscoveryResourceList {
 }
 
 /**
- * Fallback: enumerate groups via the discovery API (`/apis`) like the Rust
- * kube::discovery::Discovery did. Needs no RBAC beyond API-server access, so
- * it works for users who cannot list CRD objects at cluster scope (e.g. GKE
- * without container.customResourceDefinitions.list).
+ * Fallback: enumerate groups via the discovery API (`/apis`). Needs no RBAC
+ * beyond API-server access, so it works for users who cannot list CRD objects
+ * at cluster scope (e.g. GKE without container.customResourceDefinitions.list).
  */
 async function discoverCrdsViaDiscovery(): Promise<CrdGroup[]> {
   const groupList = await apiGet<DiscoveryGroupList>('/apis');
@@ -265,9 +252,8 @@ async function discoverCrds(): Promise<CrdGroup[]> {
     const apiext = makeApiClient(ApiextensionsV1Api);
     return groupCrdObjects((await apiext.listCustomResourceDefinition()).items);
   } catch {
-    // Listing CRD objects needs cluster-scope RBAC many users lack. The Tauri
-    // build used the discovery API and therefore worked for them — keep that
-    // behavior as the fallback path.
+    // Listing CRD objects needs cluster-scope RBAC many users lack; the
+    // discovery API does not. Fall back to it so those users still get CRDs.
     return discoverCrdsViaDiscovery();
   }
 }
@@ -559,7 +545,7 @@ async function countCrd(
     count = 0;
   }
 
-  // Key: group/kind for uniqueness (mirror Rust).
+  // Key: group/kind for uniqueness.
   return [`${crd.group}/${crd.kind}`, count];
 }
 
@@ -570,7 +556,7 @@ async function getCrdCounts(
   const custom = makeApiClient(CustomObjectsApi);
   const result: Record<string, number> = {};
 
-  // Bounded-concurrency worker pool (semaphore of 20 in Rust).
+  // Bounded-concurrency worker pool (20 in flight).
   let cursor = 0;
   async function worker(): Promise<void> {
     for (;;) {

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -1,8 +1,6 @@
 // Logs streaming handler.
 //
-// Rust source ported (faithful): src-tauri/src/k8s/logs.rs
-//
-// Commands implemented (EXACT Tauri command strings):
+// Commands implemented:
 //   - stream_pod_logs        -> streams ONE pod/container
 //   - stream_multi_pod_logs  -> streams N pods under ONE logical stream, each
 //                               line prefixed with `[pod-name] `
@@ -28,8 +26,8 @@
 //   (container/previous may be null; sinceSeconds may be null; the renderer
 //    sends camelCase tailLines/sinceSeconds.)
 //
-// Session semantics (mirrors the Rust single global STOP_FLAG): there is ONE
-// active logical log stream at a time, held in `activeSession`. Starting a new
+// Session semantics: there is ONE active logical log stream at a time, held in
+// `activeSession`. Starting a new
 // stream aborts any prior one. Session identity IS the staleness check — every
 // callback compares against `activeSession` before emitting anything.
 //
@@ -56,9 +54,9 @@ import { apiStream } from '../k8s/api';
 const LOG_CHANNEL = 'log-lines';
 const STATUS_CHANNEL = 'log-stream-status';
 
-/** Maximum lines to buffer before emitting a batch (mirrors Rust LOG_BATCH_SIZE). */
+/** Maximum lines to buffer before emitting a batch. */
 const LOG_BATCH_SIZE = 20;
-/** Maximum time (ms) to wait before flushing a partial batch (mirrors Rust LOG_FLUSH_INTERVAL_MS). */
+/** Maximum time (ms) to wait before flushing a partial batch. */
 const LOG_FLUSH_INTERVAL_MS = 50;
 
 /** Payload of STATUS_CHANNEL. Mirrors StreamStatus in src/.../log-viewer.ts. */
@@ -68,9 +66,9 @@ interface StreamStatus {
 }
 
 /**
- * One active logical stream = N underlying abortable per-pod readers. The Rust
- * kept a single global active slot; we do the same with one module-level
- * session object, and use its identity as the staleness check.
+ * One active logical stream = N underlying abortable per-pod readers. A single
+ * module-level session object holds the active slot, and its identity is the
+ * staleness check.
  */
 interface LogSession {
   controllers: AbortController[];
@@ -103,8 +101,8 @@ function optBool(v: unknown): boolean | undefined {
 }
 
 /**
- * Build the log query options from the common optional fields. Mirrors the Rust
- * build_log_params: follow is always true; the rest are only set when present.
+ * Build the log query options from the common optional fields. `follow` is
+ * always true; the rest are only set when present.
  */
 function buildLogOptions(args: Record<string, unknown>): LogOptions {
   const opts: LogOptions = { follow: true };
@@ -121,9 +119,8 @@ function buildLogOptions(args: Record<string, unknown>): LogOptions {
 
 /**
  * Batches complete log lines and flushes them as string[] over LOG_CHANNEL,
- * coalescing on a batch-size cap OR a short debounce timer (mirrors the Rust
- * spawn_log_reader). `linePrefix`, when set, prefixes each line with
- * `[prefix] ` (multi-pod streams).
+ * coalescing on a batch-size cap OR a short debounce timer. `linePrefix`, when
+ * set, prefixes each line with `[prefix] ` (multi-pod streams).
  */
 function makeBatcher(ctx: HandlerCtx, session: LogSession, linePrefix: string | undefined) {
   let batch: string[] = [];
@@ -258,7 +255,7 @@ async function openStream(
   const drained = pumpBody(session, resp.body, batcher).then(
     () => {
       batcher.clearTimer();
-      // Single-pod streams emit a "[stream ended]" marker (Rust line_prefix.is_none()).
+      // Only single-pod streams emit the "[stream ended]" marker.
       if (linePrefix === undefined) batcher.emitOne('[stream ended]');
     },
     (err: unknown) => {
@@ -322,8 +319,8 @@ function beginSession(): LogSession {
 
 /**
  * Start streaming logs for ONE pod/container. Aborts any prior active stream
- * first (single-slot semantics, like the Rust STOP_FLAG reset). Resolves once
- * the stream is established; lines arrive asynchronously via "log-lines".
+ * first (single-slot semantics). Resolves once the stream is established;
+ * lines arrive asynchronously via "log-lines".
  */
 async function streamPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Promise<null> {
   const name = optStr(args.name);
@@ -350,8 +347,7 @@ async function streamPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Pr
 /**
  * Stream logs from MULTIPLE pods under one logical stream. Each line is prefixed
  * with `[pod-name] `. A per-pod start failure emits an `[pod] [error: ...]`
- * line and continues with the rest (mirrors the Rust loop), rather than failing
- * the whole command.
+ * line and continues with the rest, rather than failing the whole command.
  */
 async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx): Promise<null> {
   const pods = Array.isArray(args.pods)
@@ -377,7 +373,7 @@ async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx
       void drained.catch(() => {});
       drains.push(drained);
     } catch (err) {
-      // Emit the per-pod error line and keep going (Rust: continue).
+      // Emit the per-pod error line and keep going.
       if (!isStale(session)) {
         ctx.emit(LOG_CHANNEL, [`[${podName}] [error: ${messageOf(err)}]`]);
       }
@@ -400,7 +396,7 @@ async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx
   return null;
 }
 
-/** Signal the running log stream(s) to stop. Takes NO args (Rust stop_log_stream). */
+/** Signal the running log stream(s) to stop. Takes NO args. */
 function stopLogStream(): null {
   stopActive();
   return null;

--- a/electron/handlers/portforward.ts
+++ b/electron/handlers/portforward.ts
@@ -1,7 +1,7 @@
-// Port-forward streaming subsystem (Tauri -> Electron migration, phase 2).
+// Port-forward streaming subsystem.
 //
-// Ports src-tauri/src/k8s/portforward.rs. For each session the renderer starts,
-// we bind a local TCP listener (net.createServer) and pipe every incoming
+// For each session the renderer starts, we bind a local TCP listener
+// (net.createServer) and pipe every incoming
 // connection through the K8s port-forward WebSocket via @kubernetes/client-node's
 // PortForward. Session state lives in a module-level Map keyed by the sessionId
 // the renderer uses; stop_port_forward (or an unexpected listener death) closes
@@ -13,8 +13,8 @@
 //     localPort, sessionId }  — translated from the snake-case PortForwardInfo by
 //     addPortForward() before invoke(); the frontend is the source of truth.
 //   - stop_port_forward args (camelCase): { sessionId }.
-//   - start returns { session_id, local_port } (snake_case — matches Rust
-//     PortForwardResult and the renderer's invoke<{ session_id; local_port }> ).
+//   - start returns { session_id, local_port } (snake_case — matches the
+//     renderer's invoke<{ session_id; local_port }> ).
 //   - `port-forward-closed` payload === sessionId (string).
 
 import * as net from 'node:net';
@@ -50,9 +50,9 @@ function toPort(value: unknown, label: string): number {
 
 /**
  * Emit `port-forward-closed` for a session at most once and drop it from the
- * map. Mirrors the Rust cleanup: on explicit stop we still tear down the server
- * but suppress the emit (the renderer initiated it); on unexpected death we emit
- * so the UI can removeBySessionId.
+ * map. On an explicit stop we still tear down the server but suppress the emit
+ * (the renderer initiated it); on unexpected death we emit so the UI can
+ * removeBySessionId.
  */
 function finalizeSession(sessionId: string, ctx: HandlerCtx | null, emit: boolean): void {
   const session = sessions.get(sessionId);
@@ -103,7 +103,7 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
       throw new Error(`Port-forward already active for session: ${sessionId}`);
     }
 
-    // Verify the pod exists before binding (mirrors pods.get() in the Rust).
+    // Verify the pod exists before binding.
     await getCoreV1Api().readNamespacedPod({ name: podName, namespace });
 
     const forward = new PortForward(kc());
@@ -137,9 +137,9 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
       socket.on('error', cleanupConnection);
       socket.on('close', cleanupConnection);
 
-      // One WebSocket per TCP connection (matches the Rust per-connection
-      // pods.portforward()). Errors here only kill THIS connection, not the
-      // session — the listener stays up for the next client.
+      // One WebSocket per TCP connection. Errors here only kill THIS
+      // connection, not the session — the listener stays up for the next
+      // client.
       forward
         .portForward(namespace, podName, [containerPort], output, errStream, input)
         .then((ws) => {
@@ -188,7 +188,7 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
       }
     });
 
-    // Same shape as Rust PortForwardResult: snake_case keys.
+    // snake_case keys, as the renderer expects.
     return { session_id: sessionId, local_port: actualPort };
   });
 
@@ -202,7 +202,7 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
     }
 
     // Renderer-initiated stop: tear down WITHOUT emitting port-forward-closed
-    // (the UI already knows; matches the `cancelled` branch in the Rust).
+    // (the UI already knows).
     session.closing = true;
     finalizeSession(sessionId, ctx, false);
     return null;

--- a/electron/handlers/resources.ts
+++ b/electron/handlers/resources.ts
@@ -105,7 +105,7 @@ function apiResourceForType(resourceType: string): ApiResource | undefined {
  * unknown kinds.
  *
  * Returns the kind string verbatim — the caller's casing is preserved in the
- * returned Resource.kind / ApiResource.kind.
+ * returned Resource.kind.
  */
 function apiResourceForKind(kind: string): { ar: ApiResource; clusterScoped: boolean } {
   const k = resolveKindOrThrow(kind);

--- a/electron/handlers/resources.ts
+++ b/electron/handlers/resources.ts
@@ -1,8 +1,5 @@
 // Handler module: resources group.
 //
-// Ports src-tauri/src/k8s/resources/* (listing.rs, types.rs, events.rs,
-// counting.rs, helpers.rs) to @kubernetes/client-node.
-//
 // Commands:
 //   - list_resources           list a kind, optionally namespaced (pods get a
 //                              lean field projection for the hot table path)
@@ -13,12 +10,10 @@
 //   - get_events               list events, optional ns + field selector
 //   - get_resource_events      events for one named resource
 //
-// WIRE CASING — the Rust types drive the JSON the Svelte stores consume:
-//   * Resource / ResourceMetadata / ResourceList have NO serde(rename_all), so
-//     their top-level keys stay snake_case: api_version, resource_version,
-//     creation_timestamp, owner_references. (`type` is renamed from type_.)
-//   * The PROJECTED pod spec/status structs DO use rename_all="camelCase", and
-//     the raw k8s API already returns camelCase inside spec/status — so the
+// WIRE CASING — the Svelte stores consume this JSON verbatim:
+//   * Resource / ResourceMetadata / ResourceList keep snake_case top-level keys:
+//     api_version, resource_version, creation_timestamp, owner_references, type.
+//   * The raw k8s API already returns camelCase inside spec/status — so the
 //     nested bodies (nodeName, podIP, containerStatuses, ...) stay camelCase.
 //   * EventItem keeps snake_case keys (first_timestamp, involved_object, ...)
 //     with `type` renamed; the inner involvedObject object stays camelCase.
@@ -79,8 +74,7 @@ interface RawEventList {
 }
 
 // ---------------------------------------------------------------------------
-// ApiResource resolution (port of helpers.rs api_resource_for_kind + the
-// per-resource_type group/version/plural the listing macros encode)
+// ApiResource resolution — group/version/plural per resource_type
 // ---------------------------------------------------------------------------
 
 interface ApiResource {
@@ -107,11 +101,11 @@ function apiResourceForType(resourceType: string): ApiResource | undefined {
 
 /**
  * Resolve the ApiResource for a SINGULAR kind string (used by get_resource /
- * get_resource_yaml). Port of helpers.rs api_resource_for_kind. Throws the same
- * "Unsupported kind for YAML fetch: <kind>" error on unknown kinds.
+ * get_resource_yaml). Throws "Unsupported kind for YAML fetch: <kind>" on
+ * unknown kinds.
  *
- * Returns the kind string verbatim (Rust keeps the caller's `kind` casing in
- * the returned Resource.kind / ApiResource.kind).
+ * Returns the kind string verbatim — the caller's casing is preserved in the
+ * returned Resource.kind / ApiResource.kind.
  */
 function apiResourceForKind(kind: string): { ar: ApiResource; clusterScoped: boolean } {
   const k = resolveKindOrThrow(kind);
@@ -129,7 +123,7 @@ function apiResourceForKind(kind: string): { ar: ApiResource; clusterScoped: boo
 
 // metaFrom now lives in electron/k8s/resource-mapping.ts (shared).
 
-/** Drop a value if it is null/undefined (Rust's `.filter(|v| !v.is_null())`). */
+/** Drop a value if it is null/undefined. */
 function presentOrUndefined<T>(v: T | null | undefined): T | undefined {
   return v === null || v === undefined ? undefined : v;
 }
@@ -137,8 +131,8 @@ function presentOrUndefined<T>(v: T | null | undefined): T | undefined {
 // ---------------------------------------------------------------------------
 // Generic paginated list against the dynamic CustomObjects endpoint.
 //
-// Core resources are reachable with group="" / version="v1"; this mirrors the
-// Rust DynamicObject path and lets every kind share one projection pass.
+// Core resources are reachable with group="" / version="v1", so every kind can
+// share one projection pass.
 // ---------------------------------------------------------------------------
 
 interface ListOpts {
@@ -174,7 +168,7 @@ async function listRaw(opts: ListOpts): Promise<{ items: RawObject[]; resourceVe
   let cont: string | undefined;
   let resourceVersion: string | undefined;
 
-  // Loop while there is a continue token (matches the Rust continue-token loop).
+  // Loop while the apiserver keeps handing back a continue token.
   for (;;) {
     const query: Record<string, string> = {};
     if (labelSelector) query.labelSelector = labelSelector;
@@ -224,7 +218,7 @@ async function listResources(resourceType: string, namespace?: string): Promise<
 
 async function listPodsBySelector(namespace: string, selector: string): Promise<ResourceList> {
   const ar = apiResourceForType('pods')!;
-  // Rust uses Api::namespaced/all with a label selector, single list (no paging).
+  // Single list with a label selector — no paging.
   const { items: raw } = await listRaw({
     ar,
     namespace: namespace.length === 0 ? undefined : namespace,
@@ -259,7 +253,7 @@ async function getResource(kind: string, name: string, namespace: string): Promi
 
   const res: Resource = {
     api_version: ar.apiVersion,
-    kind, // keep caller's kind string verbatim (Rust does kind.to_string())
+    kind, // keep the caller's kind string verbatim
     metadata: metaFrom(obj.metadata),
   };
   const spec = presentOrUndefined(obj.spec);
@@ -281,7 +275,7 @@ async function getResourceYaml(kind: string, name: string, namespace: string): P
 }
 
 // ---------------------------------------------------------------------------
-// Counts — port of counting.rs.
+// Counts.
 //
 // Same trick as countCrd (crd.ts): ask for a single item and read
 // `metadata.remainingItemCount`, so the apiserver does the counting and we
@@ -297,7 +291,7 @@ interface RawCountList {
 
 async function countResourceType(resourceType: string, namespace?: string): Promise<number> {
   const ar = apiResourceForType(resourceType);
-  if (!ar) return 0; // Rust returns 0 for unknown/unsupported types.
+  if (!ar) return 0; // unknown/unsupported types count as 0.
   try {
     const list = await apiGet<RawCountList>(
       resourcePath(ar, namespace),
@@ -308,8 +302,8 @@ async function countResourceType(resourceType: string, namespace?: string): Prom
     const remaining = list.metadata?.remainingItemCount;
     return remaining !== undefined && remaining !== null ? remaining + itemsLen : itemsLen;
   } catch {
-    // 404 (e.g. the VPA CRD is not installed) or any other failure -> 0,
-    // matching the Rust unwrap_or(0) path. No full-body retry.
+    // 404 (e.g. the VPA CRD is not installed) or any other failure -> 0.
+    // No full-body retry.
     return 0;
   }
 }
@@ -327,7 +321,7 @@ async function getResourceCounts(
 }
 
 // ---------------------------------------------------------------------------
-// Events — port of events.rs
+// Events
 // ---------------------------------------------------------------------------
 
 function eventFrom(e: RawEvent): EventItem {
@@ -368,7 +362,7 @@ async function getEvents(namespace?: string, fieldSelector?: string): Promise<Ev
   return (list.items ?? []).map(eventFrom);
 }
 
-// Plural resource_type -> involvedObject.kind (port of events.rs match).
+// Plural resource_type -> involvedObject.kind.
 const EVENT_KIND_MAP: Record<string, string> = {
   pods: 'Pod',
   deployments: 'Deployment',
@@ -402,7 +396,7 @@ async function getResourceEvents(
   name: string,
   namespace: string,
 ): Promise<EventItem[]> {
-  // Unknown types fall through to the verbatim resource_type (Rust `other => other`).
+  // Unknown types fall through to the verbatim resource_type.
   const kind = EVENT_KIND_MAP[resourceType] ?? resourceType;
   const fieldSelector = `involvedObject.name=${name},involvedObject.kind=${kind}`;
   const ns = namespace.length === 0 ? undefined : namespace;
@@ -424,7 +418,7 @@ function optStr(v: unknown): string | undefined {
 export function register(handlers: HandlerMap): void {
   const listResourcesHandler: Handler = async (args) => {
     const resourceType = str(args.resourceType);
-    // namespace is Option<String> in Rust; the frontend sends null for cluster-wide.
+    // The frontend sends null for cluster-wide.
     const ns = optStr(args.namespace);
     return listResources(resourceType, ns);
   };

--- a/electron/handlers/security.ts
+++ b/electron/handlers/security.ts
@@ -1,20 +1,13 @@
-// Security handler group — ports the Tauri "security" commands to
-// @kubernetes/client-node.
+// Security handler group — scanner detection, per-pod posture, image scans.
 //
-// Rust sources ported (faithful 1:1):
-//   - src-tauri/src/k8s/security.rs
-//       get_security_overview (scanner detection + per-pod posture) and
-//       scan_single_image (single-image scan)
-//   - src-tauri/src/commands/k8s_commands.rs (the #[tauri::command] wrappers)
-//
-// Commands implemented (EXACT Tauri command strings):
+// Commands implemented:
 //   - get_security_overview  (args: { namespace?: string | null })
 //   - scan_image             (args: { image: string })
 //
 // Wire-casing notes (frontend is source of truth):
 //   - get_security_overview: AsyncLoadStore._load sends { namespace } (string | null).
-//   - scan_image: arg key `image` (Rust param `image`).
-// Result SHAPES mirror serde wire-casing in src-tauri/src/k8s/security.rs.
+//   - scan_image: arg key `image`.
+// Result shapes are snake_case on the wire.
 
 import { spawn } from 'node:child_process';
 
@@ -24,10 +17,10 @@ import type { HandlerCtx, HandlerMap } from '../dispatch';
 import { getCoreV1Api } from '../k8s/client';
 
 // ===========================================================================
-// Result types — mirror the serde wire-casing of the Rust structs.
+// Result types — snake_case wire casing.
 // ===========================================================================
 
-/** security.rs VulnerabilityCounts (all snake_case, u32 -> number). */
+/** Vulnerability counts by severity. */
 interface VulnerabilityCounts {
   critical: number;
   high: number;
@@ -36,14 +29,12 @@ interface VulnerabilityCounts {
   unknown: number;
 }
 
-/** security.rs ImageScanResult. */
 interface ImageScanResult {
   image: string;
   vulns: VulnerabilityCounts;
   scanned_at: string;
 }
 
-/** security.rs PodSecurityInfo. */
 interface PodSecurityInfo {
   name: string;
   namespace: string;
@@ -52,7 +43,6 @@ interface PodSecurityInfo {
   compliant: boolean;
 }
 
-/** security.rs SecurityOverview. */
 interface SecurityOverview {
   pods: PodSecurityInfo[];
   total_vulns: VulnerabilityCounts;
@@ -138,8 +128,8 @@ const SCANNER_CACHE_TTL_MS = 600_000; // 10 min
 
 let scannerCache: { scanner: Scanner; expiresAt: number } | null = null;
 
-/** Mirror Rust detect_scanner(): probe `trivy --version`, then `grype version`.
- *  The result is cached for SCANNER_CACHE_TTL_MS. */
+/** Probe `trivy --version`, then `grype version`. The result is cached for
+ *  SCANNER_CACHE_TTL_MS. */
 async function detectScanner(): Promise<Scanner> {
   if (scannerCache && scannerCache.expiresAt > Date.now()) {
     return scannerCache.scanner;
@@ -377,7 +367,7 @@ async function getSecurityOverview(namespace: string | undefined): Promise<Secur
           const vulns = await scanImage(scanner, img);
           result = { image: img, vulns, scanned_at: now };
         } catch {
-          // Failed scan -> empty result (faithful to Rust).
+          // Failed scan -> empty result.
           result = { image: img, vulns: emptyCounts(), scanned_at: now };
         }
         imageResults.set(img, result);
@@ -424,7 +414,7 @@ async function getSecurityOverview(namespace: string | undefined): Promise<Secur
   }
 
   // Sort: non-compliant first, then by critical desc, then high desc.
-  // Rust sorts by `compliant` ascending (false < true), so non-compliant first.
+  // `compliant` sorts ascending (false < true), so non-compliant lands first.
   pods.sort((a, b) => {
     const byCompliant = Number(a.compliant) - Number(b.compliant);
     if (byCompliant !== 0) return byCompliant;

--- a/electron/handlers/terminal.ts
+++ b/electron/handlers/terminal.ts
@@ -1,13 +1,7 @@
-// Terminal exec handler group — ports the Tauri interactive-shell exec
-// subsystem to @kubernetes/client-node's WebSocket-based Exec API.
+// Terminal exec handler group — interactive shells over
+// @kubernetes/client-node's WebSocket-based Exec API.
 //
-// Rust source ported (faithful 1:1): src-tauri/src/k8s/exec.rs
-//   - start_exec       -> start_terminal_exec
-//   - write_stdin      -> send_terminal_input
-//   - resize_terminal  -> resize_terminal
-//   - stop_exec        -> stop_terminal_exec
-//
-// Commands implemented (EXACT Tauri command strings):
+// Commands implemented:
 //   - start_terminal_exec  { name, namespace, container, command } -> null
 //   - send_terminal_input  { data }                                -> null
 //   - resize_terminal      { width, height }  (width=cols, height=rows) -> null
@@ -18,8 +12,8 @@
 //   - terminal-output : string  (raw PTY chunk, utf8-decoded — terminal.write)
 //   - terminal-exit   : null    (payload unused; signals the session ended)
 //
-// Session model (mirrors the Rust OnceLock single-slot): exactly ONE active
-// session at a time. Starting a new one stops the previous. stop_terminal_exec
+// Session model: exactly ONE active session at a time, held in a single slot.
+// Starting a new one stops the previous. stop_terminal_exec
 // closes the WebSocket and emits terminal-exit. The session Map is cleaned on
 // stop AND on stream death (status callback / ws close / error).
 
@@ -132,7 +126,7 @@ interface Session {
   output: OutputCoalescer;
 }
 
-/** Single active session (matches the Rust OnceLock<Option<...>> single slot). */
+/** Single active session. */
 let session: Session | null = null;
 
 /** Tear down the active session if any. `notify` emits terminal-exit when true. */

--- a/electron/handlers/topology.ts
+++ b/electron/handlers/topology.ts
@@ -1,20 +1,17 @@
 // Topology handlers — the cluster relationship graph.
 //
-// Faithful port of src-tauri/src/k8s/topology/* (building.rs, extraction.rs,
-// queries.rs, types.rs). The diagnostics half (diagnose_resource) lives in
-// ./topology/diagnostics.ts; the shared JSON-coercion helpers in
-// ./topology/shared.ts.
+// The diagnostics half (diagnose_resource) lives in ./topology/diagnostics.ts;
+// the shared JSON-coercion helpers in ./topology/shared.ts.
 //
-// Commands implemented here (EXACT Tauri command strings):
+// Commands implemented here:
 //   - get_namespace_topology  (args: { namespace?: string | null })
 //   - get_resource_topology   (args: { uid: string, namespace?: string | null })
 //   - diagnose_resource       (delegated to ./topology/diagnostics)
 //
-// Return SHAPES match the Rust serde output exactly. None of the Rust structs
-// use #[serde(rename_all)], so every field is plain snake_case on the wire
-// (api_version, is_ghost, controller_id, pod_count, pod_ids, edge_type,
-// root_ids, has_cycles, total_resources, cluster_groups, ...). The Svelte types
-// in src/lib/types/cluster.ts depend on exactly these names.
+// Every field is plain snake_case on the wire (api_version, is_ghost,
+// controller_id, pod_count, pod_ids, edge_type, root_ids, has_cycles,
+// total_resources, cluster_groups, ...). The Svelte types in
+// src/lib/types/cluster.ts depend on exactly these names.
 
 import type { HandlerCtx, HandlerMap } from '../dispatch';
 import {
@@ -40,7 +37,7 @@ import { diagnoseResource } from './topology/diagnostics';
 export type { DiagnosticIssue, DiagnosticResult } from './topology/diagnostics';
 
 // ---------------------------------------------------------------------------
-// Public wire types (match cluster.ts / src-tauri topology/types.rs)
+// Public wire types (match src/lib/types/cluster.ts)
 // ---------------------------------------------------------------------------
 
 export interface TopologyNode {
@@ -79,7 +76,7 @@ export interface TopologyGraph {
 }
 
 // ---------------------------------------------------------------------------
-// Internal types (mirror RawResource / OwnerRef in topology/types.rs)
+// Internal types
 // ---------------------------------------------------------------------------
 
 interface OwnerRef {
@@ -100,7 +97,7 @@ interface RawResource {
 }
 
 // ---------------------------------------------------------------------------
-// Status extraction (port of extraction.rs::extract_status_str)
+// Status extraction
 // ---------------------------------------------------------------------------
 
 export function extractStatusStr(kind: string, obj: JsonObject): string | undefined {
@@ -152,7 +149,7 @@ export function extractStatusStr(kind: string, obj: JsonObject): string | undefi
 }
 
 // ---------------------------------------------------------------------------
-// Owner reference parsing (port of extraction.rs::parse_owner_refs)
+// Owner reference parsing
 // ---------------------------------------------------------------------------
 
 function parseOwnerRefs(meta: JsonObject): OwnerRef[] {
@@ -178,7 +175,7 @@ function parseOwnerRefs(meta: JsonObject): OwnerRef[] {
 }
 
 // ---------------------------------------------------------------------------
-// Dynamic -> RawResource conversion (port of extraction.rs::raw_from_dynamic)
+// Dynamic -> RawResource conversion
 // ---------------------------------------------------------------------------
 
 export function rawFromDynamic(kind: string, apiVersion: string, items: JsonValue[]): RawResource[] {
@@ -208,10 +205,10 @@ export function rawFromDynamic(kind: string, apiVersion: string, items: JsonValu
 }
 
 // ---------------------------------------------------------------------------
-// Typed list fetching (port of extraction.rs::fetch_typed! macro)
+// Typed list fetching
 //
 // Lists a typed resource (namespaced or all-namespaces), serializes each item to
-// JSON, and converts via raw_from_dynamic. On error it returns an empty array
+// JSON, and converts via rawFromDynamic. On error it returns an empty array
 // (errors are swallowed per type so a single RBAC denial does not break the
 // whole graph).
 // ---------------------------------------------------------------------------
@@ -233,7 +230,7 @@ async function fetchTyped(
 }
 
 // ---------------------------------------------------------------------------
-// Graph building (port of building.rs::build_graph)
+// Graph building
 // ---------------------------------------------------------------------------
 
 export function buildGraph(resources: RawResource[], autoCluster: boolean): TopologyGraph {
@@ -310,7 +307,7 @@ export function buildGraph(resources: RawResource[], autoCluster: boolean): Topo
 }
 
 // ---------------------------------------------------------------------------
-// Cycle detection (port of building.rs::detect_and_break_cycles)
+// Cycle detection
 // ---------------------------------------------------------------------------
 
 function detectAndBreakCycles(nodesMap: Map<string, TopologyNode>, edges: TopologyEdge[]): boolean {
@@ -325,8 +322,7 @@ function detectAndBreakCycles(nodesMap: Map<string, TopologyNode>, edges: Topolo
   const inStack = new Set<string>();
   const backEdges: Array<[string, string]> = [];
 
-  // Iterative DFS to avoid blowing the call stack on large graphs (the Rust
-  // version recurses; node's default stack is shallower, so we emulate it).
+  // Iterative DFS: a recursive walk blows Node's call stack on large graphs.
   function dfs(start: string): void {
     // stack frames: [node, childIndex]
     const stack: Array<{ node: string; i: number }> = [{ node: start, i: 0 }];
@@ -377,7 +373,7 @@ function detectAndBreakCycles(nodesMap: Map<string, TopologyNode>, edges: Topolo
 }
 
 // ---------------------------------------------------------------------------
-// BFS depth assignment (port of building.rs::assign_depths)
+// BFS depth assignment
 // ---------------------------------------------------------------------------
 
 function assignDepths(
@@ -421,7 +417,7 @@ function assignDepths(
 }
 
 // ---------------------------------------------------------------------------
-// Pod clustering (port of building.rs::extract_pod_clusters)
+// Pod clustering
 //
 // Groups pods by their controller when node count exceeds 200. Mutates
 // nodesMap/edges in place by removing clustered pod nodes and their edges.
@@ -478,7 +474,7 @@ function extractPodClusters(
 }
 
 // ---------------------------------------------------------------------------
-// queries.rs::get_namespace_topology
+// get_namespace_topology
 //
 // The full namespace graph (12 list calls) is cached briefly per
 // context+namespace: opening a resource detail calls get_resource_topology,
@@ -552,9 +548,9 @@ async function fetchNamespaceTopology(namespace: string | null): Promise<Topolog
   const apps = getAppsV1Api();
   const batch = getBatchV1Api();
 
-  // Each entry mirrors one fetch_typed! arm in queries.rs (kind + apiVersion +
-  // namespaced/all-namespaces list fn). Kinds needing a status/spec field keep
-  // the typed full-body list; the rest go metadata-only (listMeta above).
+  // One entry per kind (kind + apiVersion + namespaced/all-namespaces list fn).
+  // Kinds needing a status/spec field keep the typed full-body list; the rest go
+  // metadata-only (listMeta above).
   const fetches: Array<Promise<RawResource[]>> = [
     fetchTyped(
       (ns) =>
@@ -636,7 +632,7 @@ async function fetchNamespaceTopology(namespace: string | null): Promise<Topolog
 }
 
 // ---------------------------------------------------------------------------
-// queries.rs::get_resource_topology
+// get_resource_topology
 // ---------------------------------------------------------------------------
 
 async function getResourceTopology(uid: string, namespace: string | null): Promise<TopologyGraph> {

--- a/electron/handlers/topology/diagnostics.ts
+++ b/electron/handlers/topology/diagnostics.ts
@@ -1,9 +1,8 @@
-// Resource diagnostics — port of src-tauri/src/k8s/diagnostics/* (pod.rs,
-// workload.rs, aggregation.rs, types.rs). Backs the `diagnose_resource` command.
+// Resource diagnostics — backs the `diagnose_resource` command.
 //
-// Return SHAPES match the Rust serde output exactly (snake_case: resource_uid,
-// resource_kind, resource_name, checked_at, …). The Svelte types in
-// src/lib/types/cluster.ts depend on exactly these names.
+// Return shapes are snake_case (resource_uid, resource_kind, resource_name,
+// checked_at, …). The Svelte types in src/lib/types/cluster.ts depend on
+// exactly these names.
 
 import { getCoreV1Api, getAppsV1Api, getBatchV1Api } from '../../k8s/client';
 import { RESOURCE_TYPES } from '../../k8s/kinds';
@@ -19,7 +18,7 @@ import {
 } from './shared';
 
 // ---------------------------------------------------------------------------
-// Wire types (match diagnostics/types.rs)
+// Wire types (match src/lib/types/cluster.ts)
 // ---------------------------------------------------------------------------
 
 export interface DiagnosticIssue {
@@ -40,7 +39,7 @@ export interface DiagnosticResult {
 }
 
 // ---------------------------------------------------------------------------
-// pod.rs::diagnose_pod
+// diagnosePod
 // ---------------------------------------------------------------------------
 
 export function diagnosePod(obj: JsonObject): DiagnosticIssue[] {
@@ -225,7 +224,7 @@ export function diagnosePod(obj: JsonObject): DiagnosticIssue[] {
 }
 
 // ---------------------------------------------------------------------------
-// workload.rs::diagnose_deployment
+// diagnoseDeployment
 // ---------------------------------------------------------------------------
 
 export function diagnoseDeployment(obj: JsonObject): DiagnosticIssue[] {
@@ -287,8 +286,7 @@ export function diagnoseDeployment(obj: JsonObject): DiagnosticIssue[] {
 // ---------------------------------------------------------------------------
 // Minimal event fetch for the diagnose path
 //
-// Port of the subset of resources::get_resource_events used by aggregation.rs:
-// only reason / message / type_ / count are read. Self-contained here so the
+// Only reason / message / type_ / count are read. Self-contained here so the
 // topology module does not depend on the resources group.
 // ---------------------------------------------------------------------------
 
@@ -325,8 +323,8 @@ async function getResourceEvents(
     out.push({
       reason: asString(e['reason']),
       message: asString(e['message']),
-      // k8s-openapi/serde maps the JSON field "type" to type_ in Rust; on the
-      // wire the K8s Event JSON field is "type".
+      // `type` is a reserved-ish key locally, so it is read into type_; the
+      // K8s Event JSON field itself is "type".
       type_: asString(e['type']),
       count: asNumber(e['count']),
     });
@@ -335,7 +333,7 @@ async function getResourceEvents(
 }
 
 // ---------------------------------------------------------------------------
-// aggregation.rs::diagnose_resource
+// diagnoseResource
 // ---------------------------------------------------------------------------
 
 /** Read a single namespaced resource as plain JSON, mapping kind -> reader. */
@@ -369,7 +367,7 @@ async function readResource(
       resp = await apps.readNamespacedReplicaSet({ name, namespace });
       break;
     default:
-      // Rust falls back to reading a Pod for unknown kinds.
+      // Unknown kinds fall back to reading a Pod.
       resp = await core.readNamespacedPod({ name, namespace });
       break;
   }
@@ -380,7 +378,7 @@ async function readResource(
   return obj;
 }
 
-/** Map plural resource_type used for event lookup, mirroring the Rust match. */
+/** Map a singular kind to the plural resource_type used for event lookup. */
 function resourceTypeForKind(kindLower: string): string {
   switch (kindLower) {
     case 'pod':
@@ -429,7 +427,7 @@ export async function diagnoseResource(
       break;
   }
 
-  // Check events for additional signals (errors swallowed, as in Rust's if-let-Ok)
+  // Check events for additional signals; a failure here is not fatal.
   try {
     const resourceType = resourceTypeForKind(kindLower);
     const events = await getResourceEvents(resourceType, name, namespace);

--- a/electron/handlers/topology/shared.ts
+++ b/electron/handlers/topology/shared.ts
@@ -1,8 +1,7 @@
 // Shared JSON-coercion primitives for the topology + diagnostics handlers.
 //
-// k8s list/object bodies arrive as loose JSON (the Rust port used
-// serde_json::Value); these are the typed accessors both the graph-building and
-// the diagnostics code use to read them safely.
+// k8s list/object bodies arrive as loose JSON; these are the typed accessors
+// both the graph-building and the diagnostics code use to read them safely.
 
 /** Loose JSON object alias — k8s items are serialized to plain JSON. */
 export type JsonValue = unknown;

--- a/electron/handlers/updater.ts
+++ b/electron/handlers/updater.ts
@@ -1,15 +1,14 @@
-// Updater subsystem — Electron port of src-tauri/src/update.rs + the Tauri
-// updater plugin, backed by electron-updater's `autoUpdater`.
+// Updater subsystem — backed by electron-updater's `autoUpdater`.
 //
 // Renderer contract (DO NOT BREAK), from
 // src/lib/components/common/UpdateBanner.svelte + src/lib/types/settings.ts:
-//   - `check()` (tauri-updater shim) -> __updater_check returns either:
+//   - `check()` -> __updater_check returns either:
 //       * null                              when no update is available, OR
 //       * { version, body, date }           (UpdateInfo) when one is.
-//     The UI reads `.version`; the shim wraps the JSON in an Update handle
+//     The UI reads `.version`; the renderer wraps the JSON in an Update handle
 //     whose `downloadAndInstall(onEvent)` drives __updater_download below.
 //   - Background check emits the `update-available` event with the SAME
-//     UpdateInfo shape { version, body, date } (Rust emitted exactly this).
+//     UpdateInfo shape { version, body, date }.
 //   - `relaunch()` is handled separately by __process_relaunch in main.ts.
 //
 // This is the lowest-priority subsystem: in a dev run electron-updater is
@@ -48,8 +47,8 @@ const MANUAL_INSTALL = process.platform === 'darwin';
 
 /**
  * Download-lifecycle event pushed to the renderer over UPDATER_DOWNLOAD_CHANNEL.
- * Mirrors the Tauri updater's Started/Progress/Finished union that the
- * tauri-updater shim re-emits to UpdateBanner.svelte:
+ * The Started/Progress/Finished union the renderer re-emits to
+ * UpdateBanner.svelte:
  *   - Started:  { event: 'Started',  data: { contentLength } }
  *   - Progress: { event: 'Progress', data: { chunkLength } }
  *   - Finished: { event: 'Finished' }
@@ -171,8 +170,8 @@ async function runCheck(): Promise<UpdateInfo | null> {
   if (!au) return null;
   try {
     const result = await au.checkForUpdates();
-    // Unlike the Tauri updater, checkForUpdates() resolves with the latest
-    // release's updateInfo even when the app is already up to date — the real
+    // checkForUpdates() resolves with the latest release's updateInfo even
+    // when the app is already up to date — the real
     // signal is isUpdateAvailable (electron-updater's own semver comparison
     // against app.getVersion()). Without this check the banner offers the
     // running version as an "update".
@@ -188,8 +187,8 @@ async function runCheck(): Promise<UpdateInfo | null> {
 }
 
 /**
- * Background notifier — the port of Rust `check_and_notify`. Waits a few seconds
- * so it never blocks startup, runs one check, and emits `update-available` with
+ * Background notifier. Waits a few seconds so it never blocks startup, runs one
+ * check, and emits `update-available` with
  * { version, body, date } if an update exists. Idempotent across the process.
  */
 export function checkAndNotify(ctx: HandlerCtx): void {
@@ -203,7 +202,7 @@ export function checkAndNotify(ctx: HandlerCtx): void {
       .catch((err) => {
         console.warn('[updater] background notify failed:', errMsg(err));
       });
-  }, 3000); // mirrors the Rust 3s settle delay
+  }, 3000); // settle delay, so the check never competes with startup
 }
 
 /**
@@ -302,11 +301,11 @@ async function runDownloadAndInstall(ctx: HandlerCtx): Promise<null> {
 }
 
 /**
- * Register the updater commands. The renderer reaches these via the
- * tauri-updater shim (check + the synthesized downloadAndInstall).
+ * Register the updater commands. The renderer reaches these through its
+ * updater helper (check + the synthesized downloadAndInstall).
  */
 export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
-  // __updater_check — tauri-updater shim entry. Returns UpdateInfo | null.
+  // __updater_check — returns UpdateInfo | null.
   handlers.set('__updater_check', async () => {
     return runCheck();
   });
@@ -318,6 +317,6 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
     return runDownloadAndInstall(ctx);
   });
 
-  // Kick off the background "update available" notice (Rust check_and_notify).
+  // Kick off the background "update available" notice.
   checkAndNotify(ctx);
 }

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -316,8 +316,9 @@ async function startResourceWatch(
     };
 
     // Establish (or re-establish) the watch connection. On stream close the JS
-    // Watch does NOT auto-relist, so we reconnect ourselves and emit a Resync
-    // after the first sync, which makes the store do a full refresh.
+    // Watch does NOT auto-relist, so we reconnect ourselves. A Resync (which
+    // makes the store do a full relist) is emitted only for a close that left a
+    // gap — see the close handler below for the exact rule.
     const connect = (): void => {
       if (!isCurrent()) return;
 

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -1,7 +1,5 @@
 // Handler module: resource watch (streaming).
 //
-// Ports src-tauri/src/k8s/watch.rs to @kubernetes/client-node's Watch.
-//
 // Commands:
 //   - start_resource_watch   begin watching one resource type (single active
 //                            slot — replaces any existing watch)
@@ -11,27 +9,27 @@
 //   - resource-watch-event   emits an ARRAY of WatchEvent (the renderer handles
 //                            both a single object and an array; we always batch).
 //
-// WatchEvent wire shape (must match src/lib/stores/k8s.logic.ts WatchEvent and
-// the Rust WatchEvent struct — NO serde rename_all, so snake_case top-level):
+// WatchEvent wire shape (must match src/lib/stores/k8s.logic.ts WatchEvent —
+// snake_case top-level):
 //   { event_type: "Applied" | "Deleted" | "Resync",
 //     resource_type: string,
 //     resource: Resource }
 //
-// The embedded Resource matches the Rust Resource struct (snake_case top-level:
-// api_version, metadata.{name,namespace,uid,resource_version,creation_timestamp,
-// labels,annotations,owner_references}; `type` renamed from type_). The renderer
-// only reads resource.metadata.uid, but we project the full struct faithfully so
-// the upsert replaces the list item with the same shape list_resources produced.
+// The embedded Resource is snake_case top-level: api_version,
+// metadata.{name,namespace,uid,resource_version,creation_timestamp,labels,
+// annotations,owner_references}, type. The renderer only reads
+// resource.metadata.uid, but we project the full shape so the upsert replaces
+// the list item with exactly what list_resources produced.
 //
 // PROJECTION NOTE: watch events use the SAME per-kind lean projection as
 // list_resources (listProjectionFor) — a watch event replaces a list row
 // wholesale in the store, so anything fatter than the list shape only bloats
 // IPC payloads and renderer-resident memory as the cluster churns.
 //
-// TYPE TRANSLATION: the kube `watcher` runtime the Rust used emits desired-state
-// events (Apply/Delete) and skips the initial list. The JS Watch is a RAW watch
-// stream of verbs (ADDED/MODIFIED/DELETED/BOOKMARK/ERROR), so the initial connect
-// replays the current list as ADDED. We map ADDED/MODIFIED -> "Applied" and
+// TYPE TRANSLATION: the JS Watch is a RAW watch stream of verbs
+// (ADDED/MODIFIED/DELETED/BOOKMARK/ERROR), and the initial connect replays the
+// current list as ADDED. The store speaks desired state instead, so we map
+// ADDED/MODIFIED -> "Applied" and
 // DELETED -> "Deleted". Replaying the initial ADDEDs is harmless: the renderer's
 // handleWatchEvent upserts by uid, so items already loaded are simply re-applied.
 
@@ -46,7 +44,7 @@ import type { Handler, HandlerCtx, HandlerMap } from '../dispatch';
 
 const WATCH_CHANNEL = 'resource-watch-event';
 
-/** Max watch events to buffer before flushing a batch (mirrors watch.rs). */
+/** Max watch events to buffer before flushing a batch. */
 const WATCH_BATCH_SIZE = 20;
 /** Max time (ms) to hold a partial batch before flushing it. */
 const WATCH_FLUSH_INTERVAL_MS = 50;
@@ -93,8 +91,8 @@ function apiResourceForType(resourceType: string): ApiResource | undefined {
  * REST list path for the watch (the Watch API appends ?watch=true itself).
  * Core-group resources live under /api/v1/...; grouped under /apis/{g}/{v}/...
  * Namespaced kinds scope to the namespace only when one is provided AND the
- * kind is namespaced (mirrors watch.rs: namespaced_with when Some(ns), else
- * all_with — i.e. cluster-scoped, or namespaced with no ns = all namespaces).
+ * kind is namespaced. Cluster-scoped kinds, and namespaced kinds with no
+ * namespace, watch across all namespaces.
  */
 function watchPath(ar: ApiResource, namespace?: string): string {
   const base = ar.group === '' ? `/api/${ar.version}` : `/apis/${ar.group}/${ar.version}`;
@@ -105,7 +103,7 @@ function watchPath(ar: ApiResource, namespace?: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Projection — port of helpers.rs meta_from + watch.rs dynamic_to_resource.
+// Projection
 // ---------------------------------------------------------------------------
 
 // Projections live in electron/k8s/resource-mapping.ts (shared with the
@@ -113,7 +111,7 @@ function watchPath(ar: ApiResource, namespace?: string): string {
 // shape; dynamicToResource is the verbatim fallback for unknown kinds.
 
 // ---------------------------------------------------------------------------
-// Single active watch slot (mirrors watch.rs WATCHER_ABORT / WATCHER_RUNNING).
+// Single active watch slot.
 // ---------------------------------------------------------------------------
 
 interface ActiveWatch {
@@ -182,7 +180,7 @@ async function startResourceWatch(
   listResourceVersion: string | undefined,
   ctx: HandlerCtx,
 ): Promise<void> {
-  // Stop any existing watcher first (single active slot, like watch.rs).
+  // Stop any existing watcher first (single active slot).
   clearActive();
 
   const ar = apiResourceForType(resourceType);
@@ -318,9 +316,8 @@ async function startResourceWatch(
     };
 
     // Establish (or re-establish) the watch connection. On stream close the JS
-    // Watch does NOT auto-relist (unlike the kube `watcher` runtime), so we
-    // reconnect ourselves and emit a Resync after the first sync — mirroring
-    // watch.rs's InitDone-on-resync behaviour so the store does a full refresh.
+    // Watch does NOT auto-relist, so we reconnect ourselves and emit a Resync
+    // after the first sync, which makes the store do a full refresh.
     const connect = (): void => {
       if (!isCurrent()) return;
 

--- a/electron/handlers/workload-ops.ts
+++ b/electron/handlers/workload-ops.ts
@@ -1,7 +1,5 @@
 // Handler module: workload-ops
 //
-// Ports src-tauri/src/k8s/resources/operations.rs to @kubernetes/client-node.
-//
 // Commands:
 //   apply_yaml               -> apply (create-or-update) a resource from a YAML string (server-side apply)
 //   delete_resource          -> delete a single resource by kind/name/namespace (+ uid/resourceVersion preconditions)
@@ -10,8 +8,7 @@
 //   rollback_deployment      -> copy a target ReplicaSet's pod template onto the Deployment
 //   list_deployment_revisions-> list owned ReplicaSets as revisions, newest first
 //
-// All field projections, serde wire casing, and error messages mirror the Rust
-// originals. The Svelte UI (src/lib/components/details/revision-history-card.logic.ts)
+// The Svelte UI (src/lib/components/details/revision-history-card.logic.ts)
 // consumes RevisionInfo with snake_case fields — matched exactly below.
 
 import {
@@ -34,8 +31,8 @@ import type { HandlerCtx, HandlerMap } from '../dispatch.js';
 
 /**
  * Summary of a Deployment revision surfaced in the UI for rollback selection.
- * Field names are snake_case to match the Rust serde output and the TS
- * interface in src/lib/components/details/revision-history-card.logic.ts.
+ * Field names are snake_case to match the TS interface in
+ * src/lib/components/details/revision-history-card.logic.ts.
  */
 export interface RevisionInfo {
   revision: number;
@@ -59,7 +56,7 @@ interface KindInfo {
 
 /**
  * Resolve apiVersion + Kind for a kind string, via the canonical kind registry
- * (electron/k8s/kinds.ts). Throws the same unsupported-kind error as Rust.
+ * (electron/k8s/kinds.ts). Throws on an unsupported kind.
  */
 function apiResourceForKind(kind: string): KindInfo {
   const entry = resolveKindOrThrow(kind);
@@ -96,7 +93,7 @@ function appsApi(): AppsV1Api {
 }
 
 // ---------------------------------------------------------------------------
-// ReplicaSet revision helpers (ported from operations.rs)
+// ReplicaSet revision helpers
 // ---------------------------------------------------------------------------
 
 const REVISION_ANNOTATION = 'deployment.kubernetes.io/revision';
@@ -105,7 +102,7 @@ const REVISION_ANNOTATION = 'deployment.kubernetes.io/revision';
 function rsRevision(rs: V1ReplicaSet): number {
   const raw = rs.metadata?.annotations?.[REVISION_ANNOTATION];
   if (raw === undefined) return 0;
-  // Rust parses into u64 — reject anything that isn't a clean non-negative integer.
+  // Reject anything that isn't a clean non-negative integer.
   if (!/^\d+$/.test(raw.trim())) return 0;
   const n = Number(raw);
   return Number.isFinite(n) ? n : 0;
@@ -211,7 +208,7 @@ async function applyYaml(args: Record<string, unknown>): Promise<string> {
     throw new Error('YAML must contain metadata.name');
   }
 
-  // namespace defaults to "default" (mirrors the Rust unwrap_or("default")).
+  // namespace defaults to "default".
   if (metaObj && typeof metaObj.namespace !== 'string') {
     metaObj.namespace = 'default';
   }

--- a/electron/k8s/client.ts
+++ b/electron/k8s/client.ts
@@ -4,7 +4,7 @@
 // own KubeConfig — this keeps a single source of truth for the active context
 // and the optional kubeconfig path override coming from settings.
 //
-// Mirrors the Rust src-tauri/src/k8s/client.rs behaviour:
+// Behaviour:
 //   - load from default kubeconfig (KUBECONFIG env / ~/.kube/config)
 //   - honor a kubeconfigPath override persisted in settings
 //   - allow switching the active context at runtime (switch_context)

--- a/electron/k8s/errors.ts
+++ b/electron/k8s/errors.ts
@@ -76,8 +76,7 @@ export function describeInvokeError(err: unknown): string {
 /**
  * Best-effort human message extracted from a @kubernetes/client-node error.
  * Prefers the apiserver-supplied body.message (a Status object), then the JS
- * Error message, then a stringified fallback. Mirrors the Rust handlers'
- * Result<_, String> messages.
+ * Error message, then a stringified fallback.
  */
 export function k8sErrorMessage(err: unknown): string {
   if (err && typeof err === 'object') {

--- a/electron/k8s/kinds.ts
+++ b/electron/k8s/kinds.ts
@@ -162,8 +162,8 @@ export function resolveKind(kind: string): KindEntry | undefined {
 }
 
 /**
- * Resolve a kind or throw the canonical unsupported-kind error (mirrors the
- * single Rust helper error string used by both YAML fetch and workload ops).
+ * Resolve a kind or throw the canonical unsupported-kind error, shared by both
+ * the YAML fetch and workload ops paths.
  */
 export function resolveKindOrThrow(kind: string): KindEntry {
   const entry = resolveKind(kind);

--- a/electron/k8s/quantity.ts
+++ b/electron/k8s/quantity.ts
@@ -1,4 +1,4 @@
-// Kubernetes resource.Quantity parsing (port of the Rust metrics.rs helpers).
+// Kubernetes resource.Quantity parsing.
 //
 // Shared by the cost handlers (which price usage) and the metrics handlers
 // (which display it), so both read a "250m" / "1Gi" string the same way.

--- a/electron/k8s/resource-mapping.test.ts
+++ b/electron/k8s/resource-mapping.test.ts
@@ -2,10 +2,10 @@ import { test, expect, describe } from 'bun:test';
 
 import { metaFrom, dynamicToResource, presentOrUndefined, listProjectionFor } from './resource-mapping';
 
-describe('metaFrom — Rust serde null contract', () => {
+describe('metaFrom — null contract', () => {
   test('absent fields serialize as null, NOT omitted', () => {
-    // The Rust ResourceMetadata struct has no skip_serializing_if, so None ->
-    // JSON null. This is the contract the renderer was built against.
+    // Absent metadata fields must be null, not omitted. This is the contract
+    // the renderer was built against.
     const m = metaFrom(undefined);
     expect(m.name).toBeNull();
     expect(m.namespace).toBeNull();
@@ -61,7 +61,7 @@ describe('metaFrom — Rust serde null contract', () => {
 });
 
 describe('dynamicToResource', () => {
-  test('omits spec/status/data/type when absent (serde skip_serializing_if)', () => {
+  test('omits spec/status/data/type when absent', () => {
     const r = dynamicToResource({ metadata: { name: 'x', uid: 'u' } }, 'v1', 'Pod');
     expect(r.api_version).toBe('v1');
     expect(r.kind).toBe('Pod');

--- a/electron/k8s/resource-mapping.ts
+++ b/electron/k8s/resource-mapping.ts
@@ -1,12 +1,11 @@
 // Canonical k8s-object -> Resource projection.
 //
-// Port of src-tauri/src/k8s/resources/helpers.rs meta_from + the dynamic-object
-// projection reused by the resources, watch and CRD paths. Previously copied
-// (with subtly divergent null/undefined handling) into three handler files.
+// Shared by the resources, watch and CRD paths. Previously copied (with subtly
+// divergent null/undefined handling) into three handler files.
 //
-// Faithful to Rust serde: metadata fields serialize as `null` when absent (the
-// Rust struct has no skip_serializing_if on them); spec/status/data/type are
-// omitted when absent.
+// NULL CONTRACT: metadata fields serialize as `null` when absent, while
+// spec/status/data/type are OMITTED when absent. The renderer was built against
+// exactly this split — see resource-mapping.test.ts.
 
 import type { RawObject, RawObjectMeta, Resource, ResourceMetadata } from './resource-types';
 import { apiVersionOf, RESOURCE_TYPES, type ListFields } from './kinds';
@@ -23,7 +22,7 @@ export function metaFrom(m: RawObjectMeta | undefined): ResourceMetadata {
     labels: meta.labels ?? null,
     annotations: meta.annotations ?? null,
     creation_timestamp: meta.creationTimestamp ?? null,
-    // Only included when non-empty (matches the Rust filter on !refs.is_empty()).
+    // Only included when non-empty.
     owner_references: owners && owners.length > 0 ? owners : null,
   };
 }
@@ -49,7 +48,7 @@ export function listMetaFrom(m: RawObjectMeta | undefined): ResourceMetadata {
   return meta;
 }
 
-/** Drop a value if it is null/undefined (Rust's `.filter(|v| !v.is_null())`). */
+/** Drop a value if it is null/undefined. */
 export function presentOrUndefined<T>(v: T | null | undefined): T | undefined {
   return v === null || v === undefined ? undefined : v;
 }
@@ -140,7 +139,7 @@ export function projectGeneric(
 }
 
 // ---------------------------------------------------------------------------
-// Pod projection — port of listing.rs list_pods_projected.
+// Pod projection
 //
 // The pods table only reads a handful of fields; project them so we never ship
 // the full spec/status. The keys MUST match what TableRow.getCellValue +
@@ -185,7 +184,7 @@ interface RawPodStatus {
   initContainerStatuses?: RawContainerStatus[];
 }
 
-/** Drop undefined-valued keys so the object matches serde skip_serializing_if. */
+/** Drop undefined-valued keys, so absent fields are omitted rather than null. */
 function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(o)) {
@@ -252,8 +251,7 @@ export function projectSecret(obj: RawObject): Resource {
   let data: Record<string, string> | undefined;
   if (obj.data && typeof obj.data === 'object') {
     // Secret.data values arrive already base64-encoded from the JSON API, so
-    // pass them through verbatim — matches the Rust output (which base64s the
-    // decoded bytes back to the same string).
+    // pass them through verbatim.
     data = obj.data as Record<string, string>;
   } else if (obj.stringData) {
     data = obj.stringData;

--- a/electron/k8s/resource-types.ts
+++ b/electron/k8s/resource-types.ts
@@ -1,10 +1,9 @@
 // Shared wire + raw-body types for the k8s handlers.
 //
-// `Resource` / `ResourceMetadata` mirror the Rust serde output exactly
-// (src-tauri/src/k8s/resources/types.rs). None of the metadata fields carry
-// #[serde(skip_serializing_if)], so they serialize as `null` when absent;
-// spec/status/data/type DO skip when absent. The fields are typed `?: T | null`
-// so both the (faithful) null form and an omitted form satisfy the contract.
+// `Resource` / `ResourceMetadata` are the shapes the renderer consumes. Absent
+// metadata fields serialize as `null`, while spec/status/data/type are omitted
+// entirely. The fields are typed `?: T | null` so both the null form and an
+// omitted form satisfy the contract.
 //
 // `RawObjectMeta` / `RawObject` are the camelCase JSON bodies returned by the
 // @kubernetes/client-node REST/CustomObjects endpoints.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-// Electron main process — the Tauri `run()` equivalent.
+// Electron main process — app bootstrap and the IPC entry point.
 //
 // Responsibilities:
 //   1. Create the main window (hidden, 1280x800, min 900x600), painted in the
@@ -6,7 +6,7 @@
 //   2. Register ONE ipcMain.handle('k8s:invoke', dispatch) that routes every
 //      renderer invoke() through the dispatcher.
 //   3. Register the internal window/shell/process/updater bridge commands the
-//      Tauri shims call (__window_show, __shell_open, …).
+//      renderer's IPC layer calls (__window_show, __shell_open, …).
 //   4. Import + register all handler modules that currently exist (the Wire
 //      phase extends the marked block below).
 //   5. Reveal the window when the renderer is ready, capped by a 5s safety net.
@@ -128,7 +128,7 @@ function createMainWindow(): BrowserWindow {
     height: 800,
     minWidth: 900,
     minHeight: 600,
-    show: false, // mirrors tauri.conf.json `visible: false`
+    show: false, // revealed once the renderer is ready — see revealMainWindow
     title: '',
     // VSCode-style custom title bar: hide the native chrome so the in-app
     // TitleBar.svelte (bg-[var(--bg-primary)]) becomes the visible top bar and
@@ -221,14 +221,13 @@ const ctx: HandlerCtx = {
 };
 
 /**
- * Internal commands backing the Tauri API shims (window/shell/process/updater)
- * and the splash. These are NOT real Tauri commands; they are an
- * implementation detail of the shim layer, prefixed with `__` (except
- * close_splashscreen, which is a genuine Tauri command the frontend calls).
+ * Internal commands backing the renderer's window/shell/process/updater
+ * helpers. They are an implementation detail of that layer and are prefixed
+ * with `__` — except close_splashscreen, which the frontend calls by name.
  */
 const internalModule: HandlerModule = {
   register(handlers): void {
-    // --- reveal (genuine Tauri command, kept for the renderer's initApp) ---
+    // --- reveal (called by the renderer's initApp) ---
     // Named for the splash window it used to close. There is no splash any
     // more, but App.svelte still calls it to say "I am ready to be seen", which
     // is a useful signal alongside ready-to-show.
@@ -237,7 +236,7 @@ const internalModule: HandlerModule = {
       return null;
     });
 
-    // --- window (tauri-window shim) ---
+    // --- window ---
     handlers.set('__window_show', () => {
       revealMainWindow();
       return null;
@@ -253,7 +252,7 @@ const internalModule: HandlerModule = {
       return null;
     });
 
-    // --- shell (tauri-shell shim, via preload.openExternal) ---
+    // --- shell (via preload.openExternal) ---
     handlers.set('__shell_open', async (args) => {
       const url = String(args.url ?? '');
       if (!url) throw new Error('open: missing url');
@@ -261,7 +260,7 @@ const internalModule: HandlerModule = {
       return null;
     });
 
-    // --- process (tauri-process shim) ---
+    // --- process ---
     handlers.set('__process_exit', (args) => {
       const code = typeof args.code === 'number' ? args.code : 0;
       app.exit(code);
@@ -273,7 +272,7 @@ const internalModule: HandlerModule = {
       return null;
     });
 
-    // --- updater (tauri-updater shim) ---
+    // --- updater ---
     // __updater_check / __updater_download are owned by the updater handler
     // module (electron/handlers/updater.ts), registered in buildHandlerModules.
   },
@@ -410,8 +409,7 @@ function bootstrap(): void {
     return dispatch(cmd, args);
   });
 
-  // Revalidate cached pricing datasets once a day in the background (mirrors
-  // the Rust spawn_periodic_refresh in setup()).
+  // Revalidate cached pricing datasets once a day in the background.
   cost.startPeriodicRefresh();
 
   createWindows();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -221,9 +221,10 @@ const ctx: HandlerCtx = {
 };
 
 /**
- * Internal commands backing the renderer's window/shell/process/updater
- * helpers. They are an implementation detail of that layer and are prefixed
- * with `__` — except close_splashscreen, which the frontend calls by name.
+ * Internal commands backing the renderer's window/shell/process helpers. They
+ * are an implementation detail of that layer and are prefixed with `__` —
+ * except close_splashscreen, which the frontend calls by name. The updater
+ * commands live in electron/handlers/updater.ts, not here.
  */
 const internalModule: HandlerModule = {
   register(handlers): void {

--- a/electron/path-fix.ts
+++ b/electron/path-fix.ts
@@ -2,9 +2,8 @@
 //
 // On macOS (and Linux) a GUI app launched from Finder/Dock does NOT inherit the
 // login shell's PATH, so bare-command spawns (kubectl, trivy, grype, cloud auth
-// plugins) fail even though they work in a terminal. Faithful port of the Rust
-// fix_path_env() in src-tauri/src/lib.rs: run the user's login shell once,
-// capture its PATH, and adopt it into process.env.
+// plugins) fail even though they work in a terminal. The fix: run the user's
+// login shell once, capture its PATH, and adopt it into process.env.
 //
 // Must run BEFORE app.whenReady() / any spawn. No-op on Windows and when not
 // packaged-from-GUI (a terminal launch already has the right PATH, and re-running

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,7 +1,7 @@
 // Preload: the ONLY bridge between the sandboxed renderer and the Node main
-// process. Exposes a minimal, typed surface as window.electronAPI. The Tauri
-// shims (src/lib/shims/tauri-*.ts) call exclusively through this object so the
-// Svelte UI never touches Node/Electron APIs directly.
+// process. Exposes a minimal, typed surface as window.electronAPI. The
+// renderer's IPC layer (src/lib/ipc/*) calls exclusively through this object so
+// the Svelte UI never touches Node/Electron APIs directly.
 
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 
@@ -30,7 +30,7 @@ const api = {
 
   /**
    * Invoke a backend command. Returns a promise that resolves with the
-   * handler's result or rejects with its Error. `cmd` is the snake_case Tauri
+   * handler's result or rejects with its Error. `cmd` is the snake_case
    * command string; `args` is the renderer-supplied arg object.
    */
   invoke(cmd: string, args: Record<string, unknown>): Promise<unknown> {
@@ -40,7 +40,7 @@ const api = {
   /**
    * Subscribe to one of the backend event channels (terminal-output,
    * terminal-exit, log-lines, port-forward-closed, resource-watch-event, …).
-   * The tauri-event shim wraps the payload as { payload } before handing it to
+   * src/lib/ipc/event.ts wraps the payload as { payload } before handing it to
    * the UI callback.
    */
   on(channel: string, cb: Listener): void {

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,7 +1,7 @@
 # List benchmark harness
 
-End-to-end benchmark for the resource-list path: it drives the **real** Tauri
-backend (kube list → Rust serialize → IPC → Svelte render) against a local
+End-to-end benchmark for the resource-list path: it drives the **real**
+backend (kube list → serialize → IPC → Svelte render) against a local
 `kind` cluster, with no WebDriver.
 
 ## How it works
@@ -17,7 +17,7 @@ backend (kube list → Rust serialize → IPC → Svelte render) against a local
 
 Two numbers per type:
 
-- **backendMs** — time of `invoke("list_resources")` alone: kube list + Rust
+- **backendMs** — time of `invoke("list_resources")` alone: kube list +
   serialize + IPC + JS parse. This is the accurate, focus-independent metric.
 - **e2eMs** — backendMs plus the time to flush Svelte reactivity and paint the
   virtual table. Note: `requestAnimationFrame` is throttled when the window is

--- a/src/lib/benchmark/e2e-runner.ts
+++ b/src/lib/benchmark/e2e-runner.ts
@@ -1,10 +1,10 @@
 /**
  * End-to-end list benchmark runner.
  *
- * Activated only when the Rust `bench_config` command reports `enabled` (env
+ * Activated only when the `bench_config` command reports `enabled` (env
  * KDASH_BENCH=1). Drives the REAL backend + IPC + render path:
  *
- *   backendMs = time of invoke("list_resources")  (kube list + Rust serialize + IPC + JS parse)
+ *   backendMs = time of invoke("list_resources")  (kube list + serialize + IPC + JS parse)
  *   e2eMs     = backendMs + time to flush Svelte reactivity and paint the virtual table
  *
  * Results are printed to the console (sentinel line) and persisted to JSON via

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -15,10 +15,9 @@ export type SortDirection = "asc" | "desc";
 
 // Cached collator: the sort re-runs over the full list on every watch flush,
 // and in V8 (Electron) a cached Intl.Collator.compare is several times faster
-// than per-call localeCompare (which re-resolves the locale each time). The
-// old note here favoring localeCompare benchmarked JavaScriptCore under Tauri
-// and no longer applies. Timestamps (RFC 3339, uniform format) sort with plain
-// string comparison — no locale semantics needed.
+// than per-call localeCompare (which re-resolves the locale each time).
+// Timestamps (RFC 3339, uniform format) sort with plain string comparison —
+// no locale semantics needed.
 const collator = new Intl.Collator();
 
 function compareStrings(a: string, b: string): number {

--- a/src/lib/ipc/core.ts
+++ b/src/lib/ipc/core.ts
@@ -12,8 +12,8 @@ const IPC_WRAPPER = /^Error invoking remote method '[^']+': (?:Error: )?/;
  * Deep-plain-clone an args object IF it contains a non-plain value (Svelte 5
  * $state proxies above all). ipcRenderer.invoke serializes with the structured
  * clone algorithm, which THROWS "An object could not be cloned" on any Proxy —
- * so e.g. passing `settingsStore.settings` (deep $state) made save_settings
- * fail on every call under Electron (Tauri JSON-serialized, masking this).
+ * so e.g. passing `settingsStore.settings` (deep $state) makes save_settings
+ * fail on every call.
  * JSON round-trip is safe here: IPC payloads are plain JSON data by contract.
  * The common case (plain strings/numbers already) pays only a cheap scan.
  */
@@ -47,8 +47,8 @@ export function readBootSettings(): Record<string, unknown> | null {
 }
 
 /**
- * Invoke a backend command. Mirrors Tauri's invoke<T>(cmd, args?) signature:
- * resolves with the handler's result, rejects with its Error message.
+ * Invoke a backend command: resolves with the handler's result, rejects with
+ * its Error message.
  */
 export async function invoke<T = unknown>(
   cmd: string,

--- a/src/lib/ipc/event.ts
+++ b/src/lib/ipc/event.ts
@@ -1,4 +1,4 @@
-// Shim for `$lib/ipc/event`. Preserves Tauri's listen() contract:
+// Event-channel subscriptions for the renderer:
 //   - the callback receives an event object with a `.payload` field
 //   - listen() resolves to an UnlistenFn that removes the subscription
 //
@@ -6,7 +6,7 @@
 
 export type UnlistenFn = () => void;
 
-/** Minimal Tauri event shape the UI relies on (only `.payload` is used). */
+/** Minimal event shape the UI relies on (only `.payload` is used). */
 export interface Event<T> {
   payload: T;
 }

--- a/src/lib/ipc/global.d.ts
+++ b/src/lib/ipc/global.d.ts
@@ -1,5 +1,5 @@
-// Ambient declaration for the preload-exposed bridge. Lets the @tauri-apps/*
-// modules (and any src/ code) reference window.electronAPI with full typing.
+// Ambient declaration for the preload-exposed bridge. Lets any src/ code
+// reference window.electronAPI with full typing.
 //
 // Keep this in sync with electron/preload.ts (ElectronAPI).
 

--- a/src/lib/ipc/updater.ts
+++ b/src/lib/ipc/updater.ts
@@ -4,7 +4,7 @@
 // UpdateBanner.svelte (the only consumer) does:
 //   const update = await check();              // null when no update
 //   if (update) await update.downloadAndInstall(onEvent);  // Started/Progress/Finished
-//   await relaunch();                          // tauri-process shim
+//   await relaunch();                          // __process_relaunch
 //
 // The backend returns plain JSON ({ version, body, date } | null) — it cannot
 // carry a method — so the Update handle's downloadAndInstall() is synthesized
@@ -28,7 +28,7 @@ export type DownloadEvent =
   | DownloadProgressEvent
   | DownloadFinishedEvent;
 
-/** Mirror of Tauri's Update handle (only the bits UpdateBanner.svelte uses). */
+/** The Update handle (only the bits UpdateBanner.svelte uses). */
 export interface Update {
   version: string;
   /** In-app install unavailable (unsigned macOS build) — update via brew. */

--- a/src/lib/stores/async-load.logic.ts
+++ b/src/lib/stores/async-load.logic.ts
@@ -1,5 +1,5 @@
 /**
- * Base class for stores that load data from a Tauri command with
+ * Base class for stores that load data from a backend command with
  * namespace filtering, loading/error state, and stale request detection.
  *
  * Pure logic version (no Svelte runes) for testing.

--- a/src/lib/stores/async-load.svelte.ts
+++ b/src/lib/stores/async-load.svelte.ts
@@ -3,7 +3,7 @@ import { AsyncLoadStoreLogic } from "./async-load.logic";
 import { unshadowState } from "./_unshadow.js";
 
 /**
- * Base class for stores that load data from a Tauri command with
+ * Base class for stores that load data from a backend command with
  * namespace filtering, loading/error state, and stale request detection.
  *
  * Usage:
@@ -24,7 +24,7 @@ export class AsyncLoadStore<T> extends AsyncLoadStoreLogic<T> {
   }
 
   /**
-   * Load data from a Tauri command with automatic namespace normalization,
+   * Load data from a backend command with automatic namespace normalization,
    * loading state management, and stale response detection.
    */
   protected async _load(command: string, namespace: string | null): Promise<void> {

--- a/src/lib/stores/k8s.logic.ts
+++ b/src/lib/stores/k8s.logic.ts
@@ -24,7 +24,7 @@ export interface NavigationEntry {
 export const COUNTABLE_RESOURCE_TYPES: readonly string[] = LISTABLE_RESOURCE_TYPES;
 
 /**
- * Pure logic for K8sStore — no Svelte runes, no Tauri invoke.
+ * Pure logic for K8sStore — no Svelte runes, no backend invoke.
  * Testable in bun test. The Svelte store extends this and adds reactivity.
  */
 export class K8sStoreLogic {
@@ -196,7 +196,7 @@ export class K8sStoreLogic {
     this.resourceCounts = { ...this.resourceCounts, [resourceType]: count };
   }
 
-  /** Synchronous navigate-to-related for testing (no Tauri calls). */
+  /** Synchronous navigate-to-related for testing (no backend calls). */
   navigateToRelatedSync(resourceType: string, target: Resource | null): void {
     if (this.selectedResource) {
       this._navHistory.push({
@@ -213,7 +213,7 @@ export class K8sStoreLogic {
     if (event.resource_type !== this.selectedResourceType) return;
 
     if (event.event_type === "Resync") {
-      // In the real store this triggers a full refresh via Tauri
+      // In the real store this triggers a full refresh via the backend
       return;
     }
 
@@ -247,17 +247,17 @@ export class K8sStoreLogic {
     }
   }
 
-  /** Synchronous port forward add (no Tauri calls). */
+  /** Synchronous port forward add (no backend calls). */
   addPortForwardSync(info: PortForwardInfo): void {
     this.portForwards = [...this.portForwards, info];
   }
 
-  /** Synchronous port forward remove (no Tauri calls). */
+  /** Synchronous port forward remove (no backend calls). */
   removePortForwardSync(sessionId: string): void {
     this.portForwards = this.portForwards.filter((pf) => pf.session_id !== sessionId);
   }
 
-  /** Synchronous portion of resetForUserSwitch (no Tauri calls). */
+  /** Synchronous portion of resetForUserSwitch (no backend calls). */
   resetForUserSwitchSync(): void {
     this._beginScopeChange();
     this.isSwitchingContext = false;

--- a/src/lib/stores/k8s.svelte.ts
+++ b/src/lib/stores/k8s.svelte.ts
@@ -80,7 +80,7 @@ class K8sStore extends K8sStoreLogic {
   override crdCounts = $state<Record<string, number>>({});
   override selectedCrd = $state<CrdInfo | null>(null);
 
-  // Private members that require Tauri / browser APIs (not in logic class)
+  // Private members that require backend / browser APIs (not in logic class)
   private _ageInterval: ReturnType<typeof setInterval> | null = null;
   private _watchUnlisten: UnlistenFn | null = null;
   private _watchActive = false;
@@ -396,7 +396,7 @@ class K8sStore extends K8sStoreLogic {
     settingsStore.updateConnection("", "default");
   }
 
-  /** Load counts for all resource types via a single batch Tauri command. */
+  /** Load counts for all resource types via a single batch command. */
   async loadAllResourceCounts(scopeGeneration = this._scopeGeneration): Promise<void> {
     const gen = ++this._countGeneration;
     const namespace = this.currentNamespace;

--- a/src/lib/stores/settings.logic.ts
+++ b/src/lib/stores/settings.logic.ts
@@ -40,7 +40,7 @@ export class SettingsStoreLogic {
 
   /**
    * Persist settings. No-op in the logic class; overridden in the Svelte store
-   * to call Tauri invoke.
+   * to call the backend.
    */
   saveSettings(): void {
     // no-op — overridden in SvelteStore subclass

--- a/src/lib/stores/settings.test.ts
+++ b/src/lib/stores/settings.test.ts
@@ -4,7 +4,7 @@ import { SettingsStoreLogic, DEFAULT_SETTINGS } from "./settings.logic.js";
 
 /**
  * Testable subclass that tracks applyTheme calls and saveSettings calls
- * without needing Svelte runes or Tauri invoke.
+ * without needing Svelte runes or a backend invoke.
  */
 class TestSettingsStore extends SettingsStoreLogic {
   appliedTheme: string = "";

--- a/src/lib/utils/tabLifecycle.ts
+++ b/src/lib/utils/tabLifecycle.ts
@@ -5,7 +5,7 @@ import { CachedItems, RESOURCE_TAB_TYPES } from "$lib/stores/ui.logic";
 /**
  * Minimal k8s store surface used by the tab lifecycle. Kept narrow so the
  * logic can be unit-tested against a hand-rolled fake without importing
- * the real store (and its Tauri dependency).
+ * the real store (and its backend dependency).
  */
 export interface TabLifecycleK8sStore {
   selectedResource: Resource | null;


### PR DESCRIPTION
## Summary

The app was ported from Tauri 2 + Rust to Electron, but the comments never
followed. 290 references across 42 files still described the Rust originals —
`// Ports src-tauri/src/k8s/watch.rs`, `mirrors the Rust STOP_FLAG`,
`NO serde(rename_all)` — so following them required knowing a codebase that no
longer exists.

Worse, `CONTRIBUTING.md` still told new contributors to install a Rust
toolchain, run `cargo fetch`, and verify with `cargo test`. None of that works.

## What changed

**Comments that only recorded provenance are gone.** Port headers, `Rust sources
ported (faithful 1:1)` blocks, `EXACT Tauri command strings` labels, and
`/** crd/types.rs CrdInfo. */`-style tags carried no information a reader of this
repo can use.

**Comments where Rust was standing in for a real invariant now state the
invariant directly.** This was the part that could not be done with `sed`:

- `resources.ts` / `watch.ts` — the snake_case wire casing was justified by
  "the Rust structs have no `serde(rename_all)`". It is now stated as what it
  actually is: the contract the Svelte stores consume.
- `resource-mapping.ts` / `resource-types.ts` — the metadata-serializes-as-null
  vs spec-omitted-when-absent split is now spelled out and pointed at its test,
  instead of being derived from `skip_serializing_if`.
- `terminal.ts` / `logs.ts` — "mirrors the Rust `OnceLock`/`STOP_FLAG`" became
  the single-active-slot semantics it was describing.
- `connection.ts` — the write-file-then-sync ordering in `set_context` was
  explained as "matching Rust". It now explains the real reason:
  `setActiveContext()` throws on an unknown context, so the file write has to
  come first.

**`CONTRIBUTING.md`** now documents the actual setup: `bun run dev:electron`,
the three test suites, `typecheck:electron`, and `build:electron`.

**`CLAUDE.md`** added — build/test commands and the architecture notes that span
several files (the single `k8s:invoke` seam, the kind registry, the
`.logic.ts`/`.svelte.ts` store split and its `unshadowState` requirement).

## Deliberately left alone

Four `rust` hits are legitimate and stay: the Rust language icon in
`container-icon.ts` and `context-icons.ts`, and the citation of the Rust
Foundation's trademark policy in `TRADEMARK.md`.

## Verification

- `bun run typecheck:electron` — clean
- `bun run test` — 1191 + 148 passing

No behavior change. Filtering the diff over `.ts`/`.svelte` for non-comment
lines leaves only trailing comments on otherwise-identical code lines, plus two
`describe`/`test` names in `resource-mapping.test.ts` that mentioned serde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive development guidance covering setup, testing, architecture, performance conventions, and contribution workflows.
  - Updated contribution instructions for the Electron and TypeScript development environment, including Kubernetes prerequisites and current commands.
  - Clarified backend communication, event streaming, resource handling, watch behavior, updates, benchmarking, and error contracts throughout project documentation.
  - Removed outdated references to the former desktop framework and Rust implementation, improving consistency across developer-facing materials.
- **Tests**
  - Refreshed test descriptions to align with current terminology; test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->