### PR TITLE
perf(build): bundle deps instead of shipping node_modules in the asar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,16 +167,17 @@ correctly with nothing registered.
 
 - The preload bundles to **CJS** (`out/preload/index.cjs`). The renderer runs
   sandboxed, and Electron's sandboxed-preload loader only understands CommonJS.
-- Main/preload bundle all deps; only `electron` and Node built-ins are external.
-  electron-vite 5 externalizes everything under `dependencies` by default, so
-  that is enforced through package.json: `dependencies` holds **only**
-  `electron-updater` (`handlers/updater.ts` require()s it at runtime, so it must
-  exist as files in the asar) and every other package lives in
-  `devDependencies`. Moving a package back into `dependencies` un-bundles it
-  from main/preload and makes electron-builder copy it into `app.asar` — that
-  regression is invisible in a dev run and in a packaged app launched from
-  inside the repo, because Node resolves the missing module from the checkout's
-  own `node_modules`. Test packaged builds from outside the repo tree.
+- Main/preload bundle every dep except `electron`, Node built-ins, and
+  `electron-updater`. electron-vite 5 externalizes everything under
+  `dependencies` by default, so that split is enforced through package.json:
+  `dependencies` holds **only** `electron-updater` (`handlers/updater.ts`
+  require()s it at runtime, so it must exist as files in the asar) and every
+  other package lives in `devDependencies`. Moving a package back into
+  `dependencies` un-bundles it from main/preload and makes electron-builder copy
+  it into `app.asar` — that regression is invisible in a dev run and in a
+  packaged app launched from inside the repo, because Node resolves the missing
+  module from the checkout's own `node_modules`. Test packaged builds from
+  outside the repo tree.
 - `codemirrorDedupe` in `vite.shared.ts` prevents "Unrecognized extension value"
   from duplicated CodeMirror copies.
 - Two Vite configs on purpose: `electron.vite.config.ts` (app) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,16 @@ correctly with nothing registered.
 
 - The preload bundles to **CJS** (`out/preload/index.cjs`). The renderer runs
   sandboxed, and Electron's sandboxed-preload loader only understands CommonJS.
-- Main/preload deliberately skip `externalizeDepsPlugin` and bundle all deps —
-  `@kubernetes/client-node` is ESM-only and externalizing it reintroduces
-  `ERR_REQUIRE_ESM` at runtime. Only `electron` and Node built-ins are external.
+- Main/preload bundle all deps; only `electron` and Node built-ins are external.
+  electron-vite 5 externalizes everything under `dependencies` by default, so
+  that is enforced through package.json: `dependencies` holds **only**
+  `electron-updater` (`handlers/updater.ts` require()s it at runtime, so it must
+  exist as files in the asar) and every other package lives in
+  `devDependencies`. Moving a package back into `dependencies` un-bundles it
+  from main/preload and makes electron-builder copy it into `app.asar` — that
+  regression is invisible in a dev run and in a packaged app launched from
+  inside the repo, because Node resolves the missing module from the checkout's
+  own `node_modules`. Test packaged builds from outside the repo tree.
 - `codemirrorDedupe` in `vite.shared.ts` prevents "Unrecognized extension value"
   from duplicated CodeMirror copies.
 - Two Vite configs on purpose: `electron.vite.config.ts` (app) and

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,11 +8,15 @@ import { rendererAlias, codemirrorDedupe, vendorChunks, rendererPort } from "./v
 // and the production bundle. The standalone vite.config.ts is kept for the
 // renderer-only path (npm run dev / Playwright e2e webServer).
 //
-// IMPORTANT: we deliberately do NOT use externalizeDepsPlugin for main/preload.
-// @kubernetes/client-node is ESM-only; externalizing it would re-introduce
-// ERR_REQUIRE_ESM at runtime. Bundling every dep (electron-vite still
-// externalizes Node built-ins + electron) avoids that, matching the prior
-// esbuild --external:electron setup.
+// IMPORTANT: main/preload must bundle every dep. electron-vite 5 externalizes
+// anything listed under `dependencies` by default (`build.externalizeDeps`
+// defaults to true; the old externalizeDepsPlugin is deprecated), so bundling
+// is expressed the way electron-vite documents it: package.json keeps only
+// electron-updater under `dependencies` and everything else under
+// `devDependencies`. Adding a runtime dep back to `dependencies` silently
+// un-bundles it AND makes electron-builder copy it into the asar.
+// electron-updater is the one exception — handlers/updater.ts require()s it
+// lazily at runtime, so it has to ship as real files inside the asar.
 export default defineConfig({
   main: {
     build: {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "electron"
   ],
   "dependencies": {
+    "electron-updater": "^6.8.9"
+  },
+  "devDependencies": {
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-yaml": "^6.1.3",
@@ -40,34 +43,31 @@
     "@codemirror/view": "^6.43.8",
     "@kubernetes/client-node": "^1.4.0",
     "@lezer/highlight": "^1.2.3",
+    "@playwright/test": "^1.62.1",
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@tailwindcss/vite": "^4.3.3",
     "@tanstack/svelte-virtual": "^3.13.35",
+    "@types/bun": "^1.3.14",
+    "@types/node": "^26.2.0",
     "@wterm/dom": "0.3.3",
     "bits-ui": "^2.18.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",
-    "electron-updater": "^6.8.9",
-    "js-yaml": "^5.2.3",
-    "lucide-svelte": "^1.0.1",
-    "tailwind-merge": "^3.6.0",
-    "tailwind-variants": "^3.3.1",
-    "undici": "^8.10.0",
-    "yaml": "^2.9.0"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.62.1",
-    "@sveltejs/vite-plugin-svelte": "^6.2.4",
-    "@tailwindcss/vite": "^4.3.3",
-    "@types/bun": "^1.3.14",
-    "@types/node": "^26.2.0",
     "electron": "^43.3.0",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
+    "js-yaml": "^5.2.3",
+    "lucide-svelte": "^1.0.1",
     "svelte": "^5.56.8",
     "svelte-check": "^4.7.5",
+    "tailwind-merge": "^3.6.0",
+    "tailwind-variants": "^3.3.1",
     "tailwindcss": "^4.3.3",
     "tsx": "^4.23.11",
     "typescript": "^6.0.3",
-    "vite": "^7.3.6"
+    "undici": "^8.10.0",
+    "vite": "^7.3.6",
+    "yaml": "^2.9.0"
   },
   "build": {
     "appId": "com.kdashboard.app",
@@ -79,6 +79,7 @@
     "directories": {
       "output": "release"
     },
+    "electronLanguages": ["en-US"],
     "mac": {
       "target": ["dmg", "zip"],
       "icon": "build/icon.icns",


### PR DESCRIPTION
## What

The packaged app carried the entire production dependency tree inside `app.asar` — **83 MB of `node_modules` sitting next to a 197 kB main bundle**. This PR makes main/preload actually bundle their dependencies, and trims Electron's unused locale paks.

Linux x64, measured on real `electron-builder` output:

| | before | after |
|---|---|---|
| `out/main/index.js` | 197 kB (externalized) | 7.8 MB (bundled) |
| `app.asar` | 74.1 MB | **14 MB** |
| `linux-unpacked/` | 383 MB | **267 MB** |
| `AppImage` | 137.9 MB | **117.9 MB** |

## Why it regressed

`electron.vite.config.ts` claimed main/preload bundle every dep because we skip `externalizeDepsPlugin`. That stopped being true at the electron-vite 5 upgrade: v5 externalizes everything under `dependencies` **by default** (`build.externalizeDeps ?? true`, see `electron-vite/dist/chunks/lib-*.js`), and `externalizeDepsPlugin` is now deprecated. Opting out is no longer the default-off path it used to be.

So main/preload silently stopped bundling, and `electron-builder` — which copies the production dependency tree into the archive — dutifully shipped all of it. Both halves of the waste come from the same root cause.

## The fix

Express the intent the way [electron-vite documents it](https://electron-vite.org/guide/dependency-handling): only packages that must exist as real files at runtime belong in `dependencies`; everything else goes to `devDependencies`, where electron-vite bundles it and electron-builder ignores it.

`dependencies` keeps exactly one entry: **`electron-updater`**. `electron/handlers/updater.ts:121` `require()`s it lazily on purpose (touching `autoUpdater` at import time throws when no update config is present), so it has to ship unbundled. electron-builder resolves its transitive closure on its own — 16 packages, 2.7 MB.

Filtering `node_modules` through `files` globs instead was considered and rejected: it is the hand-maintained workaround from [electron-builder#9665](https://github.com/electron-userland/electron-builder/issues/9665), and it breaks silently at runtime whenever the updater's dependency tree shifts.

Second, unrelated win: `electronLanguages: ["en-US"]`. Electron ships 55 locale `.pak` files (46 MB) and the app uses one. Set at the top level of `build` rather than under `linux`, because `ElectronFramework.js` applies it to mac (`.lproj`) and Windows too. It runs in `beforeCopyExtraFiles` (`platformPackager.js:223`), ahead of the `afterPack` hook (`:246`) where `scripts/sign-adhoc.mjs` seals the bundle — so the ad-hoc signature covers the already-trimmed app. Chromium's own native strings (context menu, PDF viewer) are now always English; the app has no i18n, so nothing user-visible changes.

## Verification

- `bun run test` — 1191 + 148 pass
- `bun run typecheck:electron` — clean
- Full `bun run build:electron`, then the packaged app launched **from a directory outside the repo**: it reads the kubeconfig and reaches the project's own apiserver error path, so bundled `@kubernetes/client-node` + `undici` execute. `electron-updater` still resolves from the asar.
- The bundle has no unresolved dynamic `require()`s.

The out-of-tree part matters. A packaged build launched from inside the checkout resolves any missing module by walking up into the repo's own `node_modules`, so this class of breakage passes a naive smoke test. That trap is now written down in `CLAUDE.md`.

## Not verified

**Only the connection-failure path was exercised against a live cluster — there is none on the build machine.** Bundling changes how `@kubernetes/client-node` and `undici` load in production, so exec/attach over WebSocket, port-forward and log streaming should get a manual pass against `./scripts/dev-cluster.sh` before this rides a release tag.

## Follow-ups (not in this PR)

- `build: { externalizeDeps: false }` on main/preload, so bundling can't regress again by someone re-adding a package to `dependencies`. The stale comment is fixed here, but the invariant is still only documented, not enforced.
- `npmRebuild: false` — no native dependencies remain, so the `@electron/rebuild` step in CI is dead time.
- A packaged-artifact smoke test in `build.yml` (unpack, launch under `xvfb-run`). Nothing in CI currently runs the bundle; this regression lived through a release because of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Packaging**
  - Improved packaged application reliability by ensuring required runtime components are included correctly.
  - Reduced packaged Electron locale files to English (United States), helping streamline application distribution.

- **Documentation**
  - Clarified dependency and bundling configuration guidelines for development and packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->