### PR TITLE
feat(views): derived status, endpoints and redesigned Pod/Deployment/Service details

### DIFF
--- a/e2e/detail-panel.spec.ts
+++ b/e2e/detail-panel.spec.ts
@@ -1,256 +1,70 @@
-import { test, expect } from "./helpers";
-import { MOCK_DEPLOYMENTS_LIST, MOCK_PODS_LIST } from "./fixtures/mock-k8s";
+/**
+ * The detail panel (docked aside and full tab) against the default mock
+ * cluster: identity, the summary strip, subtabs, and the page variant's
+ * actions. Pods are the richest case (Logs / Shell / Port forward).
+ */
+import { test, expect, tableRows } from "./helpers";
 
 test.describe("DetailPanel", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
-  });
-
-  test("opens when a resource is selected", async ({ page }) => {
-    const row = page.locator('[data-testid="resource-row"]').first();
-    await row.click();
-
-    await page.waitForTimeout(300);
-
-    const detailPanel = page.locator('[data-testid="detail-panel"]');
-    await expect(detailPanel).toBeVisible();
-  });
-
-  test("closes when close button is clicked", async ({ page }) => {
-    const row = page.locator('[data-testid="resource-row"]').first();
-    await row.click();
-
-    await page.waitForTimeout(300);
-
-    const closeButton = page.locator('[data-testid="detail-panel-close"]');
-    await closeButton.click();
-
-    await page.waitForTimeout(300);
-
-    const detailPanel = page.locator('[data-testid="detail-panel"]');
-    await expect(detailPanel).not.toBeVisible();
-  });
-
-  test.describe("Resource Info Section", () => {
-    test("displays resource name", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const resourceName = page.locator('[data-testid="detail-resource-name"]');
-      await expect(resourceName).toBeVisible();
-      const name = await resourceName.textContent();
-      expect(name).toBeTruthy();
+  test.describe("Docked aside", () => {
+    test.beforeEach(async ({ page }) => {
+      await tableRows(page).first().click();
+      await expect(page.locator('[data-testid="detail-panel"]')).toBeVisible();
     });
 
-    test("displays resource kind", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const resourceKind = page.locator('[data-testid="detail-resource-kind"]');
-      await expect(resourceKind).toBeVisible();
-      const kind = await resourceKind.textContent();
-      expect(kind).toBeTruthy();
+    test("shows the resource's name, kind and namespace", async ({ page }) => {
+      const panel = page.locator('[data-testid="detail-panel"]');
+      const name = (await tableRows(page).first().locator('[data-testid="cell-name"]').textContent())?.trim() ?? "";
+      await expect(panel.locator('[data-testid="detail-resource-name"]')).toHaveText(name);
+      await expect(panel.getByText(/Pod\s*·\s*default/)).toBeVisible();
     });
 
-    test("displays resource namespace", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
+    test("opens on the Overview subtab with the summary strip", async ({ page }) => {
+      const panel = page.locator('[data-testid="detail-panel"]');
+      await expect(panel.locator('[data-testid="summary-strip"]')).toBeVisible();
+      await expect(panel.locator('[data-testid="summary-strip"]')).toContainText("Status");
+      await expect(panel.locator('[data-testid="summary-strip"]')).toContainText("Running");
+      await expect(panel.locator('[data-testid="summary-strip"]')).toContainText("1/1");
+    });
 
-      await page.waitForTimeout(300);
+    test("a healthy pod shows no attention block", async ({ page }) => {
+      await expect(page.locator('[data-testid="attention-block"]')).toHaveCount(0);
+    });
 
-      const resourceNamespace = page.locator('[data-testid="detail-resource-namespace"]');
-      const isVisible = await resourceNamespace.isVisible().catch(() => false);
+    test("switches between subtabs", async ({ page }) => {
+      const panel = page.locator('[data-testid="detail-panel"]');
+      await panel.getByRole("button", { name: "Events" }).click();
+      await expect(panel.locator('[data-testid="summary-strip"]')).toBeHidden();
+      await panel.getByRole("button", { name: "Overview" }).click();
+      await expect(panel.locator('[data-testid="summary-strip"]')).toBeVisible();
+    });
 
-      if (isVisible) {
-        await expect(resourceNamespace).toBeVisible();
-      }
+    test("the close button hides the aside", async ({ page }) => {
+      await page.getByRole("button", { name: "Close detail" }).click();
+      await expect(page.locator('[data-testid="detail-panel"]')).toBeHidden();
     });
   });
 
-  test.describe("Tabs", () => {
-    test("displays tab bar", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const tabBar = page.locator('[data-testid="detail-tabs"]');
-      await expect(tabBar).toBeVisible();
+  test.describe("Detail tab", () => {
+    test.beforeEach(async ({ page }) => {
+      await tableRows(page).first().dblclick();
+      await expect(page.locator('[data-testid="detail-panel"]')).toBeVisible();
     });
 
-    test("switches between tabs", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const yamlTab = page.locator('[data-testid="detail-tab"]').filter({ hasText: /yaml/i });
-      const isYamlTabVisible = await yamlTab.isVisible().catch(() => false);
-
-      if (isYamlTabVisible) {
-        await yamlTab.click();
-        await page.waitForTimeout(200);
-
-        const yamlContent = page.locator('[data-testid="detail-yaml-content"]');
-        await expect(yamlContent).toBeVisible();
+    test("offers the pod actions with labels", async ({ page }) => {
+      for (const name of ["Logs", "Shell", "Edit", "Delete"]) {
+        await expect(page.getByRole("button", { name, exact: true }).first()).toBeVisible();
       }
     });
 
-    test("shows events tab for pods", async ({ page }) => {
-      const podRow = page.locator('[data-testid="resource-row"]').filter({ hasText: /pod/i }).first();
-      const isPodVisible = await podRow.isVisible().catch(() => false);
-
-      if (!isPodVisible) {
-        return;
-      }
-
-      await podRow.click();
-      await page.waitForTimeout(300);
-
-      const eventsTab = page.locator('[data-testid="detail-tab"]').filter({ hasText: /events/i });
-      const isEventsTabVisible = await eventsTab.isVisible().catch(() => false);
-
-      if (isEventsTabVisible) {
-        await eventsTab.click();
-        await page.waitForTimeout(200);
-
-        const eventsContent = page.locator('[data-testid="detail-events-content"]');
-        await expect(eventsContent).toBeVisible();
-      }
-    });
-  });
-
-  test.describe("Actions", () => {
-    test("displays action buttons", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const actionsBar = page.locator('[data-testid="detail-actions"]');
-      const isVisible = await actionsBar.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(actionsBar).toBeVisible();
-      }
+    test("the Shell action switches to the terminal subtab", async ({ page }) => {
+      await page.getByRole("button", { name: "Shell", exact: true }).first().click();
+      await expect(page.locator('[data-testid="terminal-panel"]')).toBeVisible();
     });
 
-    test("opens logs action", async ({ page }) => {
-      const podRow = page.locator('[data-testid="resource-row"]').filter({ hasText: /pod/i }).first();
-      const isPodVisible = await podRow.isVisible().catch(() => false);
-
-      if (!isPodVisible) {
-        return;
-      }
-
-      await podRow.click();
-      await page.waitForTimeout(300);
-
-      const logsButton = page.locator('[data-testid="detail-action-logs"]');
-      const isLogsVisible = await logsButton.isVisible().catch(() => false);
-
-      if (isLogsVisible) {
-        await logsButton.click();
-        await page.waitForTimeout(300);
-
-        const logsPanel = page.locator('[data-testid="log-viewer"]');
-        await expect(logsPanel).toBeVisible();
-      }
-    });
-
-    test("opens terminal action for pods", async ({ page }) => {
-      const podRow = page.locator('[data-testid="resource-row"]').filter({ hasText: /pod/i }).first();
-      const isPodVisible = await podRow.isVisible().catch(() => false);
-
-      if (!isPodVisible) {
-        return;
-      }
-
-      await podRow.click();
-      await page.waitForTimeout(300);
-
-      const terminalButton = page.locator('[data-testid="detail-action-terminal"]');
-      const isTerminalVisible = await terminalButton.isVisible().catch(() => false);
-
-      if (isTerminalVisible) {
-        await terminalButton.click();
-        await page.waitForTimeout(300);
-
-        const terminalPanel = page.locator('[data-testid="terminal-panel"]');
-        await expect(terminalPanel).toBeVisible();
-      }
-    });
-  });
-
-  test.describe("Metadata Section", () => {
-    test("displays creation timestamp", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const metadataSection = page.locator('[data-testid="detail-metadata"]');
-      const isVisible = await metadataSection.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(metadataSection).toBeVisible();
-
-        const createdAt = metadataSection.locator('[data-testid="metadata-created-at"]');
-        const isCreatedVisible = await createdAt.isVisible().catch(() => false);
-
-        if (isCreatedVisible) {
-          await expect(createdAt).toBeVisible();
-        }
-      }
-    });
-
-    test("displays labels", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const labelsSection = page.locator('[data-testid="detail-labels"]');
-      const isVisible = await labelsSection.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(labelsSection).toBeVisible();
-      }
-    });
-
-    test("displays annotations", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const annotationsSection = page.locator('[data-testid="detail-annotations"]');
-      const isVisible = await annotationsSection.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(annotationsSection).toBeVisible();
-      }
-    });
-  });
-
-  test.describe("Owner References", () => {
-    test("displays owner reference when present", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(300);
-
-      const ownerSection = page.locator('[data-testid="detail-owner"]');
-      const isVisible = await ownerSection.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(ownerSection).toBeVisible();
-      }
+    test("Escape goes back to the table", async ({ page }) => {
+      await page.keyboard.press("Escape");
+      await expect(tableRows(page).first()).toBeVisible();
     });
   });
 });

--- a/e2e/events-view.spec.ts
+++ b/e2e/events-view.spec.ts
@@ -87,7 +87,8 @@ test("lists events with kubectl-style columns, newest first", async ({ page }) =
   // Event-specific columns render from the synthetic spec.
   await expect(rows.nth(0)).toContainText("Pod/web-0");
   await expect(rows.nth(0)).toContainText("Back-off restarting failed container");
-  await expect(rows.nth(0)).toContainText("warning");
+  // The Type column paints a Warning pill (capitalised, from the status category).
+  await expect(rows.nth(0)).toContainText("Warning");
 });
 
 test("the Object column deep-links to the involved resource", async ({ page }) => {
@@ -97,7 +98,8 @@ test("the Object column deep-links to the involved resource", async ({ page }) =
 });
 
 test("filter matches event reason and message", async ({ page }) => {
-  const filter = page.getByPlaceholder("Search events...");
+  // The shared table search box (typed filters + free text).
+  const filter = page.locator("#resource-filter");
   await filter.fill("backoff");
   await expect(page.locator("tbody tr")).toHaveCount(1);
   await expect(page.locator("tbody tr").first()).toContainText("BackOff");

--- a/e2e/fixtures/mocked-cluster.ts
+++ b/e2e/fixtures/mocked-cluster.ts
@@ -38,10 +38,13 @@ interface Fixtures {
   mockInvoke: (handlerSource: string) => Promise<void>;
 }
 
-export const test = base.extend<Fixtures>({
-  mockInvoke: async ({ page }, use) => {
-    const install = async (handlerSource: string) => {
-      await page.addInitScript(`
+/**
+ * Install `handlerSource` as the page's window.electronAPI.invoke before any
+ * app script runs. Shared by the `mockInvoke` fixture and by e2e/helpers.ts,
+ * whose default `page` boots the app against a small mock cluster.
+ */
+export async function installMockInvoke(page: Page, handlerSource: string): Promise<void> {
+  await page.addInitScript(`
         (function () {
           const handler = ${handlerSource};
           const fakeInvoke = async (cmd, args) => {
@@ -68,8 +71,11 @@ export const test = base.extend<Fixtures>({
           });
         })();
       `);
-    };
-    await use(install);
+}
+
+export const test = base.extend<Fixtures>({
+  mockInvoke: async ({ page }, use) => {
+    await use((handlerSource: string) => installMockInvoke(page, handlerSource));
   },
 });
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -30,10 +30,17 @@ const DEFAULT_CLUSTER = `(cmd, args) => {
     const list = lists[args.resourceType];
     return list ? { resource_type: list.resource_type, items: inNamespace(list.items) } : { resource_type: args.resourceType, items: [] };
   }
-  if (cmd === "list_pods_by_selector") return { resource_type: "pods", items: inNamespace(lists.pods.items) };
+  if (cmd === "list_pods_by_selector") {
+    // "k=v,k=v" against the pod labels, like the API server does.
+    const terms = String(args.selector ?? "").split(",").map((t) => t.trim()).filter(Boolean).map((t) => t.split("="));
+    const matches = (pod) => terms.every(([k, v]) => (pod.metadata.labels ?? {})[k] === v);
+    return { resource_type: "pods", items: inNamespace(lists.pods.items).filter(matches) };
+  }
   if (cmd === "get_resource") {
-    const all = Object.values(lists).flatMap((l) => l.items);
-    return all.find((i) => i.metadata.name === args.name && (!args.namespace || i.metadata.namespace === args.namespace)) ?? null;
+    // Restrict to the requested kind so same-name resources resolve correctly.
+    const kind = String(args.kind ?? "").toLowerCase();
+    const pool = Object.values(lists).flatMap((l) => l.items).filter((i) => !kind || String(i.kind).toLowerCase() === kind);
+    return pool.find((i) => i.metadata.name === args.name && (!args.namespace || i.metadata.namespace === args.namespace)) ?? null;
   }
   if (cmd === "get_resource_events") return [];
   if (cmd === "get_pod_metrics") return { available: false, reason: "mock cluster", pods: [] };

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,9 +1,48 @@
 import { test as base, type Page } from "@playwright/test";
+import { installMockInvoke } from "./fixtures/mocked-cluster";
+import { MOCK_CONFIGMAPS_LIST, MOCK_DEPLOYMENTS_LIST, MOCK_PODS_LIST, MOCK_SERVICES_LIST } from "./fixtures/mock-k8s";
 
 export { expect } from "@playwright/test";
 
+/**
+ * The default e2e backend: a small, healthy mock cluster (the lists in
+ * fixtures/mock-k8s) answering the commands the app issues on boot and when
+ * a table or detail view opens. `bun run dev` has no window.electronAPI at
+ * all, so without this every invoke() rejects and no table ever renders.
+ * Specs that need a specific cluster state use the `mockInvoke` fixture
+ * from fixtures/mocked-cluster instead.
+ */
+const DEFAULT_CLUSTER = `(cmd, args) => {
+  const lists = ${JSON.stringify({
+    pods: MOCK_PODS_LIST,
+    deployments: MOCK_DEPLOYMENTS_LIST,
+    services: MOCK_SERVICES_LIST,
+    configmaps: MOCK_CONFIGMAPS_LIST,
+  })};
+  const inNamespace = (items) => (args && args.namespace ? items.filter((i) => i.metadata.namespace === args.namespace) : items);
+  if (cmd === "get_contexts") return ["mock-cluster"];
+  if (cmd === "get_current_context") return "mock-cluster";
+  if (cmd === "get_namespaces") return ["default", "kube-system"];
+  if (cmd === "get_resource_counts") return {};
+  if (cmd === "bench_config") return { enabled: false };
+  if (cmd === "discover_crds") return [];
+  if (cmd === "list_resources") {
+    const list = lists[args.resourceType];
+    return list ? { resource_type: list.resource_type, items: inNamespace(list.items) } : { resource_type: args.resourceType, items: [] };
+  }
+  if (cmd === "list_pods_by_selector") return { resource_type: "pods", items: inNamespace(lists.pods.items) };
+  if (cmd === "get_resource") {
+    const all = Object.values(lists).flatMap((l) => l.items);
+    return all.find((i) => i.metadata.name === args.name && (!args.namespace || i.metadata.namespace === args.namespace)) ?? null;
+  }
+  if (cmd === "get_resource_events") return [];
+  if (cmd === "get_pod_metrics") return { available: false, reason: "mock cluster", pods: [] };
+  return null;
+}`;
+
 export const test = base.extend<{ page: Page }>({
   page: async ({ page }, use) => {
+    await installMockInvoke(page, DEFAULT_CLUSTER);
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await use(page);
@@ -15,24 +54,14 @@ export async function openCommandPalette(page: Page): Promise<void> {
   await page.waitForTimeout(300);
 }
 
-export async function filterByResourceType(page: Page, resourceType: string): Promise<void> {
-  await page.click('[data-testid="resource-type-filter"]');
-  await page.fill('[data-testid="resource-type-search"]', resourceType);
-  await page.click(`[data-testid="resource-type-${resourceType}"]`);
+/** The rows of the active resource table. */
+export function tableRows(page: Page) {
+  return page.locator('[data-testid="resource-row"]');
 }
 
+/** Open the namespace picker and choose one. */
 export async function selectNamespace(page: Page, namespace: string): Promise<void> {
-  await page.click('[data-testid="namespace-selector"]');
-  await page.fill('[data-testid="namespace-search"]', namespace);
-  await page.click(`[data-testid="namespace-option-${namespace}"]`);
-}
-
-export async function getSafetyTierColor(page: Page, tier: "green" | "yellow" | "red" | "blacked"): Promise<string> {
-  const tierColors: Record<string, string> = {
-    green: "rgb(34, 197, 94)",
-    yellow: "rgb(234, 179, 8)",
-    red: "rgb(239, 68, 68)",
-    blacked: "rgb(107, 114, 128)",
-  };
-  return tierColors[tier];
+  // The popover trigger and the button inside it both carry the label.
+  await page.getByRole("button", { name: "Change namespace" }).last().click();
+  await page.getByRole("button", { name: namespace, exact: true }).click();
 }

--- a/e2e/resource-table.spec.ts
+++ b/e2e/resource-table.spec.ts
@@ -1,252 +1,108 @@
-import { test, expect } from "./helpers";
-import { MOCK_DEPLOYMENTS_LIST, MOCK_PODS_LIST } from "./fixtures/mock-k8s";
+/**
+ * The resource table against the default mock cluster (see helpers.ts): rows,
+ * headers, the search box, sorting, namespace scoping, row preview and bulk
+ * selection. Pods is the view the app boots into.
+ */
+import { test, expect, tableRows, selectNamespace } from "./helpers";
+import { MOCK_PODS_LIST } from "./fixtures/mock-k8s";
+
+// The app boots scoped to the "default" namespace.
+const POD_NAMES = MOCK_PODS_LIST.items.filter((p) => p.metadata.namespace === "default").map((p) => p.metadata.name);
 
 test.describe("ResourceTable", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    await page.waitForLoadState("networkidle");
+  test("renders one row per pod with name and status", async ({ page }) => {
+    const rows = tableRows(page);
+    await expect(rows).toHaveCount(POD_NAMES.length);
+    await expect(rows.first().locator('[data-testid="cell-name"]')).toBeVisible();
+    // Status is the effective state derived from the container statuses.
+    await expect(rows.first().locator('[data-testid="cell-status"]')).toHaveText(/Running/);
   });
 
-  test("displays resource rows", async ({ page }) => {
-    const rows = page.locator('[data-testid="resource-row"]');
-    await expect(rows.first()).toBeVisible();
-  });
-
-  test("displays column headers", async ({ page }) => {
+  test("shows the column headers for pods", async ({ page }) => {
     const headers = page.locator('[data-testid="table-header"]');
     await expect(headers.first()).toBeVisible();
+    await expect(headers.filter({ hasText: /^Name/ })).toHaveCount(1);
+    await expect(headers.filter({ hasText: /^Status/ })).toHaveCount(1);
+    await expect(headers.filter({ hasText: /^Ready/ })).toHaveCount(1);
   });
 
-  test("displays resource name", async ({ page }) => {
-    const firstRow = page.locator('[data-testid="resource-row"]').first();
-    const nameCell = firstRow.locator('[data-testid="cell-name"]');
-    await expect(nameCell).toBeVisible();
-    const name = await nameCell.textContent();
-    expect(name).toBeTruthy();
+  test("filters rows by name and clears", async ({ page }) => {
+    const search = page.locator("#resource-filter");
+    await search.fill("api");
+    await expect(tableRows(page)).toHaveCount(1);
+    await expect(tableRows(page).first().locator('[data-testid="cell-name"]')).toContainText("api-server-v2");
+    await search.fill("");
+    await expect(tableRows(page)).toHaveCount(POD_NAMES.length);
   });
 
-  test("displays resource status", async ({ page }) => {
-    const firstRow = page.locator('[data-testid="resource-row"]').first();
-    const statusCell = firstRow.locator('[data-testid="cell-status"]');
-    await expect(statusCell).toBeVisible();
-  });
-
-  test("filters resources by name", async ({ page }) => {
-    const filterInput = page.locator('[data-testid="filter-input"]');
-    await filterInput.fill("api");
-
-    await page.waitForTimeout(300);
-
-    const rows = page.locator('[data-testid="resource-row"]');
-    const count = await rows.count();
-    expect(count).toBeGreaterThan(0);
-
-    for (let i = 0; i < count; i++) {
-      const nameCell = rows.nth(i).locator('[data-testid="cell-name"]');
-      const name = await nameCell.textContent();
-      expect(name?.toLowerCase()).toContain("api");
-    }
-  });
-
-  test("clears filter and shows all resources", async ({ page }) => {
-    const filterInput = page.locator('[data-testid="filter-input"]');
-    await filterInput.fill("api");
-
-    await page.waitForTimeout(300);
-
-    const clearButton = page.locator('[data-testid="filter-clear"]');
-    await clearButton.click();
-
-    await page.waitForTimeout(300);
-
-    const rows = page.locator('[data-testid="resource-row"]');
-    const allRowsCount = await rows.count();
-    expect(allRowsCount).toBeGreaterThan(1);
+  test("a typed facet narrows by status", async ({ page }) => {
+    const search = page.locator("#resource-filter");
+    await search.fill("status:running ");
+    await expect(tableRows(page)).toHaveCount(POD_NAMES.length);
+    await search.fill("status:crash ");
+    await expect(tableRows(page)).toHaveCount(0);
   });
 
   test.describe("Sorting", () => {
-    test("sorts by name ascending", async ({ page }) => {
-      const nameHeader = page.locator('[data-testid="header-name"]');
-      await nameHeader.click();
-
-      await page.waitForTimeout(200);
-
-      const rows = page.locator('[data-testid="resource-row"]');
-      const names = await rows.all();
-      const nameTexts: string[] = [];
-
-      for (const row of names) {
-        const nameCell = row.locator('[data-testid="cell-name"]');
-        const text = await nameCell.textContent();
-        if (text) nameTexts.push(text);
-      }
-
-      const sorted = [...nameTexts].sort((a, b) => a.localeCompare(b));
-      expect(nameTexts).toEqual(sorted);
+    test("clicking Name toggles ascending and descending", async ({ page }) => {
+      const names = async () => (await tableRows(page).locator('[data-testid="cell-name"]').allTextContents()).map((n) => n.trim());
+      const sorted = [...POD_NAMES].sort();
+      const header = page.locator('[data-testid="header-name"]');
+      // Whatever the boot order, one click per direction.
+      await header.click();
+      const first = await names();
+      const ascendingFirst = first[0] === sorted[0];
+      expect(first).toEqual(ascendingFirst ? sorted : [...sorted].reverse());
+      await header.click();
+      expect(await names()).toEqual(ascendingFirst ? [...sorted].reverse() : sorted);
     });
+  });
 
-    test("sorts by name descending after second click", async ({ page }) => {
-      const nameHeader = page.locator('[data-testid="header-name"]');
-      await nameHeader.click();
-      await nameHeader.click();
-
-      await page.waitForTimeout(200);
-
-      const rows = page.locator('[data-testid="resource-row"]');
-      const names = await rows.all();
-      const nameTexts: string[] = [];
-
-      for (const row of names) {
-        const nameCell = row.locator('[data-testid="cell-name"]');
-        const text = await nameCell.textContent();
-        if (text) nameTexts.push(text);
-      }
-
-      const sorted = [...nameTexts].sort((a, b) => b.localeCompare(a));
-      expect(nameTexts).toEqual(sorted);
+  test.describe("Namespace scoping", () => {
+    test("one namespace hides the column and the other namespaces' rows", async ({ page }) => {
+      await selectNamespace(page, "kube-system");
+      await expect(tableRows(page)).toHaveCount(1);
+      await expect(tableRows(page).first().locator('[data-testid="cell-name"]')).toContainText("cache-redis");
+      await expect(page.getByText("Namespace column hidden")).toBeVisible();
+      await selectNamespace(page, "default");
+      await expect(tableRows(page)).toHaveCount(POD_NAMES.length);
     });
   });
 
   test.describe("Selection", () => {
-    test("selects a resource on click", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.click();
-
-      await page.waitForTimeout(200);
-
-      await expect(row).toHaveAttribute("data-selected", "true");
+    test("click previews the row in the docked detail panel", async ({ page }) => {
+      const first = tableRows(page).first();
+      const name = await first.locator('[data-testid="cell-name"]').textContent();
+      await first.click();
+      const panel = page.locator('[data-testid="detail-panel"]');
+      await expect(panel).toBeVisible();
+      await expect(panel.locator('[data-testid="detail-resource-name"]')).toHaveText(name?.trim() ?? "");
+      // Escape closes the preview.
+      await page.keyboard.press("Escape");
+      await expect(panel).toBeHidden();
     });
 
-    test("opens detail panel on double click", async ({ page }) => {
-      const row = page.locator('[data-testid="resource-row"]').first();
-      await row.dblclick();
-
-      await page.waitForTimeout(300);
-
-      const detailPanel = page.locator('[data-testid="detail-panel"]');
-      await expect(detailPanel).toBeVisible();
-    });
-  });
-
-  test.describe("Bulk Selection", () => {
-    test("shows bulk action bar when resources are selected", async ({ page }) => {
-      const firstRow = page.locator('[data-testid="resource-row"]').first();
-      const checkbox = firstRow.locator('[data-testid="row-checkbox"]');
-      await checkbox.click();
-
-      await page.waitForTimeout(200);
-
-      const bulkActionBar = page.locator('[data-testid="bulk-action-bar"]');
-      await expect(bulkActionBar).toBeVisible();
-    });
-
-    test("hides bulk action bar when no resources selected", async ({ page }) => {
-      const bulkActionBar = page.locator('[data-testid="bulk-action-bar"]');
-      const isVisible = await bulkActionBar.isVisible().catch(() => false);
-
-      if (isVisible) {
-        const checkbox = page.locator('[data-testid="row-checkbox"]').first();
-        await checkbox.click();
-        await page.waitForTimeout(200);
-      }
-
-      await expect(bulkActionBar).not.toBeVisible();
-    });
-
-    test("select all checkbox selects all visible resources", async ({ page }) => {
-      const selectAllCheckbox = page.locator('[data-testid="select-all-checkbox"]');
-      await selectAllCheckbox.click();
-
-      await page.waitForTimeout(200);
-
-      const rows = page.locator('[data-testid="resource-row"]');
-      const count = await rows.count();
-
-      for (let i = 0; i < count; i++) {
-        const row = rows.nth(i);
-        await expect(row).toHaveAttribute("data-selected", "true");
-      }
+    test("double click opens the row in its own tab", async ({ page }) => {
+      const first = tableRows(page).first();
+      const name = (await first.locator('[data-testid="cell-name"]').textContent())?.trim() ?? "";
+      await first.dblclick();
+      await expect(page.locator('[data-testid="detail-panel"] [data-testid="detail-resource-name"]')).toHaveText(name);
+      // The table is gone: the tab shows the page variant with labelled actions.
+      await expect(page.getByRole("button", { name: "Shell", exact: true }).first()).toBeVisible();
     });
   });
 
-  test.describe("Namespace Filtering", () => {
-    test("filters by namespace", async ({ page }) => {
-      const namespaceSelector = page.locator('[data-testid="namespace-filter"]');
-      await namespaceSelector.click();
-
-      await page.waitForTimeout(200);
-
-      const namespaceOption = page.locator('[data-testid="namespace-option"]').filter({ hasText: "default" }).first();
-      await namespaceOption.click();
-
-      await page.waitForTimeout(300);
-
-      const rows = page.locator('[data-testid="resource-row"]');
-      const count = await rows.count();
-
-      for (let i = 0; i < count; i++) {
-        const row = rows.nth(i);
-        const namespaceCell = row.locator('[data-testid="cell-namespace"]');
-        const namespace = await namespaceCell.textContent();
-        expect(namespace?.trim()).toBe("default");
-      }
+  test.describe("Bulk selection", () => {
+    test("checking rows shows the bulk action bar with the count", async ({ page }) => {
+      await tableRows(page).nth(0).locator('[data-testid="row-checkbox"]').click({ force: true });
+      await expect(page.getByText("1 resource selected")).toBeVisible();
+      await tableRows(page).nth(1).locator('[data-testid="row-checkbox"]').click({ force: true });
+      await expect(page.getByText("2 resources selected")).toBeVisible();
     });
 
-    test("shows resources from all namespaces", async ({ page }) => {
-      const namespaceSelector = page.locator('[data-testid="namespace-filter"]');
-      await namespaceSelector.click();
-
-      await page.waitForTimeout(200);
-
-      const allNamespacesOption = page.locator('[data-testid="namespace-option"]').filter({ hasText: /all namespaces/i });
-      await allNamespacesOption.click();
-
-      await page.waitForTimeout(300);
-
-      const rows = page.locator('[data-testid="resource-row"]');
-      const count = await rows.count();
-      expect(count).toBeGreaterThan(0);
-    });
-  });
-
-  test.describe("Pagination", () => {
-    test("displays pagination controls", async ({ page }) => {
-      const pagination = page.locator('[data-testid="pagination"]');
-      const isVisible = await pagination.isVisible().catch(() => false);
-
-      if (isVisible) {
-        await expect(pagination).toBeVisible();
-      }
-    });
-
-    test("navigates to next page", async ({ page }) => {
-      const pagination = page.locator('[data-testid="pagination"]');
-      const isVisible = await pagination.isVisible().catch(() => false);
-
-      if (!isVisible) {
-        return;
-      }
-
-      const nextButton = pagination.locator('[data-testid="page-next"]');
-      const isNextVisible = await nextButton.isVisible().catch(() => false);
-
-      if (isNextVisible) {
-        const prevCount = await page.locator('[data-testid="resource-row"]').count();
-        await nextButton.click();
-        await page.waitForTimeout(300);
-
-        const newCount = await page.locator('[data-testid="resource-row"]').count();
-        expect(newCount).toBe(prevCount);
-      }
-    });
-  });
-
-  test.describe("Virtual Scrolling", () => {
-    test("renders only visible rows for large datasets", async ({ page }) => {
-      const rows = page.locator('[data-testid="resource-row"]');
-      const visibleCount = await rows.count();
-
-      expect(visibleCount).toBeLessThan(100);
+    test("the header checkbox selects every visible row", async ({ page }) => {
+      await page.locator('[data-testid="select-all-checkbox"]').click({ force: true });
+      await expect(page.getByText(`${POD_NAMES.length} resources selected`)).toBeVisible();
     });
   });
 });

--- a/electron/k8s/resource-mapping.test.ts
+++ b/electron/k8s/resource-mapping.test.ts
@@ -14,6 +14,7 @@ describe('metaFrom — null contract', () => {
     expect(m.labels).toBeNull();
     expect(m.annotations).toBeNull();
     expect(m.creation_timestamp).toBeNull();
+    expect(m.deletion_timestamp).toBeNull();
     expect(m.owner_references).toBeNull();
     // Every field present in the serialized JSON (none dropped):
     const json = JSON.parse(JSON.stringify(m));
@@ -21,6 +22,7 @@ describe('metaFrom — null contract', () => {
       [
         'annotations',
         'creation_timestamp',
+        'deletion_timestamp',
         'labels',
         'name',
         'namespace',
@@ -47,6 +49,7 @@ describe('metaFrom — null contract', () => {
       uid: 'u1',
       resource_version: '42',
       creation_timestamp: '2024-01-01T00:00:00Z',
+      deletion_timestamp: null,
       labels: { app: 'web' },
       annotations: { a: 'b' },
       owner_references: null,

--- a/electron/k8s/resource-mapping.ts
+++ b/electron/k8s/resource-mapping.ts
@@ -22,6 +22,7 @@ export function metaFrom(m: RawObjectMeta | undefined): ResourceMetadata {
     labels: meta.labels ?? null,
     annotations: meta.annotations ?? null,
     creation_timestamp: meta.creationTimestamp ?? null,
+    deletion_timestamp: meta.deletionTimestamp ?? null,
     // Only included when non-empty.
     owner_references: owners && owners.length > 0 ? owners : null,
   };
@@ -146,8 +147,8 @@ export function projectGeneric(
 // container status rendering read (and src/lib/types PodStatus/ContainerStatus):
 //   spec.nodeName, spec.containers[].{name,image}, spec.initContainers[].{name,image}
 //   status.{phase,podIP,hostIP,startTime}
-//   status.conditions[].{type,status}
-//   status.containerStatuses[].{name,ready,restartCount,image,state,started}
+//   status.conditions[].{type,status,reason}
+//   status.containerStatuses[].{name,ready,restartCount,image,state,lastState,started}
 //   status.initContainerStatuses[...]
 // ---------------------------------------------------------------------------
 
@@ -160,6 +161,8 @@ interface RawContainer {
 interface RawCondition {
   type?: string;
   status?: string;
+  /** Why a condition is False — "Unschedulable" is what a Pending row shows. */
+  reason?: string;
 }
 interface RawContainerStatus {
   name?: string;
@@ -167,6 +170,8 @@ interface RawContainerStatus {
   restartCount?: number;
   image?: string;
   state?: unknown;
+  /** The previous termination: its finishedAt is when the last restart happened. */
+  lastState?: unknown;
   started?: boolean;
 }
 interface RawPodSpec {
@@ -204,6 +209,7 @@ function projectContainerStatus(cs: RawContainerStatus): Partial<RawContainerSta
     restartCount: cs.restartCount,
     image: cs.image,
     state: cs.state,
+    lastState: presentOrUndefined(cs.lastState),
     started: cs.started,
   });
 }
@@ -229,7 +235,7 @@ export function projectPod(obj: RawObject): Resource {
       podIP: rawStatus.podIP,
       hostIP: rawStatus.hostIP,
       startTime: rawStatus.startTime,
-      conditions: rawStatus.conditions?.map((c) => compact({ type: c.type, status: c.status })),
+      conditions: rawStatus.conditions?.map((c) => compact({ type: c.type, status: c.status, reason: c.reason })),
       containerStatuses: rawStatus.containerStatuses?.map(projectContainerStatus),
       initContainerStatuses: rawStatus.initContainerStatuses?.map(projectContainerStatus),
     });

--- a/electron/k8s/resource-types.ts
+++ b/electron/k8s/resource-types.ts
@@ -16,6 +16,8 @@ export interface ResourceMetadata {
   labels?: Record<string, string> | null;
   annotations?: Record<string, string> | null;
   creation_timestamp?: string | null;
+  /** Set once the object is being deleted; the renderer shows it as Terminating. */
+  deletion_timestamp?: string | null;
   owner_references?: unknown;
 }
 
@@ -46,6 +48,7 @@ export interface RawObjectMeta {
   labels?: Record<string, string>;
   annotations?: Record<string, string>;
   creationTimestamp?: string;
+  deletionTimestamp?: string;
   ownerReferences?: unknown[];
   managedFields?: unknown;
   [k: string]: unknown;

--- a/src/lib/components/common/ReplicaBar.svelte
+++ b/src/lib/components/common/ReplicaBar.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { cn } from "$lib/utils";
+
+  /**
+   * The replica count as a bar: ready (accent), pods that exist but are not
+   * ready yet (pending tone), and the gap to the desired count (a faint
+   * failed tint). One glance says "2 of 3, one still coming up" where
+   * "2/3" alone does not.
+   */
+  interface Props {
+    ready: number;
+    pending: number;
+    missing: number;
+    class?: string;
+    /** Bar thickness, in px. */
+    height?: number;
+  }
+
+  let { ready, pending, missing, class: className, height = 4 }: Props = $props();
+
+  let total = $derived(ready + pending + missing);
+  let title = $derived(
+    total === 0
+      ? "No replicas desired"
+      : `${ready} ready · ${pending} not ready · ${missing} missing`,
+  );
+</script>
+
+<span
+  class={cn("inline-flex w-16 shrink-0 overflow-hidden rounded-full bg-[var(--bg-tertiary)]", className)}
+  style:height="{height}px"
+  style:gap="1px"
+  role="img"
+  aria-label={title}
+  {title}
+>
+  {#if ready > 0}
+    <span class="block h-full bg-[var(--accent)]" style:flex="{ready} {ready} 0"></span>
+  {/if}
+  {#if pending > 0}
+    <span class="block h-full bg-[var(--status-pending)]" style:flex="{pending} {pending} 0"></span>
+  {/if}
+  {#if missing > 0}
+    <span
+      class="block h-full"
+      style:flex="{missing} {missing} 0"
+      style:background-color="color-mix(in srgb, var(--status-failed) 55%, transparent)"
+    ></span>
+  {/if}
+</span>

--- a/src/lib/components/details/AttentionBlock.svelte
+++ b/src/lib/components/details/AttentionBlock.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { AlertTriangle } from "lucide-svelte";
+
+  /**
+   * Why this thing is not healthy, and what to do next — shown only when
+   * something is wrong. A title line, a few lines of evidence (last exit
+   * code, the latest Warning event), and actions that jump to logs/events.
+   */
+  interface Props {
+    tone?: "error" | "warning";
+    title: string;
+    children?: Snippet;
+    actions?: Snippet;
+  }
+
+  let { tone = "error", title, children, actions }: Props = $props();
+  let color = $derived(tone === "error" ? "var(--status-failed)" : "var(--status-pending)");
+</script>
+
+<div
+  class="mx-6 mt-4 rounded-md p-3.5"
+  style="background-color: color-mix(in srgb, {color} 8%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, {color} 25%, transparent);"
+  role="status"
+  data-testid="attention-block"
+>
+  <div class="flex items-start gap-2 text-[12px] font-semibold leading-[17px]" style:color>
+    <AlertTriangle class="mt-px h-3.5 w-3.5 shrink-0" />
+    <span class="min-w-0 break-words">{title}</span>
+  </div>
+  {#if children}
+    <div class="mt-2 flex flex-col gap-1 text-[12px] leading-[17px] text-[var(--text-secondary)] [&_code]:font-mono [&_code]:text-[var(--text-primary)] [&_b]:font-medium [&_b]:text-[var(--text-primary)]">
+      {@render children()}
+    </div>
+  {/if}
+  {#if actions}
+    <div class="mt-2.5 flex flex-wrap items-center gap-1.5">
+      {@render actions()}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/details/ConditionsList.svelte
+++ b/src/lib/components/details/ConditionsList.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { Check, X, Minus } from "lucide-svelte";
+  import { cn } from "$lib/utils";
+
+  /**
+   * Conditions as a checklist: a tick for True, a cross for False, a dash
+   * for Unknown, with the reason (or message) trailing in muted text. `wrap`
+   * lays them out inline for the four pod conditions; `list` one per line
+   * with the reason right-aligned.
+   */
+  export interface ConditionItem {
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+  }
+
+  interface Props {
+    conditions: ConditionItem[];
+    layout?: "wrap" | "list";
+    /** Conditions whose healthy state is False (e.g. a Node's MemoryPressure). */
+    invert?: ReadonlySet<string>;
+  }
+
+  let { conditions, layout = "list", invert }: Props = $props();
+
+  type Verdict = "ok" | "bad" | "unknown";
+  function verdict(c: ConditionItem): Verdict {
+    const wantTrue = !invert?.has(c.type);
+    if (c.status === "True") return wantTrue ? "ok" : "bad";
+    if (c.status === "False") return wantTrue ? "bad" : "ok";
+    return "unknown";
+  }
+  const COLOR: Record<Verdict, string> = {
+    ok: "var(--status-running)",
+    bad: "var(--status-failed)",
+    unknown: "var(--text-muted)",
+  };
+</script>
+
+<div class={cn(layout === "wrap" ? "flex flex-wrap gap-x-5 gap-y-2" : "flex flex-col gap-2")}>
+  {#each conditions as c (c.type)}
+    {@const v = verdict(c)}
+    {@const note = c.reason || c.message}
+    <div class={cn("flex min-w-0 items-baseline gap-2", layout === "list" && "justify-between")} title={c.message ?? c.reason ?? ""}>
+      <span class="inline-flex shrink-0 items-center gap-1.5 text-[12px]" style:color={v === "bad" ? COLOR.bad : "var(--text-secondary)"}>
+        <span class="inline-flex" style:color={COLOR[v]}>
+          {#if v === "ok"}<Check class="h-3 w-3" strokeWidth={2.5} />{:else if v === "bad"}<X class="h-3 w-3" strokeWidth={2.5} />{:else}<Minus class="h-3 w-3" strokeWidth={2.5} />{/if}
+        </span>
+        {c.type}
+      </span>
+      {#if note}
+        <span class="min-w-0 truncate text-[11px] text-[var(--text-muted)]">{note}</span>
+      {/if}
+    </div>
+  {/each}
+</div>

--- a/src/lib/components/details/DeploymentDetails.svelte
+++ b/src/lib/components/details/DeploymentDetails.svelte
@@ -83,6 +83,7 @@
     let cancelled = false;
     if (!sel) {
       pods = [];
+      podsLoading = false;
       return;
     }
     podsLoading = true;
@@ -106,6 +107,10 @@
   $effect(() => {
     const ns = namespace;
     let cancelled = false;
+    // Drop the previous namespace's lists so a stale HPA/Service cannot be
+    // matched against the new Deployment while the requests are in flight.
+    autoscalers = [];
+    services = [];
     invoke<{ items: Resource[] }>("list_resources", { resourceType: "hpa", namespace: ns })
       .then((r) => { if (!cancelled) autoscalers = r.items; })
       .catch(() => { if (!cancelled) autoscalers = []; });

--- a/src/lib/components/details/DeploymentDetails.svelte
+++ b/src/lib/components/details/DeploymentDetails.svelte
@@ -1,185 +1,451 @@
 <script lang="ts">
   import type { Resource } from "$lib/types";
   import { invoke } from "$lib/ipc/core";
-  import { Box } from "lucide-svelte";
-  import StatusBadge from "$lib/components/common/StatusBadge.svelte";
-  import MetadataSection from "./MetadataSection.svelte";
-  import LabelsSection from "./LabelsSection.svelte";
+  import { Box, History, Layers, Link, Scale, Tag } from "lucide-svelte";
+  import { Badge } from "$lib/components/ui";
+  import SummaryStrip from "./SummaryStrip.svelte";
+  import SummaryCell from "./SummaryCell.svelte";
+  import DetailColumns from "./DetailColumns.svelte";
   import DetailSection from "./DetailSection.svelte";
+  import ConditionsList from "./ConditionsList.svelte";
+  import LinkRow from "./LinkRow.svelte";
+  import RecentEventsCard from "./RecentEventsCard.svelte";
+  import CollapsibleCard from "./CollapsibleCard.svelte";
   import KvGrid from "./KvGrid.svelte";
   import KvField from "./KvField.svelte";
-  import CollapsibleConditions from "./CollapsibleConditions.svelte";
   import SmartAnnotationsCard from "./SmartAnnotationsCard.svelte";
-  import RelatedResourcesCard from "./RelatedResourcesCard.svelte";
   import StrategyCard from "./StrategyCard.svelte";
   import RevisionHistoryCard from "./RevisionHistoryCard.svelte";
-  import { formatAge } from "$lib/utils/age";
-  import { k8sStore } from "$lib/stores/k8s.svelte";
-  import { openResourceDetail } from "$lib/actions/navigation";
+  import ReplicaBar from "$lib/components/common/ReplicaBar.svelte";
+  import { formatAge, formatTimestamp } from "$lib/utils/age";
+  import { deploymentStatus, replicaSegments, shortImage, templateImages } from "$lib/utils/workload-status";
+  import { podReadyCount, podRestarts, podStatus } from "$lib/utils/pod-status";
+  import { autoscalerSummary, formatTargets } from "$lib/utils/autoscaler";
+  import { formatBytes } from "$lib/stores/metrics.logic";
+  import { metricsStore } from "$lib/stores/metrics.svelte";
+  import { statusCategory, statusColor, isQuietStatus } from "$lib/components/table/status-category";
+  import { splitPodName } from "$lib/components/table/table-filter";
+  import { navigateToResourceTable, openRelatedResourceTab, openResourceDetail } from "$lib/actions/navigation";
+  import {
+    deploymentRevision,
+    findAutoscalerFor,
+    requestTotals,
+    servicesSelecting,
+    strategyLabel,
+    templateContainerRows,
+    templateReferences,
+    type TemplateReference,
+  } from "./deployment-details.logic";
 
   interface Props {
     resource: Resource;
+    layout?: "page" | "aside";
   }
 
-  let { resource }: Props = $props();
+  let { resource, layout = "page" }: Props = $props();
+  let page = $derived(layout === "page");
 
   let status = $derived(resource.status ?? {});
   let spec = $derived(resource.spec ?? {});
+  let namespace = $derived(resource.metadata.namespace ?? "");
 
-  let replicas = $derived((spec.replicas as number) ?? 0);
-  let readyReplicas = $derived((status.readyReplicas as number) ?? 0);
-  let availableReplicas = $derived((status.availableReplicas as number) ?? 0);
+  let health = $derived(deploymentStatus(resource));
+  let segments = $derived(replicaSegments(resource));
+  let revision = $derived(deploymentRevision(resource));
+  let strategy = $derived(strategyLabel(resource));
+  let images = $derived(templateImages(resource));
   let updatedReplicas = $derived((status.updatedReplicas as number) ?? 0);
+  let rollingOut = $derived(updatedReplicas < segments.desired);
 
-  let strategy = $derived((spec.strategy as { type?: string })?.type ?? "RollingUpdate");
   let selector = $derived(
     (spec.selector as { matchLabels?: Record<string, string> })?.matchLabels ?? {}
   );
-  let conditions = $derived(
-    (status.conditions as Array<{
-      type: string;
-      status: string;
-      reason?: string;
-      message?: string;
-    }>) ?? []
-  );
+  let selectorTerms = $derived(Object.entries(selector).map(([k, v]) => `${k}=${v}`));
+  let selectorString = $derived(selectorTerms.join(","));
   let labels = $derived(resource.metadata.labels ?? {});
   let annotations = $derived(resource.metadata.annotations ?? {});
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let image = $derived(
-    (((spec.template as any)?.spec?.containers?.[0]?.image) as string) ?? "—"
-  );
-  let conditionLabel = $derived(
-    conditions.find((c) => c.type === "Available")?.status === "True"
-      ? "Available"
-      : conditions.find((c) => c.type === "Progressing")?.status === "True"
-        ? "Progressing"
-        : "Unavailable"
+  let conditions = $derived(
+    (status.conditions as Array<{ type: string; status: string; reason?: string; message?: string }>) ?? []
   );
 
-  // Pods belonging to this deployment
+  let containerRows = $derived(templateContainerRows(resource));
+  let totals = $derived(requestTotals(resource));
+  let references = $derived(templateReferences(resource));
+
+  // --- Pods of the selector --------------------------------------------------
   let pods = $state<Resource[]>([]);
   let podsLoading = $state(false);
 
-  let selectorString = $derived(
-    Object.entries(selector).map(([k, v]) => `${k}=${v}`).join(",")
-  );
-
-  function getPodPhase(pod: Resource): string {
-    return (pod.status?.phase as string) ?? "Unknown";
-  }
-
-  function getPodReadyCount(pod: Resource): string {
-    const containerStatuses = (pod.status?.containerStatuses as Array<{ ready: boolean }>) ?? [];
-    const total = containerStatuses.length;
-    const ready = containerStatuses.filter((c) => c.ready).length;
-    return `${ready}/${total}`;
-  }
-
-  function getPodRestarts(pod: Resource): number {
-    const containerStatuses = (pod.status?.containerStatuses as Array<{ restartCount: number }>) ?? [];
-    return containerStatuses.reduce((sum, c) => sum + (c.restartCount ?? 0), 0);
-  }
-
-  function handlePodClick(pod: Resource) {
-    openResourceDetail(pod, "pods");
-  }
-
   $effect(() => {
     const sel = selectorString;
+    const ns = namespace;
     let cancelled = false;
-
-    if (sel) {
-      podsLoading = true;
-      invoke<{ items: Resource[] }>("list_pods_by_selector", {
-        namespace: resource.metadata.namespace ?? "",
-        selector: sel,
-      }).then((result) => {
-        if (!cancelled) pods = result.items;
-      }).catch(() => {
-        if (!cancelled) pods = [];
-      }).finally(() => {
-        if (!cancelled) podsLoading = false;
-      });
+    if (!sel) {
+      pods = [];
+      return;
     }
-
+    podsLoading = true;
+    invoke<{ items: Resource[] }>("list_pods_by_selector", { namespace: ns, selector: sel })
+      .then((result) => { if (!cancelled) pods = result.items; })
+      .catch(() => { if (!cancelled) pods = []; })
+      .finally(() => { if (!cancelled) podsLoading = false; });
     return () => { cancelled = true; };
   });
+
+  // Keep the per-pod memory column fresh while the panel is open.
+  $effect(() => {
+    void namespace;
+    void metricsStore.loadPodMetrics(namespace || null);
+  });
+  let podUsageKnown = $derived(pods.some((p) => metricsStore.getPodUsage(p.metadata.namespace, p.metadata.name)));
+
+  // --- HPA and Services in the namespace (one list each, matched locally) ---
+  let autoscalers = $state<Resource[]>([]);
+  let services = $state<Resource[]>([]);
+  $effect(() => {
+    const ns = namespace;
+    let cancelled = false;
+    invoke<{ items: Resource[] }>("list_resources", { resourceType: "hpa", namespace: ns })
+      .then((r) => { if (!cancelled) autoscalers = r.items; })
+      .catch(() => { if (!cancelled) autoscalers = []; });
+    invoke<{ items: Resource[] }>("list_resources", { resourceType: "services", namespace: ns })
+      .then((r) => { if (!cancelled) services = r.items; })
+      .catch(() => { if (!cancelled) services = []; });
+    return () => { cancelled = true; };
+  });
+  let hpa = $derived(findAutoscalerFor(resource, autoscalers));
+  let hpaSummary = $derived(hpa ? autoscalerSummary(hpa, "hpa") : null);
+  let matchedServices = $derived(servicesSelecting(resource, services));
+
+  const REF_COLOR: Record<TemplateReference["kind"], string> = {
+    ConfigMap: "var(--status-running)",
+    Secret: "var(--status-pending)",
+    ServiceAccount: "var(--status-pending)",
+    PersistentVolumeClaim: "var(--text-secondary)",
+  };
+  const REF_TYPE: Record<TemplateReference["kind"], string> = {
+    ConfigMap: "configmaps",
+    Secret: "secrets",
+    ServiceAccount: "serviceaccounts",
+    PersistentVolumeClaim: "persistentvolumeclaims",
+  };
+
+  function podRestartsColor(n: number): string {
+    return n > 5 ? "var(--status-failed)" : n > 0 ? "var(--status-pending)" : "var(--text-muted)";
+  }
 </script>
 
-<div class="select-text">
-  <MetadataSection {resource} />
-
-  <!-- Deployment Spec -->
-  <DetailSection title="Deployment Spec" icon={Box}>
-    <KvGrid>
-      <KvField label="Ready">
-        <span class="font-mono text-[13px] {readyReplicas === replicas ? 'text-[var(--text-primary)]' : 'text-[var(--status-pending)]'}">{readyReplicas}/{replicas}</span>
-      </KvField>
-      <KvField label="Up-to-date" value={updatedReplicas} />
-      <KvField label="Available" value={availableReplicas} />
-      <KvField label="Strategy" value={strategy} mono={false} />
-      <KvField label="Conditions">
-        <StatusBadge status={conditionLabel} />
-      </KvField>
-      {#if selectorString}
-        <KvField label="Selector" value={selectorString} />
-      {/if}
-      <KvField label="Image" value={image} />
-      {#if spec.paused}
-        <KvField label="Paused">
-          <span class="font-mono text-[13px] text-[var(--status-pending)]">true</span>
-        </KvField>
-      {/if}
-    </KvGrid>
-  </DetailSection>
-
-  <LabelsSection {labels} />
-
-  <!-- Conditions -->
-  {#if conditions.length > 0}
-    <CollapsibleConditions {conditions} />
-  {/if}
-
-  <!-- Pods -->
-  <DetailSection title="Pods" icon={Box}>
-    {#snippet actions()}
-      <span class="font-mono text-[11px] text-[var(--text-muted)]">{podsLoading ? "…" : pods.length}</span>
-    {/snippet}
-    {#if pods.length > 0}
-      <table class="w-full border-collapse text-[13px]">
-        <thead>
-          <tr class="border-b border-[var(--border-color)]">
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Name</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Status</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Ready</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Restarts</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Age</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each pods as pod}
-            <tr
-              class="cursor-pointer border-b border-[var(--border-color)] last:border-b-0 transition-colors hover:bg-[var(--table-row-hover)]"
-              onclick={() => handlePodClick(pod)}
-            >
-              <td class="max-w-[200px] truncate px-3 py-2.5 text-[12px] font-medium text-[var(--text-primary)]" title={pod.metadata.name}>{pod.metadata.name}</td>
-              <td class="px-3 py-2.5"><StatusBadge status={getPodPhase(pod)} /></td>
-              <td class="px-3 py-2.5 font-mono text-[12px] tabular-nums text-[var(--text-secondary)]">{getPodReadyCount(pod)}</td>
-              <td class="px-3 py-2.5 font-mono text-[12px] tabular-nums text-[var(--text-secondary)]">{getPodRestarts(pod)}</td>
-              <td class="px-3 py-2.5 font-mono text-[12px] text-[var(--text-muted)]">{formatAge(pod.metadata.creation_timestamp)}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {:else if !podsLoading}
-      <p class="text-[12px] text-[var(--text-muted)]">No pods found</p>
+{#snippet statusPill(label: string, detail?: string)}
+  {@const category = statusCategory(label)}
+  <span class="flex min-w-0 items-center gap-1.5">
+    {#if isQuietStatus(category)}
+      <span class="truncate text-[12px] text-[var(--text-muted)]">{label}</span>
+    {:else}
+      <span
+        class="inline-flex shrink-0 items-center gap-1.5 rounded-sm px-1.5 text-[11px] font-medium leading-4"
+        style="color: {statusColor(category)}; background-color: color-mix(in srgb, {statusColor(category)} 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, {statusColor(category)} 25%, transparent);"
+      >
+        <span class="h-[5px] w-[5px] shrink-0 rounded-full" style="background-color: {statusColor(category)}"></span>
+        {label}
+      </span>
     {/if}
-  </DetailSection>
+    {#if detail}
+      <span class="truncate text-[11px] text-[var(--text-muted)]" title={detail}>{detail}</span>
+    {/if}
+  </span>
+{/snippet}
 
-  <StrategyCard {spec} kind="Deployment" />
-  <RevisionHistoryCard {resource} />
-  <RelatedResourcesCard {resource} resourceType="deployments" />
+<div class="select-text">
+  <SummaryStrip>
+    <SummaryCell label="Status" title={health.detail}>
+      {@render statusPill(health.label, page ? health.detail : undefined)}
+    </SummaryCell>
+    <SummaryCell label="Replicas">
+      <span class="flex items-center gap-2">
+        <span
+          class="font-mono text-[13px] tabular-nums"
+          style:color={segments.ready < segments.desired ? "var(--status-pending)" : "var(--text-primary)"}
+        >{segments.ready}/{segments.desired}</span>
+        <ReplicaBar ready={segments.ready} pending={segments.pending} missing={segments.missing} class="w-12" />
+      </span>
+    </SummaryCell>
+    <SummaryCell label="Revision" value={revision === null ? "—" : `#${revision}`} />
+    <SummaryCell label="Strategy" value={strategy} mono={false} />
+    {#if page}
+      <SummaryCell label="Autoscaling">
+        {#if hpaSummary}
+          <span class="flex items-center gap-1.5 overflow-hidden">
+            <span class="font-mono text-[13px] tabular-nums text-[var(--text-primary)]">HPA {hpaSummary.min ?? "?"}–{hpaSummary.max ?? "?"}</span>
+            <span class="truncate font-mono text-[11px] text-[var(--text-muted)]">{formatTargets(hpaSummary, 1)}</span>
+          </span>
+        {:else}
+          <span class="text-[12px] text-[var(--text-muted)]">—</span>
+        {/if}
+      </SummaryCell>
+      <SummaryCell label="Images">
+        {#if images.length === 0}
+          <span class="text-[12px] text-[var(--text-muted)]">—</span>
+        {:else}
+          <span class="flex items-center gap-1">
+            <Badge appearance="surface" size="sm" bordered mono class="max-w-[160px] truncate px-1.5" title={images[0]}>{shortImage(images[0])}</Badge>
+            {#if images.length > 1}
+              <Badge appearance="surface" size="sm" bordered mono class="px-1.5" title={images.slice(1).join(", ")}>+{images.length - 1}</Badge>
+            {/if}
+          </span>
+        {/if}
+      </SummaryCell>
+      <SummaryCell label="Selector" value={selectorTerms.join(", ") || "—"} />
+      <SummaryCell label="Pods" value={podsLoading && pods.length === 0 ? "…" : pods.length} />
+    {/if}
+    <SummaryCell label="Age" value={formatAge(resource.metadata.creation_timestamp)} />
+  </SummaryStrip>
+
+  <DetailColumns {layout}>
+    {#snippet main()}
+      <!-- Rollout: the bar, the counts, the conditions, then the ReplicaSets as revisions. -->
+      <DetailSection title="Rollout" icon={History}>
+        {#snippet actions()}
+          {#if spec.paused}
+            <span class="font-mono text-[11px] text-[var(--status-pending)]">paused</span>
+          {/if}
+        {/snippet}
+        <div class="flex flex-col gap-3">
+          <div class="flex flex-col gap-1.5">
+            <div class="flex items-center justify-between gap-3 text-[11px] text-[var(--text-muted)]">
+              <span class="truncate">
+                {#if rollingOut}
+                  rev {revision === null ? "?" : revision - 1} → {revision ?? "?"} · {updatedReplicas} of {segments.desired} updated
+                {:else if revision !== null}
+                  rev {revision} · up to date
+                {:else}
+                  up to date
+                {/if}
+              </span>
+              <span class="shrink-0 font-mono tabular-nums">{segments.ready} ready · {segments.pending} not ready · {segments.missing} missing</span>
+            </div>
+            <ReplicaBar ready={segments.ready} pending={segments.pending} missing={segments.missing} height={6} class="w-full" />
+          </div>
+          {#if conditions.length > 0}
+            <ConditionsList {conditions} layout="list" />
+          {/if}
+        </div>
+      </DetailSection>
+      <RevisionHistoryCard {resource} />
+
+      <!-- Pods of the selector -->
+      <DetailSection title="Pods" icon={Box}>
+        {#snippet actions()}
+          <button
+            type="button"
+            class="text-[11px] text-[var(--accent)] hover:underline"
+            onclick={() => navigateToResourceTable("Pods", "pods")}
+            title="Open the Pods table"
+          >open in Pods</button>
+          <span class="font-mono text-[11px] text-[var(--text-muted)]">{podsLoading && pods.length === 0 ? "…" : pods.length}</span>
+        {/snippet}
+        {#if pods.length > 0}
+          <div class="overflow-x-auto">
+          <table class="w-full border-collapse text-[12px]">
+            <thead>
+              <tr class="border-b border-[var(--border-color)] text-left text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--text-muted)]">
+                <th class="pb-1.5 pr-3 font-medium">Name</th>
+                <th class="pb-1.5 pr-3 font-medium">Status</th>
+                <th class="pb-1.5 pr-3 text-right font-medium">Ready</th>
+                <th class="pb-1.5 pr-3 text-right font-medium" title="Restarts">↻</th>
+                {#if podUsageKnown}<th class="pb-1.5 pr-3 text-right font-medium">Mem</th>{/if}
+                {#if page}<th class="pb-1.5 pr-3 font-medium">Node</th>{/if}
+                <th class="pb-1.5 text-right font-medium">Age</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each pods as pod (pod.metadata.uid)}
+                {@const st = podStatus(pod)}
+                {@const ready = podReadyCount(pod)}
+                {@const restarts = podRestarts(pod)}
+                {@const name = splitPodName(pod.metadata.name)}
+                {@const usage = metricsStore.getPodUsage(pod.metadata.namespace, pod.metadata.name)}
+                <tr
+                  class="cursor-pointer border-b border-[var(--hairline)] transition-colors last:border-b-0 hover:bg-[var(--table-row-hover)]"
+                  onclick={() => openResourceDetail(pod, "pods")}
+                >
+                  <td class="max-w-[220px] truncate py-2 pr-3 font-medium text-[var(--text-primary)]" title={pod.metadata.name}>
+                    {name.base}<span class="font-normal text-[var(--text-muted)]">{name.suffix}</span>
+                  </td>
+                  <td class="py-2 pr-3">{@render statusPill(st.label, st.reason)}</td>
+                  <td class="py-2 pr-3 text-right font-mono tabular-nums" style:color={ready.ready < ready.total ? "var(--status-pending)" : "var(--text-secondary)"}>{ready.ready}/{ready.total}</td>
+                  <td class="py-2 pr-3 text-right font-mono tabular-nums" style:color={podRestartsColor(restarts.count)}>{restarts.count}</td>
+                  {#if podUsageKnown}
+                    <td class="py-2 pr-3 text-right font-mono tabular-nums text-[var(--text-secondary)]">{usage ? formatBytes(usage.memory_bytes) : "—"}</td>
+                  {/if}
+                  {#if page}
+                    <td class="max-w-[160px] truncate py-2 pr-3 font-mono text-[11px] text-[var(--text-muted)]">{(pod.spec?.nodeName as string) ?? "—"}</td>
+                  {/if}
+                  <td class="py-2 text-right font-mono text-[11px] tabular-nums text-[var(--text-muted)]">{formatAge(pod.metadata.creation_timestamp)}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+          </div>
+        {:else if !podsLoading}
+          <p class="text-[12px] text-[var(--text-muted)]">No pods match the selector</p>
+        {/if}
+      </DetailSection>
+
+      <!-- What the template runs -->
+      {#if containerRows.length > 0}
+        <DetailSection title="Template · containers" icon={Layers}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{containerRows.length}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            <div class="overflow-x-auto">
+            <table class="w-full border-collapse text-[12px]">
+              <thead>
+                <tr class="border-b border-[var(--border-color)] text-left text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--text-muted)]">
+                  <th class="pb-1.5 pr-3 font-medium">Container</th>
+                  <th class="pb-1.5 pr-3 font-medium">CPU req / lim</th>
+                  <th class="pb-1.5 pr-3 font-medium">Mem req / lim</th>
+                  {#if page}<th class="pb-1.5 pr-3 font-medium">Ports</th>{/if}
+                  <th class="pb-1.5 pr-3 font-medium">Probes</th>
+                  <th class="pb-1.5 text-right font-medium">Env</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each containerRows as row (row.name)}
+                  <tr class="border-b border-[var(--hairline)] last:border-b-0">
+                    <td class="max-w-[220px] py-2 pr-3">
+                      <div class="flex flex-col">
+                        <span class="font-medium text-[var(--text-primary)]">{row.name}</span>
+                        <span class="truncate font-mono text-[11px] text-[var(--text-muted)]" title={row.image}>{shortImage(row.image)}</span>
+                      </div>
+                    </td>
+                    <td class="py-2 pr-3 font-mono tabular-nums text-[var(--text-secondary)]">{row.cpu}</td>
+                    <td class="py-2 pr-3 font-mono tabular-nums text-[var(--text-secondary)]">{row.memory}</td>
+                    {#if page}<td class="py-2 pr-3 font-mono tabular-nums text-[var(--text-secondary)]">{row.ports}</td>{/if}
+                    <td class="py-2 pr-3">
+                      <span class="inline-flex gap-1">
+                        <Badge appearance="surface" size="sm" bordered mono class="px-1.5" title="Liveness probe {row.probes.liveness ? 'configured' : 'not configured'}" style={row.probes.liveness ? "" : "opacity: .4;"}>L</Badge>
+                        <Badge appearance="surface" size="sm" bordered mono class="px-1.5" title="Readiness probe {row.probes.readiness ? 'configured' : 'not configured'}" style={row.probes.readiness ? "" : "opacity: .4;"}>R</Badge>
+                        <Badge appearance="surface" size="sm" bordered mono class="px-1.5" title="Startup probe {row.probes.startup ? 'configured' : 'not configured'}" style={row.probes.startup ? "" : "opacity: .4;"}>S</Badge>
+                      </span>
+                    </td>
+                    <td class="py-2 text-right font-mono tabular-nums text-[var(--text-secondary)]">{row.envCount}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+            </div>
+            <div class="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-[var(--text-muted)]">
+              <span>Request per pod <span class="font-mono text-[var(--text-secondary)]">{totals.perPodLabel}</span></span>
+              <span>× {totals.replicas} {totals.replicas === 1 ? "replica" : "replicas"} = <span class="font-mono text-[var(--text-secondary)]">{totals.totalLabel}</span></span>
+            </div>
+          </div>
+        </DetailSection>
+      {/if}
+
+      <RecentEventsCard {resource} />
+    {/snippet}
+
+    {#snippet rail()}
+      <!-- Scaling: the HPA that owns the replica count, if any -->
+      <DetailSection title="Scaling" icon={Scale}>
+        {#if hpa && hpaSummary}
+          <div class="flex flex-col gap-2.5">
+            <div class="flex items-center justify-between gap-3">
+              <LinkRow kind="HPA" name={hpa.metadata.name} color="var(--status-running)" onclick={() => openRelatedResourceTab("hpa", hpa!.metadata.name, namespace)} />
+            </div>
+            <div class="flex flex-wrap gap-x-4 gap-y-1 font-mono text-[11px] tabular-nums text-[var(--text-secondary)]">
+              <span>current <span class="text-[var(--text-primary)]">{hpaSummary.current ?? "—"}</span></span>
+              <span>min <span class="text-[var(--text-primary)]">{hpaSummary.min ?? "—"}</span></span>
+              <span>max <span class="text-[var(--text-primary)]">{hpaSummary.max ?? "—"}</span></span>
+            </div>
+            {#if hpaSummary.targets.length > 0}
+              <div class="flex flex-col gap-1 text-[11px] text-[var(--text-muted)]">
+                {#each hpaSummary.targets as t (t.name)}
+                  <div class="flex items-center justify-between gap-3">
+                    <span class="truncate">{t.name}</span>
+                    <span class="shrink-0 font-mono tabular-nums text-[var(--text-secondary)]">{t.currentLabel} / {t.targetLabel}</span>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+            {#if hpaSummary.lastScaleTime}
+              <span class="text-[11px] text-[var(--text-muted)]">Last scale {formatAge(hpaSummary.lastScaleTime)} ago · scaling the Deployment by hand will be overridden.</span>
+            {/if}
+          </div>
+        {:else}
+          <p class="text-[12px] text-[var(--text-muted)]">No autoscaler targets this deployment</p>
+        {/if}
+      </DetailSection>
+
+      <StrategyCard {spec} kind="Deployment" />
+
+      <!-- Related: the services in front, the config behind -->
+      {#if matchedServices.length > 0 || references.length > 0}
+        <DetailSection title="Related" icon={Link}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{matchedServices.length + references.length}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            {#each matchedServices as svc (svc.metadata.uid)}
+              <LinkRow kind="Service" name={svc.metadata.name} color="var(--accent)" onclick={() => openRelatedResourceTab("services", svc.metadata.name, namespace)} />
+            {/each}
+            {#each references as ref (`${ref.kind}/${ref.name}`)}
+              <LinkRow kind={ref.kind === "PersistentVolumeClaim" ? "PVC" : ref.kind} name={ref.name} color={REF_COLOR[ref.kind]} onclick={() => openRelatedResourceTab(REF_TYPE[ref.kind], ref.name, namespace)} />
+            {/each}
+          </div>
+        </DetailSection>
+      {/if}
+
+      <!-- Selector and labels -->
+      <DetailSection title="Selector · labels" icon={Tag}>
+        <div class="flex flex-col gap-2.5">
+          {#if selectorTerms.length > 0}
+            <span class="text-[11px] text-[var(--text-muted)]">Selector</span>
+            <div class="flex flex-wrap gap-1.5">
+              {#each selectorTerms as term (term)}
+                <Badge appearance="surface" size="sm" bordered mono class="px-1.5">{term}</Badge>
+              {/each}
+            </div>
+          {/if}
+          {#if Object.keys(labels).length > 0}
+            <span class="text-[11px] text-[var(--text-muted)]">Labels</span>
+            <div class="flex flex-wrap gap-1.5">
+              {#each Object.entries(labels) as [key, val] (key)}
+                <span class="inline-flex items-center rounded-md border border-[var(--border-color)] bg-[var(--bg-secondary)] px-2 py-1 font-mono text-[11px] text-[var(--text-secondary)]">
+                  {key}=<span class="ml-0.5 font-medium text-[var(--text-primary)]">{val}</span>
+                </span>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </DetailSection>
+    {/snippet}
+  </DetailColumns>
+
+  <!-- Rarely read: metadata and annotations, collapsed at the foot. -->
+  <CollapsibleCard title="Metadata">
+    <div class="px-6 pt-1">
+      <KvGrid>
+        <KvField label="Name" value={resource.metadata.name} />
+        {#if resource.metadata.namespace}
+          <KvField label="Namespace" value={resource.metadata.namespace} />
+        {/if}
+        <KvField label="Created" value={formatTimestamp(resource.metadata.creation_timestamp)} mono={false} />
+        {#if resource.metadata.uid}
+          <KvField label="UID" value={resource.metadata.uid} />
+        {/if}
+        {#if resource.metadata.resource_version}
+          <KvField label="Resource version" value={resource.metadata.resource_version} />
+        {/if}
+        {#if spec.paused}
+          <KvField label="Paused">
+            <span class="font-mono text-[13px] text-[var(--status-pending)]">true</span>
+          </KvField>
+        {/if}
+      </KvGrid>
+    </div>
+  </CollapsibleCard>
   <SmartAnnotationsCard annotations={annotations} />
 </div>

--- a/src/lib/components/details/DetailColumns.svelte
+++ b/src/lib/components/details/DetailColumns.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  /**
+   * The overview's body. In the detail tab (`page`) it is two columns: what
+   * changes over time on the left (containers, rollout, endpoints, events),
+   * what is structural in a 380px rail on the right (conditions, network,
+   * related, labels). In the docked aside both stacks run in one column,
+   * main first.
+   */
+  interface Props {
+    layout: "page" | "aside";
+    main: Snippet;
+    rail: Snippet;
+  }
+
+  let { layout, main, rail }: Props = $props();
+</script>
+
+{#if layout === "page"}
+  <!-- Two columns only when the tab is wide enough for both (container
+       query, not viewport: the sidebar and the window both move the width).
+       Below that the rail stacks under the main column, as in the aside. -->
+  <div class="@container">
+    <div class="grid grid-cols-1 items-start @[900px]:grid-cols-[minmax(0,1fr)_380px]">
+      <div class="flex min-w-0 flex-col @[900px]:border-r @[900px]:border-[var(--border-color)]">{@render main()}</div>
+      <div class="flex min-w-0 flex-col">{@render rail()}</div>
+    </div>
+  </div>
+{:else}
+  {@render main()}
+  {@render rail()}
+{/if}

--- a/src/lib/components/details/DetailPanel.svelte
+++ b/src/lib/components/details/DetailPanel.svelte
@@ -191,9 +191,9 @@
          Logs / Shell / Edit already have subtabs below. -->
     <div class="flex h-11 shrink-0 items-center gap-2 border-b border-[var(--border-color)] bg-[var(--bg-primary)] pl-4 pr-2">
       <div class="flex min-w-0 flex-1 flex-col">
-        <span class="truncate text-[13px] font-semibold leading-4 text-[var(--text-primary)]" title={resource.metadata.name}>{resource.metadata.name}</span>
+        <span class="truncate text-[13px] font-semibold leading-4 text-[var(--text-primary)]" title={resource.metadata.name} data-testid="detail-resource-name">{resource.metadata.name}</span>
         <span class="truncate text-[10px] leading-[14px] text-[var(--text-muted)]">
-          {resource.kind}{#if resource.metadata.namespace} · {resource.metadata.namespace}{/if}{#if nodeName} · {nodeName}{/if}
+          {resource.kind}{#if resource.metadata.namespace}{" · "}{resource.metadata.namespace}{/if}{#if nodeName}{" · "}{nodeName}{/if}
         </span>
       </div>
       <div class="flex shrink-0 items-center gap-0.5">
@@ -253,7 +253,7 @@
             {/if}
           </div>
         {:else}
-          <span class="truncate text-[15px] font-semibold text-[var(--text-primary)]">{resource.metadata.name}</span>
+          <span class="truncate text-[15px] font-semibold text-[var(--text-primary)]" data-testid="detail-resource-name">{resource.metadata.name}</span>
           <div class="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
             <span class="text-[var(--text-muted)]">{resource.kind}</span>
             {#if resource.metadata.namespace}
@@ -371,9 +371,9 @@
       {#if activeSubtab === "overview"}
         <ScrollArea class="h-full select-text">
           {#if kind === "pod"}
-            <PodDetails {resource} />
+            <PodDetails {resource} layout={aside ? "aside" : "page"} />
           {:else if kind === "deployment"}
-            <DeploymentDetails {resource} />
+            <DeploymentDetails {resource} layout={aside ? "aside" : "page"} />
           {:else if kind === "statefulset"}
             <StatefulSetDetails {resource} />
           {:else if kind === "daemonset"}
@@ -383,7 +383,7 @@
           {:else if kind === "cronjob"}
             <CronJobDetails {resource} />
           {:else if kind === "service"}
-            <ServiceDetails {resource} />
+            <ServiceDetails {resource} layout={aside ? "aside" : "page"} />
           {:else if kind === "ingress"}
             <IngressDetails {resource} />
           {:else if autoscalerKind}

--- a/src/lib/components/details/EventsCard.svelte
+++ b/src/lib/components/details/EventsCard.svelte
@@ -15,20 +15,21 @@
   let eventsLoading = $state(false);
   let error = $state<string | null>(null);
 
-  let eventKey = $derived(`${resource.kind}:${resource.metadata.name}:${resource.metadata.namespace}`);
+  // Primitive deriveds: the `resource` prop is replaced on every watch delta
+  // (same pod, new object), and an effect that read its fields directly
+  // re-ran each time — cancelling the in-flight fetch and never showing
+  // anything for a pod that updates often. These only notify on a real change.
+  let resourceType = $derived(kindToResourceType(resource.kind));
+  let resourceName = $derived(resource.metadata.name);
+  let resourceNamespace = $derived(resource.metadata.namespace ?? "");
 
   $effect(() => {
-    // Track key so the fetch re-runs when the resource changes.
-    void eventKey;
+    const args = { resourceType, name: resourceName, namespace: resourceNamespace };
     let cancelled = false;
 
     eventsLoading = true;
     error = null;
-    invoke<K8sEvent[]>("get_resource_events", {
-      resourceType: kindToResourceType(resource.kind),
-      name: resource.metadata.name,
-      namespace: resource.metadata.namespace ?? "",
-    }).then((result) => {
+    invoke<K8sEvent[]>("get_resource_events", args).then((result) => {
       if (!cancelled) {
         events = result;
       }

--- a/src/lib/components/details/LinkRow.svelte
+++ b/src/lib/components/details/LinkRow.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { ArrowUpRight } from "lucide-svelte";
+
+  /**
+   * One related object: a small kind tag, the name in mono, an arrow. Dense
+   * enough to list seven of them where RelCard fits three. Non-navigable
+   * rows (a kind the catalog cannot open) render without the button.
+   */
+  interface Props {
+    kind: string;
+    name: string;
+    /** Tone for the kind tag; defaults to the secondary text colour. */
+    color?: string;
+    /** Muted trailing note (a host/path, a count). */
+    note?: string;
+    onclick?: () => void;
+  }
+
+  let { kind, name, color = "var(--text-secondary)", note, onclick }: Props = $props();
+</script>
+
+{#if onclick}
+  <button
+    type="button"
+    class="group flex w-full min-w-0 items-center gap-2 text-left"
+    {onclick}
+    title="{kind} {name}"
+  >
+    <span
+      class="shrink-0 rounded-sm px-1.5 py-px text-[10px] font-semibold leading-4"
+      style="color: {color}; border: 1px solid color-mix(in srgb, {color} 30%, transparent); background-color: color-mix(in srgb, {color} 8%, transparent);"
+    >{kind}</span>
+    <span class="min-w-0 flex-1 truncate font-mono text-[12px] font-medium text-[var(--text-primary)] group-hover:underline">{name}</span>
+    {#if note}<span class="shrink-0 truncate text-[11px] text-[var(--text-muted)]">{note}</span>{/if}
+    <ArrowUpRight class="h-3 w-3 shrink-0 text-[var(--text-muted)] transition-transform group-hover:-translate-y-px group-hover:translate-x-px" />
+  </button>
+{:else}
+  <div class="flex w-full min-w-0 items-center gap-2" title="{kind} {name}">
+    <span class="shrink-0 rounded-sm border border-[var(--border-color)] px-1.5 py-px text-[10px] font-medium leading-4 text-[var(--text-muted)]">{kind}</span>
+    <span class="min-w-0 flex-1 truncate font-mono text-[12px] text-[var(--text-muted)]">{name}</span>
+    {#if note}<span class="shrink-0 truncate text-[11px] text-[var(--text-muted)]">{note}</span>{/if}
+  </div>
+{/if}

--- a/src/lib/components/details/PodDetails.svelte
+++ b/src/lib/components/details/PodDetails.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
-  import { Box, Link, FileText, Lock, GitBranch, Database, Copy, Globe, Server, Network, Layers, Unplug } from "lucide-svelte";
+  import { Link, Globe, CheckCircle2, Unplug } from "lucide-svelte";
   import { onMount } from "svelte";
   import { invoke } from "$lib/ipc/core";
   import type { Resource, ResourceList } from "$lib/types";
-  import type { IconComponent } from "$lib/actions/types";
-  import StatusBadge from "$lib/components/common/StatusBadge.svelte";
-  import MetadataSection from "./MetadataSection.svelte";
-  import LabelsSection from "./LabelsSection.svelte";
+  import { Button } from "$lib/components/ui";
   import DetailSection from "./DetailSection.svelte";
   import KvGrid from "./KvGrid.svelte";
   import KvField from "./KvField.svelte";
-  import RelCard from "./RelCard.svelte";
+  import SummaryStrip from "./SummaryStrip.svelte";
+  import SummaryCell from "./SummaryCell.svelte";
+  import AttentionBlock from "./AttentionBlock.svelte";
+  import ConditionsList from "./ConditionsList.svelte";
+  import LinkRow from "./LinkRow.svelte";
+  import RecentEventsCard from "./RecentEventsCard.svelte";
+  import DetailColumns from "./DetailColumns.svelte";
+  import CollapsibleCard from "./CollapsibleCard.svelte";
+  import LabelsSection from "./LabelsSection.svelte";
   import PodContainerCards from "./PodContainerCards.svelte";
   import PodUsageCard from "./PodUsageCard.svelte";
   import SmartAnnotationsCard from "./SmartAnnotationsCard.svelte";
@@ -22,24 +27,31 @@
   import PodPortForwarding from "./PodPortForwarding.svelte";
   import PodConfigSecrets from "./PodConfigSecrets.svelte";
   import { k8sStore } from "$lib/stores/k8s.svelte";
+  import { uiStore } from "$lib/stores/ui.svelte";
   import { openRelatedResourceTab } from "$lib/actions/navigation";
-  import { getRelatedResources } from "$lib/utils/related-resources";
+  import { getRelatedResources, displayKind } from "$lib/utils/related-resources";
   import { extractConfigMapReferences, type SpecContainer, type ContainerStatus, type PortInfo } from "./pod-utils";
+  import { podStatus, podReadyCount, podRestarts, podOwner, podProblem, orderedPodConditions } from "$lib/utils/pod-status";
+  import { statusCategory, statusColor, isQuietStatus } from "$lib/components/table/status-category";
+  import { formatAge, formatTimestamp } from "$lib/utils/age";
+  import { podProblemCopy } from "./pod-details.logic";
 
-  const KIND_ICON: Record<string, IconComponent> = {
-    ConfigMap: FileText, Secret: Lock, Deployment: Layers, ReplicaSet: GitBranch,
-    StatefulSet: Database, DaemonSet: Copy, Service: Globe, Node: Server,
-    Pod: Box, Ingress: Network,
-  };
-  const kindIcon = (kind: string): IconComponent => KIND_ICON[kind] ?? Box;
-
+  /**
+   * The pod overview, in reading order: what state it is in (summary strip),
+   * why it is not healthy when it is not (attention block), its containers,
+   * usage and ports, recent events; then the structural rail — conditions,
+   * network, related objects, labels — and the rarely-read material collapsed
+   * at the bottom. Metadata is last on purpose: a UID never answers "what is
+   * wrong with this pod".
+   */
   interface Props {
     resource: Resource;
+    layout?: "page" | "aside";
   }
 
-  let { resource }: Props = $props();
+  let { resource, layout = "page" }: Props = $props();
 
-  // --- Shared icon-error tracking ---
+  // --- Shared icon-error tracking (port-forward rows) ---
   let failedIcons: Set<string> = $state(new Set());
 
   function handleIconError(url: string) {
@@ -52,29 +64,40 @@
   // --- Pod metadata ---
   let status = $derived(resource.status ?? {});
   let spec = $derived(resource.spec ?? {});
-  let phase = $derived((status.phase as string) ?? "Unknown");
-  let podIP = $derived((status.podIP as string) ?? "-");
-  let nodeName = $derived((spec.nodeName as string) ?? (status.nodeName as string) ?? "-");
+  let podIP = $derived((status.podIP as string) ?? "—");
+  let hostIP = $derived((status.hostIP as string) ?? "—");
+  let nodeName = $derived((spec.nodeName as string) ?? (status.nodeName as string) ?? "");
+  let namespace = $derived(resource.metadata.namespace ?? "");
 
-  let containerStatuses = $derived(
-    (status.containerStatuses as ContainerStatus[]) ?? []
-  );
-  let specContainers = $derived(
-    (spec.containers as SpecContainer[]) ?? []
-  );
-  let specContainerMap = $derived(new Map(specContainers.map(c => [c.name, c])));
+  let containerStatuses = $derived((status.containerStatuses as ContainerStatus[]) ?? []);
+  let specContainers = $derived((spec.containers as SpecContainer[]) ?? []);
+  let specContainerMap = $derived(new Map(specContainers.map((c) => [c.name, c])));
 
-  let restartCount = $derived(
-    containerStatuses.reduce((sum, c) => sum + (c.restartCount ?? 0), 0)
-  );
+  // --- Derived state (kubectl-style) ---
+  let podState = $derived(podStatus(resource));
+  let stateCategory = $derived(statusCategory(podState.label));
+  let ready = $derived(podReadyCount(resource));
+  let restarts = $derived(podRestarts(resource));
+  let owner = $derived(podOwner(resource));
+  let problem = $derived(podProblem(resource));
+  let problemCopy = $derived(problem ? podProblemCopy(problem) : null);
+  let conditions = $derived(orderedPodConditions(resource));
+  let ageTick = $derived(k8sStore.ageTick);
+
+  function restartColor(count: number): string {
+    if (count > 5) return "var(--status-failed)";
+    if (count > 0) return "var(--status-pending)";
+    return "var(--text-primary)";
+  }
 
   // --- Volumes & config references ---
-  let volumes = $derived((spec.volumes as Array<{
-    name: string;
-    configMap?: { name: string; items?: Array<{ key: string }> };
-    secret?: { secretName: string; items?: Array<{ key: string }> };
-  }>) ?? []);
-
+  let volumes = $derived(
+    (spec.volumes as Array<{
+      name: string;
+      configMap?: { name: string; items?: Array<{ key: string }> };
+      secret?: { secretName: string; items?: Array<{ key: string }> };
+    }>) ?? [],
+  );
   let configResources = $derived(extractConfigMapReferences(volumes, specContainers));
 
   // --- All container ports ---
@@ -83,13 +106,7 @@
     for (const container of specContainers) {
       for (const port of container.ports ?? []) {
         const cp = port.containerPort ?? 0;
-        if (cp > 0) {
-          ports.push({
-            containerName: container.name,
-            containerPort: cp,
-            protocol: port.protocol ?? "TCP",
-          });
-        }
+        if (cp > 0) ports.push({ containerName: container.name, containerPort: cp, protocol: port.protocol ?? "TCP" });
       }
     }
     return ports;
@@ -98,9 +115,6 @@
   // --- Labels & annotations ---
   let labels = $derived(resource.metadata.labels ?? {});
   let annotations = $derived(resource.metadata.annotations ?? {});
-
-  let readyCount = $derived(containerStatuses.filter((c) => c.ready).length);
-  let totalContainers = $derived(containerStatuses.length);
 
   // --- Related resources (owner / replicaset / service / node) ---
   // Services are loaded for reverse selector matching, like RelatedResourcesCard.
@@ -112,88 +126,204 @@
       // one (they can differ when opening a pod via cross-link / All Namespaces).
       resourceType: "services",
       namespace: resource.metadata.namespace ?? k8sStore.currentNamespace,
-    }).then((result) => {
-      if (!cancelled) allServices = result.items;
-    }).catch(() => {
-      // non-critical — service relations just won't show
-    });
-    return () => { cancelled = true; };
+    })
+      .then((result) => {
+        if (!cancelled) allServices = result.items;
+      })
+      .catch(() => {
+        // non-critical — service relations just won't show
+      });
+    return () => {
+      cancelled = true;
+    };
   });
 
   let related = $derived(getRelatedResources(resource, "pods", allServices));
+
+  const KIND_COLOR: Record<string, string> = {
+    ReplicaSet: "var(--status-running)",
+    Deployment: "var(--status-running)",
+    StatefulSet: "var(--status-running)",
+    DaemonSet: "var(--status-running)",
+    Job: "var(--status-running)",
+    CronJob: "var(--status-running)",
+    Service: "var(--accent)",
+    Ingress: "var(--accent)",
+    Secret: "var(--status-pending)",
+    Node: "var(--status-pending)",
+  };
+  const kindColor = (kind: string): string => KIND_COLOR[kind] ?? "var(--text-secondary)";
+
+  function openOwner() {
+    if (!owner) return;
+    const type = related.find((r) => r.kind === owner.kind && r.name === owner.name)?.resourceType;
+    if (type) openRelatedResourceTab(type, owner.name, namespace);
+  }
 </script>
 
 <div class="select-text">
-  <MetadataSection {resource} />
+  <SummaryStrip>
+    <SummaryCell label="Status" title={podState.reason ? `${podState.label} · ${podState.reason}` : podState.label}>
+      {#if isQuietStatus(stateCategory)}
+        <span class="truncate text-[12px] text-[var(--text-muted)]">{podState.label}</span>
+      {:else}
+        <span
+          class="inline-flex max-w-full items-center gap-1.5 truncate rounded-sm px-1.5 text-[11px] font-medium leading-4"
+          style="color: {statusColor(stateCategory)}; background-color: color-mix(in srgb, {statusColor(stateCategory)} 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, {statusColor(stateCategory)} 25%, transparent);"
+        >
+          <span class="h-[5px] w-[5px] shrink-0 rounded-full" style="background-color: {statusColor(stateCategory)}"></span>
+          <span class="truncate">{podState.label}</span>
+        </span>
+      {/if}
+    </SummaryCell>
+    <SummaryCell label="Ready">
+      <span
+        class="font-mono text-[13px] tabular-nums"
+        style:color={ready.total > 0 && ready.ready < ready.total ? "var(--status-pending)" : "var(--text-primary)"}
+      >{ready.ready}/{ready.total}</span>
+    </SummaryCell>
+    <SummaryCell label="Restarts" title={restarts.lastAt ? `Last restart ${formatTimestamp(restarts.lastAt)}` : undefined}>
+      <span class="font-mono text-[13px] tabular-nums" style:color={restartColor(restarts.count)}>{restarts.count}</span>
+      {#if restarts.count > 0 && restarts.lastAt}
+        {@const _tick = ageTick}
+        <span class="ml-1.5 truncate font-mono text-[10px] text-[var(--text-muted)]">{formatAge(restarts.lastAt)} ago</span>
+      {/if}
+    </SummaryCell>
+    <SummaryCell label="Age">
+      {@const _tick = ageTick}
+      <span class="font-mono text-[13px] tabular-nums text-[var(--text-primary)]">{formatAge(resource.metadata.creation_timestamp)}</span>
+    </SummaryCell>
+    <SummaryCell label="QoS" value={(status.qosClass as string) ?? "—"} mono={false} />
+    {#if layout === "page"}
+      <SummaryCell label="Pod IP" value={podIP} />
+      <SummaryCell label="Node">
+        {#if nodeName}
+          <button type="button" class="truncate font-mono text-[13px] text-[var(--accent)] hover:underline" onclick={() => openRelatedResourceTab("nodes", nodeName)}>{nodeName}</button>
+        {:else}
+          <span class="text-[12px] text-[var(--text-muted)]">—</span>
+        {/if}
+      </SummaryCell>
+      <SummaryCell label="Controlled by" title={owner ? `${owner.kind}/${owner.name}` : undefined}>
+        {#if owner}
+          <button type="button" class="truncate font-mono text-[13px] text-[var(--accent)] hover:underline" onclick={openOwner}>{owner.short}/{owner.name}</button>
+        {:else}
+          <span class="text-[12px] text-[var(--text-muted)]">—</span>
+        {/if}
+      </SummaryCell>
+    {/if}
+  </SummaryStrip>
 
-  <!-- Pod Spec -->
-  <DetailSection title="Pod Spec" icon={Box}>
-    <KvGrid>
-      <KvField label="Status">
-        <StatusBadge status={phase} />
-      </KvField>
-      <KvField label="Pod IP" value={podIP} />
-      <KvField label="Node" value={nodeName} />
-      <KvField label="QoS Class" value={(status.qosClass as string) ?? "—"} />
-      <KvField label="Ready" value={`${readyCount}/${totalContainers}`} />
-      <KvField label="Restarts">
-        <span class="font-mono text-[13px] {restartCount > 5 ? 'text-[var(--status-failed)]' : restartCount > 0 ? 'text-[var(--status-pending)]' : 'text-[var(--text-primary)]'}">{restartCount}</span>
-      </KvField>
-      <KvField label="Restart Policy" value={(spec.restartPolicy as string) ?? "Always"} mono={false} />
-      <KvField label="Service Account" value={(spec.serviceAccountName as string) ?? "default"} />
-      <KvField label="DNS Policy" value={(spec.dnsPolicy as string) ?? "—"} mono={false} />
-    </KvGrid>
-  </DetailSection>
-
-  <PodUsageCard {resource} />
-
-  <PodContainerCards {containerStatuses} {specContainerMap} />
-
-  <!-- Port Forwarding -->
-  {#if allPorts.length > 0}
-    <DetailSection title="Port Forwarding" icon={Unplug}>
-      <PodPortForwarding
-        {allPorts}
-        podName={resource.metadata.name}
-        namespace={resource.metadata.namespace ?? "default"}
-        {specContainerMap}
-        {failedIcons}
-        onIconError={handleIconError}
-      />
-    </DetailSection>
+  {#if problem && problemCopy}
+    <AttentionBlock tone={problemCopy.tone} title={problemCopy.title}>
+      {#each problemCopy.lines as line (line)}
+        <span>{line}</span>
+      {/each}
+      {#snippet actions()}
+        {#if problem.container}
+          <Button variant="toolbar" size="xs" onclick={() => { uiStore.detailSubtab = "logs"; }}>Logs</Button>
+        {/if}
+        <Button variant="toolbar" size="xs" onclick={() => { uiStore.detailSubtab = "events"; }}>Events</Button>
+      {/snippet}
+    </AttentionBlock>
   {/if}
 
-  <!-- Config & Secrets — inline, expandable key/value viewer -->
-  {#if configResources.length > 0}
-    <PodConfigSecrets
-      {configResources}
-      namespace={resource.metadata.namespace ?? ""}
-    />
-  {/if}
+  <DetailColumns {layout}>
+    {#snippet main()}
+      <PodContainerCards {containerStatuses} {specContainerMap} />
 
-  <!-- Related Resources -->
-  {#if related.length > 0}
-    <DetailSection title="Related Resources" icon={Link}>
-      <div class="grid gap-2.5 [grid-template-columns:repeat(auto-fill,minmax(252px,1fr))]">
-        {#each related as rel}
-          <RelCard
-            icon={kindIcon(rel.kind)}
-            kind={rel.kind}
-            name={rel.name}
-            onclick={() => openRelatedResourceTab(rel.resourceType, rel.name, resource.metadata.namespace)}
+      <PodUsageCard {resource} />
+
+      {#if allPorts.length > 0}
+        <DetailSection title="Port Forwarding" icon={Unplug}>
+          <PodPortForwarding
+            {allPorts}
+            podName={resource.metadata.name}
+            namespace={resource.metadata.namespace ?? "default"}
+            {specContainerMap}
+            {failedIcons}
+            onIconError={handleIconError}
           />
-        {/each}
-      </div>
-    </DetailSection>
-  {/if}
+        </DetailSection>
+      {/if}
 
-  <LabelsSection {labels} />
+      {#if configResources.length > 0}
+        <PodConfigSecrets {configResources} namespace={resource.metadata.namespace ?? ""} />
+      {/if}
 
-  <!-- Extended detail — rich functional sections beyond the reference scope -->
+      <RecentEventsCard {resource} />
+    {/snippet}
+
+    {#snippet rail()}
+      {#if conditions.length > 0}
+        <DetailSection title="Conditions" icon={CheckCircle2}>
+          <ConditionsList {conditions} layout={layout === "aside" ? "wrap" : "list"} />
+        </DetailSection>
+      {/if}
+
+      <DetailSection title="Network" icon={Globe}>
+        <KvGrid>
+          <KvField label="Pod IP" value={podIP} />
+          <KvField label="Host IP" value={hostIP} />
+          <KvField label="Node">
+            {#if nodeName}
+              <button type="button" class="truncate text-left font-mono text-[13px] text-[var(--accent)] hover:underline" onclick={() => openRelatedResourceTab("nodes", nodeName)}>{nodeName}</button>
+            {:else}
+              <span class="font-mono text-[13px] text-[var(--text-muted)]">—</span>
+            {/if}
+          </KvField>
+          <KvField label="Service Account" value={(spec.serviceAccountName as string) ?? "default"} />
+          <KvField label="DNS Policy" value={(spec.dnsPolicy as string) ?? "—"} mono={false} />
+          <KvField label="Restart Policy" value={(spec.restartPolicy as string) ?? "Always"} mono={false} />
+        </KvGrid>
+      </DetailSection>
+
+      {#if related.length > 0}
+        <DetailSection title="Related" icon={Link}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{related.length}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            {#each related as rel (`${rel.kind}/${rel.name}`)}
+              <LinkRow
+                kind={displayKind(rel.kind)}
+                name={rel.name}
+                color={kindColor(rel.kind)}
+                onclick={rel.resourceType ? () => openRelatedResourceTab(rel.resourceType, rel.name, namespace) : undefined}
+              />
+            {/each}
+          </div>
+        </DetailSection>
+      {/if}
+
+      <LabelsSection {labels} />
+    {/snippet}
+  </DetailColumns>
+
+  <!-- Rarely read, so collapsed: init containers, probes, security, scheduling, volumes, then metadata. -->
   <InitContainersCard {spec} {status} />
   <ProbesCard {spec} />
   <SecurityContextCard {spec} />
   <TolerationsCard {spec} />
   <VolumesCard {spec} />
-  <SmartAnnotationsCard annotations={annotations} />
+  <CollapsibleCard title="Metadata">
+    <div class="px-6 pt-1">
+      <KvGrid>
+        <KvField label="Name" value={resource.metadata.name} />
+        {#if resource.metadata.namespace}
+          <KvField label="Namespace" value={resource.metadata.namespace} />
+        {/if}
+        <KvField label="Created" value={resource.metadata.creation_timestamp} mono={false} />
+        {#if resource.metadata.uid}
+          <KvField label="UID" value={resource.metadata.uid} />
+        {/if}
+        {#if resource.metadata.resource_version}
+          <KvField label="Resource Version" value={resource.metadata.resource_version} />
+        {/if}
+        {#if owner}
+          <KvField label="Controlled By" value={`${owner.kind}/${owner.name}`} />
+        {/if}
+      </KvGrid>
+    </div>
+  </CollapsibleCard>
+  <SmartAnnotationsCard {annotations} />
 </div>

--- a/src/lib/components/details/RecentEventsCard.svelte
+++ b/src/lib/components/details/RecentEventsCard.svelte
@@ -34,6 +34,8 @@
     const args = { resourceType, name: resourceName, namespace: resourceNamespace };
     let cancelled = false;
     loading = true;
+    // Never show the previous resource's events under the new one's name.
+    events = [];
     invoke<K8sEvent[]>("get_resource_events", args)
       .then((result) => {
         if (!cancelled) events = result;

--- a/src/lib/components/details/RecentEventsCard.svelte
+++ b/src/lib/components/details/RecentEventsCard.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import { Bell } from "lucide-svelte";
+  import type { Resource, Event as K8sEvent } from "$lib/types";
+  import { invoke } from "$lib/ipc/core";
+  import { formatAge } from "$lib/utils/age";
+  import { kindToResourceType } from "$lib/utils";
+  import { uiStore } from "$lib/stores/ui.svelte";
+  import { Button } from "$lib/components/ui";
+  import DetailSection from "./DetailSection.svelte";
+
+  /**
+   * The last few events inline on the overview, newest first, so a BackOff
+   * is visible without switching to the Events subtab. "All events" opens
+   * that subtab (EventsCard), which merges in the lifecycle conditions.
+   */
+  interface Props {
+    resource: Resource;
+    limit?: number;
+  }
+
+  let { resource, limit = 4 }: Props = $props();
+
+  let events = $state<K8sEvent[]>([]);
+  let loading = $state(false);
+
+  // Primitive deriveds rather than `resource` itself: the prop is replaced on
+  // every watch delta, and reading its fields in the effect would re-run the
+  // fetch (and cancel the previous one) on each of them.
+  let resourceType = $derived(kindToResourceType(resource.kind));
+  let resourceName = $derived(resource.metadata.name);
+  let resourceNamespace = $derived(resource.metadata.namespace ?? "");
+
+  $effect(() => {
+    const args = { resourceType, name: resourceName, namespace: resourceNamespace };
+    let cancelled = false;
+    loading = true;
+    invoke<K8sEvent[]>("get_resource_events", args)
+      .then((result) => {
+        if (!cancelled) events = result;
+      })
+      .catch(() => {
+        if (!cancelled) events = [];
+      })
+      .finally(() => {
+        if (!cancelled) loading = false;
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
+  // Timestamps cross the IPC boundary as strings or Dates (structured clone
+  // keeps a Date a Date), and classic events may carry neither.
+  const ts = (e: K8sEvent): string => {
+    const v: unknown = e.last_timestamp ?? e.first_timestamp;
+    if (v == null) return "";
+    return v instanceof Date ? v.toISOString() : String(v);
+  };
+  let recent = $derived([...events].sort((a, b) => ts(b).localeCompare(ts(a))).slice(0, limit));
+</script>
+
+{#if recent.length > 0 || loading}
+  <DetailSection title="Recent events" icon={Bell}>
+    {#snippet actions()}
+      <span class="font-mono text-[11px] text-[var(--text-muted)]">{loading ? "…" : events.length}</span>
+      <Button variant="muted" size="inline-xs" class="text-[var(--accent)] hover:text-[var(--accent)]" onclick={() => { uiStore.detailSubtab = "events"; }}>All events</Button>
+    {/snippet}
+    <div class="flex flex-col">
+      {#each recent as e, i (`${e.reason}:${ts(e)}:${i}`)}
+        {@const warning = e.type === "Warning"}
+        <div class="flex min-h-[30px] items-center gap-3 border-b border-[var(--hairline)] last:border-b-0" title={e.message ?? ""}>
+          <span class="w-9 shrink-0 font-mono text-[11px] tabular-nums text-[var(--text-muted)]">{ts(e) ? formatAge(ts(e)) : "—"}</span>
+          {#if warning}
+            <span
+              class="inline-flex shrink-0 items-center gap-1.5 rounded-sm px-1.5 text-[11px] font-medium leading-4"
+              style="color: var(--status-pending); background-color: color-mix(in srgb, var(--status-pending) 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-pending) 25%, transparent);"
+            ><span class="h-[5px] w-[5px] rounded-full bg-[var(--status-pending)]"></span>Warning</span>
+          {:else}
+            <span class="w-[58px] shrink-0 text-[11px] text-[var(--text-muted)]">Normal</span>
+          {/if}
+          <span class="w-[120px] shrink-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{e.reason || "Event"}</span>
+          <span class="min-w-0 flex-1 truncate text-[12px] text-[var(--text-secondary)]">{e.message ?? ""}</span>
+          {#if (e.count ?? 1) > 1}
+            <span class="shrink-0 font-mono text-[11px] tabular-nums text-[var(--text-muted)]">×{e.count}</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </DetailSection>
+{/if}

--- a/src/lib/components/details/ServiceDetails.svelte
+++ b/src/lib/components/details/ServiceDetails.svelte
@@ -79,6 +79,7 @@
     let cancelled = false;
     if (!sel) {
       pods = [];
+      podsLoading = false;
       return;
     }
     podsLoading = true;
@@ -104,7 +105,7 @@
       .catch(() => { if (!cancelled) ingresses = []; });
     return () => { cancelled = true; };
   });
-  let routes = $derived(ingressesForService(ingresses, name));
+  let routes = $derived(ingressesForService(ingresses, name, namespace));
 
   // --- Attention -------------------------------------------------------------
   let noBackends = $derived(
@@ -255,7 +256,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  {#each addresses as ep (`${ep.address}:${ep.port ?? ""}`)}
+                  {#each addresses as ep, i (`${ep.address}:${ep.port ?? ""}:${i}`)}
                     <tr class="border-b border-[var(--hairline)] last:border-b-0">
                       <td class="{TD} font-mono tabular-nums text-[var(--text-primary)]">{ep.address}{ep.port ? `:${ep.port}` : ""}</td>
                       <td class="{TD} max-w-[220px] truncate">

--- a/src/lib/components/details/ServiceDetails.svelte
+++ b/src/lib/components/details/ServiceDetails.svelte
@@ -1,124 +1,453 @@
 <script lang="ts">
-  import { Badge } from "$lib/components/ui";
-  import { Globe } from "lucide-svelte";
-  import type { Resource } from "$lib/types";
-  import MetadataSection from "./MetadataSection.svelte";
-  import LabelsSection from "./LabelsSection.svelte";
+  import { Badge, Button } from "$lib/components/ui";
+  import { Globe, Server, Filter, Link, Unplug, Cloud } from "lucide-svelte";
+  import type { Resource, ResourceList } from "$lib/types";
+  import { invoke } from "$lib/ipc/core";
+  import { formatAge } from "$lib/utils/age";
+  import {
+    endpointAddresses,
+    isHeadless,
+    serviceExternal,
+    servicePorts,
+    serviceSelector,
+  } from "$lib/utils/service-info";
+  import { podReadyCount, podStatus } from "$lib/utils/pod-status";
+  import { statusCategory, statusColor, isQuietStatus } from "$lib/components/table/status-category";
+  import { splitPodName } from "$lib/components/table/table-filter";
+  import { endpointsStore } from "$lib/stores/endpoints.svelte";
+  import { openRelatedResourceTab, openResourceDetail } from "$lib/actions/navigation";
+  import SummaryStrip from "./SummaryStrip.svelte";
+  import SummaryCell from "./SummaryCell.svelte";
+  import AttentionBlock from "./AttentionBlock.svelte";
+  import DetailColumns from "./DetailColumns.svelte";
   import DetailSection from "./DetailSection.svelte";
-  import KvField from "./KvField.svelte";
   import KvGrid from "./KvGrid.svelte";
+  import KvField from "./KvField.svelte";
+  import LinkRow from "./LinkRow.svelte";
+  import RecentEventsCard from "./RecentEventsCard.svelte";
+  import CollapsibleCard from "./CollapsibleCard.svelte";
+  import LabelsSection from "./LabelsSection.svelte";
   import SmartAnnotationsCard from "./SmartAnnotationsCard.svelte";
-  import RelatedResourcesCard from "./RelatedResourcesCard.svelte";
+  import { ingressesForService, podControllers, podsMissingFromSlices, sliceSummaryLine } from "./service-details.logic";
 
+  /**
+   * A Service, read the way you debug one: does it have backends, where is
+   * it reachable, which ports map where, which pods the selector catches and
+   * which of them the EndpointSlice actually lists.
+   */
   interface Props {
     resource: Resource;
+    layout?: "page" | "aside";
   }
 
-  let { resource }: Props = $props();
+  let { resource, layout = "page" }: Props = $props();
 
   let spec = $derived(resource.spec ?? {});
   let status = $derived(resource.status ?? {});
+  let namespace = $derived(resource.metadata.namespace ?? "");
+  let name = $derived(resource.metadata.name);
 
   let serviceType = $derived((spec.type as string) ?? "ClusterIP");
   let clusterIP = $derived((spec.clusterIP as string) ?? "-");
-  let externalIPs = $derived((spec.externalIPs as string[]) ?? []);
-  let externalName = $derived((spec.externalName as string) ?? null);
-  let sessionAffinity = $derived((spec.sessionAffinity as string) ?? "None");
-
-  let loadBalancerIngress = $derived(
-    ((status.loadBalancer as { ingress?: Array<{ ip?: string; hostname?: string }> })?.ingress) ?? []
-  );
-
-  let ports = $derived(
-    (spec.ports as Array<{
-      name?: string;
-      protocol?: string;
-      port?: number;
-      targetPort?: string | number;
-      nodePort?: number;
-    }>) ?? []
-  );
-
-  let selectorStr = $derived(Object.entries((spec.selector as Record<string, string>) ?? {}).map(([k, v]) => `${k}=${v}`).join(", ") || "-");
+  let headless = $derived(isHeadless(resource));
+  let external = $derived(serviceExternal(resource));
+  let selectorTerms = $derived(serviceSelector(resource));
+  let selectorString = $derived(selectorTerms.join(","));
+  let ports = $derived(servicePorts(resource));
+  let hasNodePorts = $derived(ports.some((p) => p.nodePort));
+  let hasAppProtocol = $derived(ports.some((p) => p.appProtocol));
   let labels = $derived(resource.metadata.labels ?? {});
   let annotations = $derived(resource.metadata.annotations ?? {});
 
-  let hasNodePorts = $derived(ports.some((p) => p.nodePort));
+  // --- EndpointSlices (store, throttled) -----------------------------------
+  $effect(() => {
+    void name;
+    void endpointsStore.load(namespace || null, true);
+  });
+  let summary = $derived(endpointsStore.summaryFor(namespace, name));
+  let slices = $derived(endpointsStore.slicesFor(namespace, name));
+  let addresses = $derived(endpointAddresses(slices, name, namespace));
+  let sliceLine = $derived(sliceSummaryLine(slices));
+  let hasZones = $derived(addresses.some((a) => a.zone));
 
+  // --- Pods behind the selector --------------------------------------------
+  let pods = $state<Resource[]>([]);
+  let podsLoading = $state(false);
+  $effect(() => {
+    const sel = selectorString;
+    const ns = namespace;
+    let cancelled = false;
+    if (!sel) {
+      pods = [];
+      return;
+    }
+    podsLoading = true;
+    invoke<ResourceList>("list_pods_by_selector", { namespace: ns, selector: sel })
+      .then((r) => { if (!cancelled) pods = r.items; })
+      .catch(() => { if (!cancelled) pods = []; })
+      .finally(() => { if (!cancelled) podsLoading = false; });
+    return () => { cancelled = true; };
+  });
+  let runningPods = $derived(pods.filter((p) => podStatus(p).label === "Running").length);
+  let readyPods = $derived(pods.filter((p) => { const r = podReadyCount(p); return r.total > 0 && r.ready === r.total; }).length);
+  let controllers = $derived(podControllers(pods));
+  let missingPods = $derived(podsMissingFromSlices(pods, addresses));
+
+  // --- Ingresses routing here ----------------------------------------------
+  let ingresses = $state<Resource[]>([]);
+  $effect(() => {
+    const ns = namespace;
+    void name;
+    let cancelled = false;
+    invoke<ResourceList>("list_resources", { resourceType: "ingresses", namespace: ns })
+      .then((r) => { if (!cancelled) ingresses = r.items; })
+      .catch(() => { if (!cancelled) ingresses = []; });
+    return () => { cancelled = true; };
+  });
+  let routes = $derived(ingressesForService(ingresses, name));
+
+  // --- Attention -------------------------------------------------------------
+  let noBackends = $derived(
+    summary !== undefined && selectorTerms.length > 0 && (summary === null || summary.total === 0),
+  );
+
+  // --- Load balancer -------------------------------------------------------
+  let lbIngress = $derived(
+    ((status.loadBalancer as { ingress?: Array<{ ip?: string; hostname?: string }> })?.ingress ?? [])
+      .map((i) => i.ip ?? i.hostname ?? "")
+      .filter(Boolean),
+  );
+  let sourceRanges = $derived((spec.loadBalancerSourceRanges as string[] | undefined) ?? []);
+  let ipFamilies = $derived(((spec.ipFamilies as string[] | undefined) ?? []).join(", "));
+
+  const TH = "pb-1.5 text-left text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--text-muted)]";
+  const TD = "whitespace-nowrap py-1.5 pr-3 text-[12px]";
 </script>
 
-<div class="select-text">
-  <MetadataSection {resource} />
-
-  <!-- Service Spec -->
-  <DetailSection title="Service Spec" icon={Globe}>
-    <KvGrid>
-      <KvField label="Type">
-        <Badge appearance="surface" size="sm" bordered mono class="w-fit px-1.5">{serviceType}</Badge>
-      </KvField>
-      <KvField label="Cluster IP" value={clusterIP} />
-      <KvField label="Selector" value={selectorStr} />
-      <KvField label="Session Affinity" value={sessionAffinity} mono={false} />
-      {#if spec.ipFamilyPolicy}
-        <KvField label="IP Family Policy" value={spec.ipFamilyPolicy as string} mono={false} />
+<div class="select-text" data-testid="service-details">
+  <SummaryStrip>
+    <SummaryCell label="Type">
+      <span class="flex items-center gap-1.5">
+        <Badge appearance="surface" size="sm" bordered mono class="px-1.5">{serviceType}</Badge>
+        {#if headless}<span class="text-[11px] text-[var(--text-muted)]">headless</span>{/if}
+      </span>
+    </SummaryCell>
+    <SummaryCell label="Cluster IP" value={clusterIP} />
+    <SummaryCell label="External" title={external.label}>
+      {#if external.label}
+        <span class="truncate font-mono text-[12px] tabular-nums text-[var(--text-primary)]">{external.label}</span>
+      {:else if external.pending}
+        <span
+          class="inline-flex shrink-0 items-center gap-1.5 rounded-sm px-1.5 text-[11px] font-medium leading-4"
+          style="color: var(--status-pending); background-color: color-mix(in srgb, var(--status-pending) 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-pending) 25%, transparent);"
+        ><span class="h-[5px] w-[5px] rounded-full bg-[var(--status-pending)]"></span>Pending</span>
+      {:else}
+        <span class="text-[12px] text-[var(--text-muted)]">—</span>
       {/if}
-      {#if spec.internalTrafficPolicy}
-        <KvField label="Internal Traffic" value={spec.internalTrafficPolicy as string} mono={false} />
+    </SummaryCell>
+    <SummaryCell label="Endpoints">
+      {#if summary === undefined}
+        <span></span>
+      {:else if summary === null}
+        <span class="text-[12px] text-[var(--text-muted)]" title="No EndpointSlice for this service">—</span>
+      {:else if summary.total === 0}
+        <span class="inline-flex items-center gap-1.5" title="No endpoints: nothing backs this service">
+          <span class="h-[5px] w-[5px] rounded-full bg-[var(--status-failed)]"></span>
+          <span class="font-mono text-[13px] tabular-nums text-[var(--status-failed)]">0</span>
+        </span>
+      {:else}
+        <span
+          class="font-mono text-[13px] tabular-nums"
+          style:color={summary.ready < summary.total ? "var(--status-pending)" : "var(--text-primary)"}
+        >{summary.ready}/{summary.total}</span>
       {/if}
-      {#if spec.externalTrafficPolicy}
-        <KvField label="External Traffic" value={spec.externalTrafficPolicy as string} mono={false} />
-      {/if}
-      {#if externalName}
-        <KvField label="External Name" value={externalName} />
-      {/if}
-      {#if externalIPs.length > 0}
-        <KvField label="External IPs" value={externalIPs.join(", ")} />
-      {/if}
-      {#if loadBalancerIngress.length > 0}
-        <KvField label="Load Balancer" value={loadBalancerIngress.map((i) => i.ip ?? i.hostname ?? "").join(", ")} />
-      {/if}
-    </KvGrid>
-  </DetailSection>
-
-  <!-- Ports -->
-  <DetailSection title="Ports" icon={Globe}>
-    {#snippet actions()}
-      <span class="font-mono text-[11px] text-[var(--text-muted)]">{ports.length}</span>
-    {/snippet}
-    {#if ports.length > 0}
-      <table class="w-full border-collapse text-[13px]">
-        <thead>
-          <tr class="border-b border-[var(--border-color)]">
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Name</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Protocol</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Port</th>
-            <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Target</th>
-            {#if hasNodePorts}
-              <th class="px-3 py-2 text-left text-[11px] font-medium text-[var(--text-muted)]">Node Port</th>
-            {/if}
-          </tr>
-        </thead>
-        <tbody>
-          {#each ports as port}
-            <tr class="border-b border-[var(--border-color)] last:border-b-0">
-              <td class="px-3 py-2.5 text-[12px] font-medium text-[var(--text-primary)]">{port.name ?? "-"}</td>
-              <td class="px-3 py-2.5 font-mono text-[12px] text-[var(--text-secondary)]">{port.protocol ?? "TCP"}</td>
-              <td class="px-3 py-2.5 font-mono text-[12px] tabular-nums text-[var(--text-primary)]">{port.port ?? "-"}</td>
-              <td class="px-3 py-2.5 font-mono text-[12px] tabular-nums text-[var(--text-secondary)]">{port.targetPort ?? "-"}</td>
-              {#if hasNodePorts}
-                <td class="px-3 py-2.5 font-mono text-[12px] tabular-nums text-[var(--text-secondary)]">{port.nodePort ?? "-"}</td>
-              {/if}
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    {:else}
-      <p class="text-[12px] text-[var(--text-muted)]">No ports configured</p>
+    </SummaryCell>
+    {#if layout === "page"}
+      <SummaryCell label="Ports" value={ports.length ? ports.map((p) => p.port).join(" · ") : "—"} />
+      <SummaryCell label="Selector" value={selectorTerms.length ? selectorTerms.join(", ") : "—"} />
+      <SummaryCell label="Traffic" value={`${(spec.internalTrafficPolicy as string) ?? "Cluster"} / ${(spec.externalTrafficPolicy as string) ?? "—"}`} mono={false} />
     {/if}
-  </DetailSection>
+    <SummaryCell label="Age" value={formatAge(resource.metadata.creation_timestamp)} />
+  </SummaryStrip>
 
-  <RelatedResourcesCard {resource} resourceType="services" />
+  {#if noBackends}
+    <AttentionBlock tone="error" title="No endpoints — traffic to this service has nowhere to go">
+      <span>
+        Selector <code>{selectorTerms.join(", ")}</code> matches
+        <b>{podsLoading ? "…" : `${runningPods} running ${runningPods === 1 ? "pod" : "pods"}`}</b>
+        in <code>{namespace || "default"}</code>.
+      </span>
+      {#if !podsLoading && pods.length > 0 && readyPods === 0}
+        <span>{pods.length} {pods.length === 1 ? "pod matches" : "pods match"} but none is ready.</span>
+      {/if}
+      {#snippet actions()}
+        {#if pods.length > 0}
+          <Button variant="toolbar" size="xs" onclick={() => openResourceDetail(pods[0], "pods")}>
+            <Filter class="h-3 w-3" />
+            First matching pod
+          </Button>
+        {/if}
+      {/snippet}
+    </AttentionBlock>
+  {/if}
+  {#if external.pending}
+    <AttentionBlock tone="warning" title="LoadBalancer has no address yet">
+      <span>The cloud controller has not assigned an IP or hostname. If this persists, check the controller's events and the service's annotations.</span>
+    </AttentionBlock>
+  {/if}
 
-  <LabelsSection {labels} />
-  <SmartAnnotationsCard annotations={annotations} />
+  <DetailColumns {layout}>
+    {#snippet main()}
+      <!-- Ports -->
+      <DetailSection title="Ports" icon={Globe}>
+        {#snippet actions()}
+          <span class="font-mono text-[11px] text-[var(--text-muted)]">{ports.length}</span>
+        {/snippet}
+        {#if ports.length > 0}
+          <div class="overflow-x-auto">
+          <table class="w-full border-collapse">
+            <thead>
+              <tr class="border-b border-[var(--border-color)]">
+                <th class={TH}>Name</th>
+                <th class="{TH} text-right">Port</th>
+                <th class="{TH} text-right">→ Target</th>
+                <th class="{TH} pl-4">Protocol</th>
+                {#if hasAppProtocol}<th class={TH}>App protocol</th>{/if}
+                {#if hasNodePorts}<th class="{TH} text-right">Node port</th>{/if}
+              </tr>
+            </thead>
+            <tbody>
+              {#each ports as port, i (`${port.name ?? ""}:${port.port ?? ""}:${i}`)}
+                <tr class="border-b border-[var(--hairline)] last:border-b-0">
+                  <td class="{TD} font-medium text-[var(--text-primary)]">{port.name ?? "-"}</td>
+                  <td class="{TD} text-right font-mono tabular-nums text-[var(--text-primary)]">{port.port ?? "-"}</td>
+                  <td class="{TD} text-right font-mono tabular-nums text-[var(--text-secondary)]">{port.targetPort ?? port.port ?? "-"}</td>
+                  <td class="{TD} pl-4 font-mono text-[var(--text-secondary)]">{port.protocol ?? "TCP"}</td>
+                  {#if hasAppProtocol}<td class="{TD} font-mono text-[var(--text-secondary)]">{port.appProtocol ?? "—"}</td>{/if}
+                  {#if hasNodePorts}<td class="{TD} text-right font-mono tabular-nums text-[var(--text-secondary)]">{port.nodePort ?? "—"}</td>{/if}
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+          </div>
+        {:else}
+          <p class="text-[12px] text-[var(--text-muted)]">No ports configured</p>
+        {/if}
+      </DetailSection>
+
+      <!-- Endpoints -->
+      {#if serviceType !== "ExternalName"}
+        <DetailSection title="Endpoints" icon={Server}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{summary === undefined ? "…" : summary === null ? "—" : summary.total}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            {#if addresses.length > 0}
+              <div class="overflow-x-auto">
+              <table class="w-full border-collapse">
+                <thead>
+                  <tr class="border-b border-[var(--border-color)]">
+                    <th class={TH}>Address</th>
+                    <th class={TH}>Pod</th>
+                    <th class={TH}>Node</th>
+                    {#if hasZones}<th class={TH}>Zone</th>{/if}
+                    <th class={TH}>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each addresses as ep (`${ep.address}:${ep.port ?? ""}`)}
+                    <tr class="border-b border-[var(--hairline)] last:border-b-0">
+                      <td class="{TD} font-mono tabular-nums text-[var(--text-primary)]">{ep.address}{ep.port ? `:${ep.port}` : ""}</td>
+                      <td class="{TD} max-w-[220px] truncate">
+                        {#if ep.targetRef?.name}
+                          {@const ref = ep.targetRef}
+                          <button
+                            type="button"
+                            class="max-w-full truncate font-mono text-[11px] text-[var(--text-secondary)] hover:text-[var(--accent)] hover:underline"
+                            onclick={() => openRelatedResourceTab(ref.kind === "Pod" ? "pods" : (ref.kind ?? "pods").toLowerCase() + "s", ref.name ?? "", ref.namespace ?? namespace)}
+                          >{ref.name}</button>
+                        {:else}
+                          <span class="text-[var(--text-muted)]">—</span>
+                        {/if}
+                      </td>
+                      <td class="{TD} max-w-[160px] truncate font-mono text-[11px] text-[var(--text-muted)]" title={ep.nodeName ?? ""}>{ep.nodeName ?? "—"}</td>
+                      {#if hasZones}<td class="{TD} font-mono text-[11px] text-[var(--text-muted)]">{ep.zone ?? "—"}</td>{/if}
+                      <td class={TD}>
+                        {#if ep.terminating}
+                          <span class="text-[11px] text-[var(--text-muted)]">terminating</span>
+                        {:else if ep.ready}
+                          <span class="inline-flex items-center gap-1.5 text-[11px] text-[var(--status-running)]">✓ ready</span>
+                        {:else}
+                          <span class="inline-flex items-center gap-1.5 text-[11px] text-[var(--status-pending)]">✗ not ready</span>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+              </div>
+            {:else}
+              <div class="rounded-sm border border-dashed border-[var(--border-color)] px-3 py-2.5 text-center text-[12px] text-[var(--text-muted)]">
+                {summary === undefined ? "Loading endpoints…" : "No ready or terminating endpoints"}
+              </div>
+            {/if}
+            {#if sliceLine || summary}
+              <div class="flex flex-wrap gap-x-4 text-[11px] text-[var(--text-muted)]">
+                {#if sliceLine}<span class="truncate font-mono">{sliceLine}</span>{/if}
+                {#if summary}<span>{summary.ready} ready · {summary.terminating} terminating</span>{/if}
+              </div>
+            {/if}
+            {#if missingPods.length > 0 && summary !== undefined}
+              <div class="text-[11px] text-[var(--text-muted)]">
+                Not in any slice yet:
+                {#each missingPods as p, i (p.metadata.uid)}
+                  <span class="font-mono">{p.metadata.name}</span><span class="text-[var(--text-muted)]"> ({podStatus(p).label})</span>{i < missingPods.length - 1 ? ", " : ""}
+                {/each}
+              </div>
+            {/if}
+          </div>
+        </DetailSection>
+      {/if}
+
+      <!-- Selector → pods -->
+      {#if selectorTerms.length > 0}
+        <DetailSection title="Selector → pods" icon={Filter}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{podsLoading ? "…" : pods.length}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            <div class="flex flex-wrap gap-1.5">
+              {#each selectorTerms as term (term)}
+                <Badge appearance="surface" size="sm" bordered mono class="px-1.5">{term}</Badge>
+              {/each}
+            </div>
+            {#if pods.length > 0}
+              <div class="overflow-x-auto">
+              <table class="w-full border-collapse">
+                <thead>
+                  <tr class="border-b border-[var(--border-color)]">
+                    <th class={TH}>Name</th>
+                    <th class={TH}>Status</th>
+                    <th class="{TH} text-right">Ready</th>
+                    <th class="{TH} text-right">Age</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each pods as pod (pod.metadata.uid)}
+                    {@const st = podStatus(pod)}
+                    {@const cat = statusCategory(st.label)}
+                    {@const ready = podReadyCount(pod)}
+                    {@const parts = splitPodName(pod.metadata.name)}
+                    <tr
+                      class="cursor-pointer border-b border-[var(--hairline)] transition-colors last:border-b-0 hover:bg-[var(--table-row-hover)]"
+                      onclick={() => openResourceDetail(pod, "pods")}
+                    >
+                      <td class="{TD} max-w-[220px] truncate font-medium text-[var(--text-primary)]" title={pod.metadata.name}>{parts.base}<span class="font-normal text-[var(--text-muted)]">{parts.suffix}</span></td>
+                      <td class={TD}>
+                        {#if isQuietStatus(cat)}
+                          <span class="text-[var(--text-muted)]">{st.label}</span>
+                        {:else}
+                          <span
+                            class="inline-flex items-center gap-1.5 rounded-sm px-1.5 text-[11px] font-medium leading-4"
+                            style="color: {statusColor(cat)}; background-color: color-mix(in srgb, {statusColor(cat)} 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, {statusColor(cat)} 25%, transparent);"
+                          ><span class="h-[5px] w-[5px] rounded-full" style="background-color: {statusColor(cat)}"></span>{st.label}</span>
+                        {/if}
+                      </td>
+                      <td class="{TD} text-right font-mono tabular-nums" style:color={ready.total > 0 && ready.ready < ready.total ? "var(--status-pending)" : "var(--text-secondary)"}>{ready.ready}/{ready.total}</td>
+                      <td class="{TD} text-right font-mono tabular-nums text-[var(--text-muted)]">{formatAge(pod.metadata.creation_timestamp)}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+              </div>
+            {:else if !podsLoading}
+              <p class="text-[12px] text-[var(--text-muted)]">No pods match this selector</p>
+            {/if}
+          </div>
+        </DetailSection>
+      {/if}
+
+      <RecentEventsCard {resource} />
+    {/snippet}
+
+    {#snippet rail()}
+      {#if serviceType === "LoadBalancer"}
+        <DetailSection title="Load balancer" icon={Cloud}>
+          <KvGrid>
+            <KvField label={lbIngress.length > 1 ? "Addresses" : "Address"} value={lbIngress.length ? lbIngress.join(", ") : "pending"} />
+            {#if spec.loadBalancerClass}<KvField label="Class" value={spec.loadBalancerClass as string} mono={false} />{/if}
+            {#if sourceRanges.length > 0}<KvField label="Source ranges" value={sourceRanges.join(", ")} />{/if}
+            {#if spec.allocateLoadBalancerNodePorts !== undefined}<KvField label="Allocate node ports" value={String(spec.allocateLoadBalancerNodePorts)} mono={false} />{/if}
+          </KvGrid>
+        </DetailSection>
+      {/if}
+
+      <DetailSection title="Traffic" icon={Unplug}>
+        <KvGrid>
+          <KvField label="Session affinity" value={(spec.sessionAffinity as string) ?? "None"} mono={false} />
+          <KvField label="Internal traffic policy" value={(spec.internalTrafficPolicy as string) ?? "Cluster"} mono={false} />
+          <KvField label="External traffic policy" value={(spec.externalTrafficPolicy as string) ?? "—"} mono={false} />
+          <KvField label="IP families" value={ipFamilies ? `${ipFamilies}${spec.ipFamilyPolicy ? ` · ${spec.ipFamilyPolicy}` : ""}` : "—"} />
+          <KvField label="Publish not-ready" value={String(spec.publishNotReadyAddresses === true)} mono={false} />
+          {#if spec.healthCheckNodePort}<KvField label="Health check node port" value={String(spec.healthCheckNodePort)} />{/if}
+        </KvGrid>
+      </DetailSection>
+
+      {#if controllers.length > 0 || routes.length > 0 || slices.length > 0 || spec.externalName}
+        <DetailSection title="Related" icon={Link}>
+          {#snippet actions()}
+            <span class="font-mono text-[11px] text-[var(--text-muted)]">{controllers.length + routes.length + slices.length + (spec.externalName ? 1 : 0)}</span>
+          {/snippet}
+          <div class="flex flex-col gap-2.5">
+            {#each controllers as c (`${c.kind}/${c.name}`)}
+              <LinkRow
+                kind={c.kind}
+                name={c.name}
+                color="var(--status-running)"
+                onclick={() => openRelatedResourceTab(c.kind.toLowerCase() + "s", c.name, namespace)}
+              />
+            {/each}
+            {#each routes as r (r.name)}
+              <LinkRow
+                kind="Ingress"
+                name={r.name}
+                color="var(--accent)"
+                note={r.routes.join(", ")}
+                onclick={() => openRelatedResourceTab("ingresses", r.name, namespace)}
+              />
+            {/each}
+            {#each slices as s (s.metadata.uid)}
+              <LinkRow
+                kind="EndpointSlice"
+                name={s.metadata.name}
+                color="var(--accent)"
+                onclick={() => openRelatedResourceTab("endpointslices", s.metadata.name, namespace)}
+              />
+            {/each}
+            {#if spec.externalName}
+              <LinkRow kind="ExternalName" name={spec.externalName as string} />
+            {/if}
+            {#if routes.length === 0 && serviceType !== "ExternalName"}
+              <span class="text-[11px] text-[var(--text-muted)]">No Ingress routes to this service.</span>
+            {/if}
+          </div>
+        </DetailSection>
+      {/if}
+
+      <LabelsSection {labels} />
+    {/snippet}
+  </DetailColumns>
+
+  <CollapsibleCard title="Metadata">
+    <div class="px-6 pt-1">
+      <KvGrid>
+        <KvField label="Name" value={resource.metadata.name} />
+        {#if resource.metadata.namespace}<KvField label="Namespace" value={resource.metadata.namespace} />{/if}
+        <KvField label="Created" value={resource.metadata.creation_timestamp} mono={false} />
+        {#if resource.metadata.uid}<KvField label="UID" value={resource.metadata.uid} />{/if}
+        {#if resource.metadata.resource_version}<KvField label="Resource version" value={resource.metadata.resource_version} />{/if}
+      </KvGrid>
+    </div>
+  </CollapsibleCard>
+  <SmartAnnotationsCard {annotations} />
 </div>

--- a/src/lib/components/details/SummaryCell.svelte
+++ b/src/lib/components/details/SummaryCell.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  /** One labelled value in a SummaryStrip. `value` for plain text, children for pills/bars. */
+  interface Props {
+    label: string;
+    value?: string | number | null;
+    mono?: boolean;
+    title?: string;
+    children?: Snippet;
+  }
+
+  let { label, value, mono = true, title, children }: Props = $props();
+</script>
+
+<div
+  class="flex min-w-0 flex-col gap-1.5 px-4 py-3 [&:not(:first-child)]:border-l [&:not(:first-child)]:border-[var(--border-color)]"
+  {title}
+>
+  <span class="truncate whitespace-nowrap text-[10px] font-medium uppercase tracking-[0.06em] text-[var(--text-muted)]">{label}</span>
+  <span class="flex min-h-[18px] items-center overflow-hidden whitespace-nowrap">
+    {#if children}
+      {@render children()}
+    {:else}
+      <span class={mono ? "truncate font-mono text-[13px] tabular-nums text-[var(--text-primary)]" : "truncate text-[12px] text-[var(--text-secondary)]"}>{value ?? "—"}</span>
+    {/if}
+  </span>
+</div>

--- a/src/lib/components/details/SummaryStrip.svelte
+++ b/src/lib/components/details/SummaryStrip.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  /**
+   * The strip under the subtabs: the five to eight numbers that used to be
+   * scattered down the page (status, ready, restarts, age…), each a
+   * SummaryCell. Auto-fits its columns, so the same cells work in a 440px
+   * aside and a full-width tab.
+   */
+  interface Props {
+    children: Snippet;
+  }
+
+  let { children }: Props = $props();
+</script>
+
+<div
+  class="grid border-b border-[var(--border-color)] bg-[var(--bg-secondary)]"
+  style="grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));"
+  data-testid="summary-strip"
+>
+  {@render children()}
+</div>

--- a/src/lib/components/details/deployment-details.logic.ts
+++ b/src/lib/components/details/deployment-details.logic.ts
@@ -126,8 +126,11 @@ export function strategyLabel(resource: Resource): string {
 /** The HPA whose scaleTargetRef points at this Deployment, if any. */
 export function findAutoscalerFor(resource: Resource, autoscalers: Resource[]): Resource | null {
   const name = resource.metadata.name;
+  const namespace = resource.metadata.namespace;
   return (
     autoscalers.find((hpa) => {
+      // scaleTargetRef resolves inside the HPA's own namespace.
+      if (hpa.metadata.namespace !== namespace) return false;
       const ref = (hpa.spec as Json | undefined)?.scaleTargetRef as { kind?: string; name?: string } | undefined;
       return ref?.kind === "Deployment" && ref.name === name;
     }) ?? null
@@ -137,7 +140,9 @@ export function findAutoscalerFor(resource: Resource, autoscalers: Resource[]): 
 /** Services whose selector is a non-empty subset of the pod template's labels. */
 export function servicesSelecting(resource: Resource, services: Resource[]): Resource[] {
   const labels = templateLabels(resource);
+  const namespace = resource.metadata.namespace;
   return services.filter((svc) => {
+    if (svc.metadata.namespace !== namespace) return false;
     const selector = (svc.spec as Json | undefined)?.selector as Record<string, string> | undefined;
     if (!selector) return false;
     const entries = Object.entries(selector);

--- a/src/lib/components/details/deployment-details.logic.ts
+++ b/src/lib/components/details/deployment-details.logic.ts
@@ -1,0 +1,194 @@
+// Pure derived data for DeploymentDetails: what the pod template runs (one row
+// per container, with request/limit and probes), what a pod costs in requests
+// and what that is across the replicas, which HPA scales this deployment and
+// which Services select its pods. Testable under bun, no Svelte runtime.
+
+import type { Resource } from "$lib/types";
+import { formatBytes, formatCpu, parseCpuQuantity, parseMemoryQuantity } from "$lib/stores/metrics.logic";
+
+type Json = Record<string, unknown>;
+
+interface TemplateContainer {
+  name?: string;
+  image?: string;
+  ports?: Array<{ containerPort?: number; protocol?: string }>;
+  env?: unknown[];
+  envFrom?: Array<{ configMapRef?: { name?: string }; secretRef?: { name?: string } }>;
+  resources?: { requests?: Record<string, string>; limits?: Record<string, string> };
+  livenessProbe?: unknown;
+  readinessProbe?: unknown;
+  startupProbe?: unknown;
+}
+
+export interface TemplateContainerRow {
+  name: string;
+  image: string;
+  /** "250m / 500m" — request / limit, "—" for an absent side. */
+  cpu: string;
+  memory: string;
+  /** "8080/TCP, 9090/TCP" or "—". */
+  ports: string;
+  probes: { liveness: boolean; readiness: boolean; startup: boolean };
+  envCount: number;
+}
+
+export interface RequestTotals {
+  /** Sum of CPU requests across the template's containers, in cores. */
+  cpuPerPod: number;
+  memoryPerPod: number;
+  replicas: number;
+  cpuTotal: number;
+  memoryTotal: number;
+  /** "350m · 192Mi" */
+  perPodLabel: string;
+  /** "1.05 · 576Mi" */
+  totalLabel: string;
+}
+
+function templateSpec(resource: Resource): Json {
+  const template = (resource.spec as Json | undefined)?.template as { spec?: Json } | undefined;
+  return template?.spec ?? {};
+}
+
+function templateContainers(resource: Resource): TemplateContainer[] {
+  const list = templateSpec(resource).containers;
+  return Array.isArray(list) ? (list as TemplateContainer[]) : [];
+}
+
+/** Pod template labels (what a Service selector must be a subset of). */
+export function templateLabels(resource: Resource): Record<string, string> {
+  const template = (resource.spec as Json | undefined)?.template as { metadata?: { labels?: Record<string, string> } } | undefined;
+  return template?.metadata?.labels ?? {};
+}
+
+const reqLim = (c: TemplateContainer, key: "cpu" | "memory"): string => {
+  const req = c.resources?.requests?.[key];
+  const lim = c.resources?.limits?.[key];
+  if (!req && !lim) return "—";
+  return `${req ?? "—"} / ${lim ?? "—"}`;
+};
+
+export function templateContainerRows(resource: Resource): TemplateContainerRow[] {
+  return templateContainers(resource).map((c) => ({
+    name: c.name ?? "",
+    image: c.image ?? "",
+    cpu: reqLim(c, "cpu"),
+    memory: reqLim(c, "memory"),
+    ports: (c.ports ?? [])
+      .filter((p) => p.containerPort)
+      .map((p) => `${p.containerPort}/${p.protocol ?? "TCP"}`)
+      .join(", ") || "—",
+    probes: { liveness: !!c.livenessProbe, readiness: !!c.readinessProbe, startup: !!c.startupProbe },
+    envCount: (c.env?.length ?? 0) + (c.envFrom?.length ?? 0),
+  }));
+}
+
+/** Requests summed over the template's containers, then multiplied by the desired replicas. */
+export function requestTotals(resource: Resource): RequestTotals {
+  let cpuPerPod = 0;
+  let memoryPerPod = 0;
+  for (const c of templateContainers(resource)) {
+    const req = c.resources?.requests;
+    if (req?.cpu) cpuPerPod += parseCpuQuantity(req.cpu);
+    if (req?.memory) memoryPerPod += parseMemoryQuantity(req.memory);
+  }
+  const raw = (resource.spec as Json | undefined)?.replicas;
+  const replicas = typeof raw === "number" ? raw : 1;
+  const cpuTotal = cpuPerPod * replicas;
+  const memoryTotal = memoryPerPod * replicas;
+  return {
+    cpuPerPod,
+    memoryPerPod,
+    replicas,
+    cpuTotal,
+    memoryTotal,
+    perPodLabel: `${formatCpu(cpuPerPod)} · ${formatBytes(memoryPerPod)}`,
+    totalLabel: `${formatCpu(cpuTotal)} · ${formatBytes(memoryTotal)}`,
+  };
+}
+
+/** The Deployment's revision annotation as a number, or null. */
+export function deploymentRevision(resource: Resource): number | null {
+  const raw = resource.metadata?.annotations?.["deployment.kubernetes.io/revision"];
+  const n = raw === undefined ? NaN : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** "RollingUpdate 25% / 25%", "Recreate". */
+export function strategyLabel(resource: Resource): string {
+  const strategy = ((resource.spec as Json | undefined)?.strategy ?? {}) as { type?: string; rollingUpdate?: { maxSurge?: string | number; maxUnavailable?: string | number } };
+  const type = strategy.type ?? "RollingUpdate";
+  if (type !== "RollingUpdate") return type;
+  const ru = strategy.rollingUpdate ?? {};
+  return `RollingUpdate ${ru.maxSurge ?? "25%"} / ${ru.maxUnavailable ?? "25%"}`;
+}
+
+/** The HPA whose scaleTargetRef points at this Deployment, if any. */
+export function findAutoscalerFor(resource: Resource, autoscalers: Resource[]): Resource | null {
+  const name = resource.metadata.name;
+  return (
+    autoscalers.find((hpa) => {
+      const ref = (hpa.spec as Json | undefined)?.scaleTargetRef as { kind?: string; name?: string } | undefined;
+      return ref?.kind === "Deployment" && ref.name === name;
+    }) ?? null
+  );
+}
+
+/** Services whose selector is a non-empty subset of the pod template's labels. */
+export function servicesSelecting(resource: Resource, services: Resource[]): Resource[] {
+  const labels = templateLabels(resource);
+  return services.filter((svc) => {
+    const selector = (svc.spec as Json | undefined)?.selector as Record<string, string> | undefined;
+    if (!selector) return false;
+    const entries = Object.entries(selector);
+    if (entries.length === 0) return false;
+    return entries.every(([k, v]) => labels[k] === v);
+  });
+}
+
+export interface TemplateReference {
+  kind: "ConfigMap" | "Secret" | "ServiceAccount" | "PersistentVolumeClaim";
+  name: string;
+}
+
+/** ConfigMaps, Secrets, PVCs and the ServiceAccount the template references, deduped in first-seen order. */
+export function templateReferences(resource: Resource): TemplateReference[] {
+  const out: TemplateReference[] = [];
+  const seen = new Set<string>();
+  const add = (kind: TemplateReference["kind"], name: string | undefined) => {
+    if (!name) return;
+    const key = `${kind}/${name}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ kind, name });
+  };
+  const spec = templateSpec(resource);
+  const volumes = Array.isArray(spec.volumes) ? (spec.volumes as Json[]) : [];
+  for (const vol of volumes) {
+    add("ConfigMap", (vol.configMap as { name?: string } | undefined)?.name);
+    add("Secret", (vol.secret as { secretName?: string } | undefined)?.secretName);
+    add("PersistentVolumeClaim", (vol.persistentVolumeClaim as { claimName?: string } | undefined)?.claimName);
+    const projected = vol.projected as { sources?: Json[] } | undefined;
+    for (const src of projected?.sources ?? []) {
+      add("ConfigMap", (src.configMap as { name?: string } | undefined)?.name);
+      add("Secret", (src.secret as { name?: string } | undefined)?.name);
+    }
+  }
+  const containers = [
+    ...(Array.isArray(spec.initContainers) ? (spec.initContainers as TemplateContainer[]) : []),
+    ...templateContainers(resource),
+  ];
+  for (const c of containers) {
+    for (const ef of c.envFrom ?? []) {
+      add("ConfigMap", ef.configMapRef?.name);
+      add("Secret", ef.secretRef?.name);
+    }
+    for (const env of (c.env ?? []) as Array<{ valueFrom?: { configMapKeyRef?: { name?: string }; secretKeyRef?: { name?: string } } }>) {
+      add("ConfigMap", env.valueFrom?.configMapKeyRef?.name);
+      add("Secret", env.valueFrom?.secretKeyRef?.name);
+    }
+  }
+  const sa = spec.serviceAccountName;
+  if (typeof sa === "string" && sa && sa !== "default") add("ServiceAccount", sa);
+  return out;
+}

--- a/src/lib/components/details/deployment-details.test.ts
+++ b/src/lib/components/details/deployment-details.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import {
+  deploymentRevision,
+  findAutoscalerFor,
+  requestTotals,
+  servicesSelecting,
+  strategyLabel,
+  templateContainerRows,
+  templateReferences,
+} from "./deployment-details.logic";
+
+function res(kind: string, name: string, spec: Record<string, unknown>, annotations: Record<string, string> = {}): Resource {
+  return {
+    kind,
+    api_version: "v1",
+    metadata: { name, namespace: "ns", uid: name, creation_timestamp: "", labels: {}, annotations, resource_version: "1", owner_references: [] },
+    spec,
+    status: {},
+  };
+}
+
+const deploy = res("Deployment", "api", {
+  replicas: 3,
+  strategy: { type: "RollingUpdate", rollingUpdate: { maxSurge: "50%", maxUnavailable: 1 } },
+  template: {
+    metadata: { labels: { app: "api", tier: "backend" } },
+    spec: {
+      serviceAccountName: "api",
+      volumes: [
+        { name: "cfg", configMap: { name: "api-config" } },
+        { name: "creds", secret: { secretName: "api-db" } },
+        { name: "cache", persistentVolumeClaim: { claimName: "api-cache" } },
+        { name: "proj", projected: { sources: [{ configMap: { name: "ca" } }, { secret: { name: "api-db" } }] } },
+      ],
+      initContainers: [{ name: "migrate", image: "api:2.4.1", envFrom: [{ secretRef: { name: "migrate-secret" } }] }],
+      containers: [
+        {
+          name: "api",
+          image: "ghcr.io/shop/api:2.4.1",
+          ports: [{ containerPort: 8080 }, { containerPort: 9090, protocol: "UDP" }],
+          env: [{ name: "A", value: "1" }, { name: "B", valueFrom: { configMapKeyRef: { name: "api-config", key: "b" } } }],
+          envFrom: [{ configMapRef: { name: "api-env" } }],
+          resources: { requests: { cpu: "250m", memory: "128Mi" }, limits: { cpu: "500m", memory: "256Mi" } },
+          livenessProbe: {},
+          readinessProbe: {},
+        },
+        { name: "otel", image: "otel/collector:0.98.0", resources: { requests: { cpu: "100m", memory: "64Mi" } } },
+      ],
+    },
+  },
+}, { "deployment.kubernetes.io/revision": "12" });
+
+describe("templateContainerRows", () => {
+  test("one row per container with request/limit, ports, probes and env count", () => {
+    const rows = templateContainerRows(deploy);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({
+      name: "api", image: "ghcr.io/shop/api:2.4.1", cpu: "250m / 500m", memory: "128Mi / 256Mi",
+      ports: "8080/TCP, 9090/UDP", probes: { liveness: true, readiness: true, startup: false }, envCount: 3,
+    });
+    expect(rows[1]).toMatchObject({ cpu: "100m / —", ports: "—", probes: { liveness: false, readiness: false, startup: false }, envCount: 0 });
+  });
+});
+
+describe("requestTotals", () => {
+  test("sums requests per pod and multiplies by replicas", () => {
+    const t = requestTotals(deploy);
+    expect(t.cpuPerPod).toBeCloseTo(0.35);
+    expect(t.memoryPerPod).toBe(192 * 1024 * 1024);
+    expect(t.replicas).toBe(3);
+    expect(t.perPodLabel).toBe("350m · 192 Mi");
+    expect(t.totalLabel).toBe("1.05 · 576 Mi");
+  });
+
+  test("no requests and no replicas field", () => {
+    const t = requestTotals(res("Deployment", "x", { template: { spec: { containers: [{ name: "a" }] } } }));
+    expect(t.replicas).toBe(1);
+    expect(t.perPodLabel).toBe("0m · 0");
+  });
+});
+
+describe("revision / strategy", () => {
+  test("revision from the annotation, strategy summarised", () => {
+    expect(deploymentRevision(deploy)).toBe(12);
+    expect(deploymentRevision(res("Deployment", "x", {}))).toBeNull();
+    expect(strategyLabel(deploy)).toBe("RollingUpdate 50% / 1");
+    expect(strategyLabel(res("Deployment", "x", {}))).toBe("RollingUpdate 25% / 25%");
+    expect(strategyLabel(res("Deployment", "x", { strategy: { type: "Recreate" } }))).toBe("Recreate");
+  });
+});
+
+describe("findAutoscalerFor / servicesSelecting / templateReferences", () => {
+  test("matches the HPA by scaleTargetRef kind and name", () => {
+    const mine = res("HorizontalPodAutoscaler", "api", { scaleTargetRef: { kind: "Deployment", name: "api" } });
+    const other = res("HorizontalPodAutoscaler", "web", { scaleTargetRef: { kind: "Deployment", name: "web" } });
+    const sts = res("HorizontalPodAutoscaler", "api-sts", { scaleTargetRef: { kind: "StatefulSet", name: "api" } });
+    expect(findAutoscalerFor(deploy, [other, sts, mine])).toBe(mine);
+    expect(findAutoscalerFor(deploy, [other])).toBeNull();
+  });
+
+  test("services whose selector is a subset of the template labels", () => {
+    const api = res("Service", "api", { selector: { app: "api" } });
+    const full = res("Service", "api-backend", { selector: { app: "api", tier: "backend" } });
+    const web = res("Service", "web", { selector: { app: "web" } });
+    const empty = res("Service", "none", { selector: {} });
+    const ext = res("Service", "ext", { type: "ExternalName" });
+    expect(servicesSelecting(deploy, [api, full, web, empty, ext]).map((s) => s.metadata.name)).toEqual(["api", "api-backend"]);
+  });
+
+  test("template references: volumes, projected, envFrom, env valueFrom, init containers, service account; deduped", () => {
+    expect(templateReferences(deploy)).toEqual([
+      { kind: "ConfigMap", name: "api-config" },
+      { kind: "Secret", name: "api-db" },
+      { kind: "PersistentVolumeClaim", name: "api-cache" },
+      { kind: "ConfigMap", name: "ca" },
+      { kind: "Secret", name: "migrate-secret" },
+      { kind: "ConfigMap", name: "api-env" },
+      { kind: "ServiceAccount", name: "api" },
+    ]);
+  });
+});

--- a/src/lib/components/details/deployment-details.test.ts
+++ b/src/lib/components/details/deployment-details.test.ts
@@ -97,6 +97,9 @@ describe("findAutoscalerFor / servicesSelecting / templateReferences", () => {
     const sts = res("HorizontalPodAutoscaler", "api-sts", { scaleTargetRef: { kind: "StatefulSet", name: "api" } });
     expect(findAutoscalerFor(deploy, [other, sts, mine])).toBe(mine);
     expect(findAutoscalerFor(deploy, [other])).toBeNull();
+    // Same name in another namespace is somebody else's HPA.
+    const elsewhere = { ...mine, metadata: { ...mine.metadata, namespace: "other" } };
+    expect(findAutoscalerFor(deploy, [elsewhere])).toBeNull();
   });
 
   test("services whose selector is a subset of the template labels", () => {
@@ -106,6 +109,8 @@ describe("findAutoscalerFor / servicesSelecting / templateReferences", () => {
     const empty = res("Service", "none", { selector: {} });
     const ext = res("Service", "ext", { type: "ExternalName" });
     expect(servicesSelecting(deploy, [api, full, web, empty, ext]).map((s) => s.metadata.name)).toEqual(["api", "api-backend"]);
+    const foreign = { ...api, metadata: { ...api.metadata, namespace: "other" } };
+    expect(servicesSelecting(deploy, [foreign])).toEqual([]);
   });
 
   test("template references: volumes, projected, envFrom, env valueFrom, init containers, service account; deduped", () => {

--- a/src/lib/components/details/pod-details.logic.ts
+++ b/src/lib/components/details/pod-details.logic.ts
@@ -1,0 +1,49 @@
+// Copy for the pod overview's attention block, built from podProblem(). Pure
+// so the wording ("Container api is crash-looping · last exit code 1 · Error
+// · 3m ago") is unit-tested rather than eyeballed.
+
+import type { PodProblem } from "$lib/utils/pod-status";
+import { formatAge } from "$lib/utils/age";
+
+export interface PodProblemCopy {
+  tone: "error" | "warning";
+  title: string;
+  lines: string[];
+}
+
+const CRASH = /crashloop/i;
+const IMAGE = /imagepull|errimage|invalidimagename/i;
+const CONFIG = /createcontainerconfigerror|createcontainererror/i;
+
+export function podProblemCopy(problem: PodProblem, now: number = Date.now()): PodProblemCopy {
+  void now;
+  const lines: string[] = [];
+
+  if (!problem.container) {
+    // The scheduler could not place the pod.
+    lines.push(problem.message ? problem.message : `Reason: ${problem.reason}`);
+    return { tone: "warning", title: "Pod cannot be scheduled", lines };
+  }
+
+  const who = `${problem.init ? "Init container" : "Container"} ${problem.container}`;
+  let title: string;
+  let tone: PodProblemCopy["tone"] = "error";
+  if (CRASH.test(problem.reason)) title = `${who} is crash-looping`;
+  else if (IMAGE.test(problem.reason)) title = `${who} cannot pull its image`;
+  else if (CONFIG.test(problem.reason)) title = `${who} cannot be created`;
+  else if (/oom/i.test(problem.reason)) title = `${who} was OOM-killed`;
+  else title = `${who} failed: ${problem.reason}`;
+
+  if (problem.exitCode !== undefined || problem.lastReason) {
+    const parts = [`Last exit: code ${problem.exitCode ?? "?"}`];
+    if (problem.lastReason) parts.push(problem.lastReason);
+    if (problem.lastFinishedAt) parts.push(`${formatAge(problem.lastFinishedAt)} ago`);
+    lines.push(parts.join(" · "));
+  }
+  if (problem.restartCount > 0) {
+    lines.push(`${problem.restartCount} restart${problem.restartCount === 1 ? "" : "s"}`);
+  }
+  if (problem.message) lines.push(problem.message.trim());
+
+  return { tone, title, lines };
+}

--- a/src/lib/components/details/pod-details.test.ts
+++ b/src/lib/components/details/pod-details.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { podProblemCopy } from "./pod-details.logic";
+
+describe("podProblemCopy", () => {
+  test("a crash-looping container names the container, the last exit and the restarts", () => {
+    const copy = podProblemCopy({
+      container: "api", init: false, reason: "CrashLoopBackOff", message: "back-off 5m0s restarting failed container",
+      exitCode: 1, lastReason: "Error", lastFinishedAt: new Date(Date.now() - 3 * 60_000).toISOString(), restartCount: 7,
+    });
+    expect(copy.tone).toBe("error");
+    expect(copy.title).toBe("Container api is crash-looping");
+    expect(copy.lines[0]).toMatch(/^Last exit: code 1 · Error · 3m ago$/);
+    expect(copy.lines[1]).toBe("7 restarts");
+    expect(copy.lines[2]).toBe("back-off 5m0s restarting failed container");
+  });
+
+  test("image pull, init container, and generic reasons", () => {
+    expect(podProblemCopy({ container: "web", reason: "ImagePullBackOff", restartCount: 0 }).title).toBe("Container web cannot pull its image");
+    expect(podProblemCopy({ container: "migrate", init: true, reason: "Error", exitCode: 2, restartCount: 1 })).toMatchObject({
+      title: "Init container migrate failed: Error",
+      lines: ["Last exit: code 2", "1 restart"],
+    });
+    expect(podProblemCopy({ container: "app", reason: "OOMKilled", exitCode: 137, restartCount: 3 }).title).toBe("Container app was OOM-killed");
+  });
+
+  test("an unschedulable pod is a warning with the scheduler's message", () => {
+    expect(podProblemCopy({ reason: "Unschedulable", message: "0/3 nodes are available: 3 Insufficient cpu.", restartCount: 0 })).toEqual({
+      tone: "warning",
+      title: "Pod cannot be scheduled",
+      lines: ["0/3 nodes are available: 3 Insufficient cpu."],
+    });
+    expect(podProblemCopy({ reason: "Unschedulable", restartCount: 0 }).lines).toEqual(["Reason: Unschedulable"]);
+  });
+});

--- a/src/lib/components/details/service-details.logic.ts
+++ b/src/lib/components/details/service-details.logic.ts
@@ -1,0 +1,74 @@
+// Pure derivations for ServiceDetails: which Ingresses route to the service,
+// which controllers stand behind the pods its selector matches, and which
+// matched pods are not in any EndpointSlice yet. Testable under bun.
+
+import type { Resource } from "$lib/types";
+import { podOwner } from "$lib/utils/pod-status";
+import type { EndpointAddress } from "$lib/utils/service-info";
+
+type Json = Record<string, unknown>;
+
+export interface IngressRoute {
+  /** The Ingress name. */
+  name: string;
+  /** `host` + `path` pairs that point at this service, joined for display. */
+  routes: string[];
+}
+
+/**
+ * The Ingresses whose rules (or default backend) send traffic to `serviceName`,
+ * with a short "host path" note per matching path.
+ */
+export function ingressesForService(ingresses: Resource[], serviceName: string): IngressRoute[] {
+  const out: IngressRoute[] = [];
+  for (const ing of ingresses) {
+    const spec = (ing.spec ?? {}) as Json;
+    const routes: string[] = [];
+    const defaultBackend = spec.defaultBackend as { service?: { name?: string } } | undefined;
+    if (defaultBackend?.service?.name === serviceName) routes.push("default backend");
+    const rules = Array.isArray(spec.rules) ? (spec.rules as Array<Json>) : [];
+    for (const rule of rules) {
+      const host = typeof rule.host === "string" ? rule.host : "*";
+      const http = rule.http as { paths?: Array<{ path?: string; backend?: { service?: { name?: string } } }> } | undefined;
+      for (const p of http?.paths ?? []) {
+        if (p.backend?.service?.name === serviceName) routes.push(`${host} ${p.path ?? "/"}`.trim());
+      }
+    }
+    if (routes.length > 0) out.push({ name: ing.metadata.name, routes });
+  }
+  return out;
+}
+
+export interface OwnerRef {
+  kind: string;
+  name: string;
+}
+
+/** Distinct controllers (ReplicaSet, StatefulSet…) behind the matched pods, in first-seen order. */
+export function podControllers(pods: Resource[]): OwnerRef[] {
+  const seen = new Set<string>();
+  const out: OwnerRef[] = [];
+  for (const pod of pods) {
+    const owner = podOwner(pod);
+    if (!owner) continue;
+    const key = `${owner.kind}/${owner.name}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ kind: owner.kind, name: owner.name });
+  }
+  return out;
+}
+
+/** Pods the selector matches that no EndpointSlice lists yet (not ready, or not yet reconciled). */
+export function podsMissingFromSlices(pods: Resource[], addresses: EndpointAddress[]): Resource[] {
+  const listed = new Set(addresses.map((a) => a.targetRef?.name).filter((n): n is string => Boolean(n)));
+  return pods.filter((p) => !listed.has(p.metadata.name));
+}
+
+/** Distinct EndpointSlice names + address types for the footer line. */
+export function sliceSummaryLine(slices: Resource[]): string {
+  if (slices.length === 0) return "";
+  const names = slices.map((s) => s.metadata.name);
+  const types = [...new Set(slices.map((s) => ((s.spec as Json | undefined)?.addressType as string) ?? (s as unknown as Json).addressType as string).filter(Boolean))];
+  return [`EndpointSlice ${names.join(", ")}`, ...types].join(" · ");
+}

--- a/src/lib/components/details/service-details.logic.ts
+++ b/src/lib/components/details/service-details.logic.ts
@@ -19,9 +19,11 @@ export interface IngressRoute {
  * The Ingresses whose rules (or default backend) send traffic to `serviceName`,
  * with a short "host path" note per matching path.
  */
-export function ingressesForService(ingresses: Resource[], serviceName: string): IngressRoute[] {
+export function ingressesForService(ingresses: Resource[], serviceName: string, namespace?: string | null): IngressRoute[] {
   const out: IngressRoute[] = [];
   for (const ing of ingresses) {
+    // Ingress backends resolve in the Ingress's own namespace.
+    if (namespace != null && namespace !== "" && ing.metadata.namespace !== namespace) continue;
     const spec = (ing.spec ?? {}) as Json;
     const routes: string[] = [];
     const defaultBackend = spec.defaultBackend as { service?: { name?: string } } | undefined;

--- a/src/lib/components/details/service-details.test.ts
+++ b/src/lib/components/details/service-details.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import { ingressesForService, podControllers, podsMissingFromSlices, sliceSummaryLine } from "./service-details.logic";
+
+function res(name: string, spec: Record<string, unknown> = {}, owners: Array<{ kind: string; name: string }> = []): Resource {
+  return {
+    kind: "X",
+    api_version: "v1",
+    metadata: {
+      name, namespace: "ns", uid: name, creation_timestamp: "", labels: {}, annotations: {}, resource_version: "1",
+      owner_references: owners.map((o) => ({ api_version: "apps/v1", uid: "o", controller: true, ...o })),
+    },
+    spec,
+    status: {},
+  };
+}
+
+describe("ingressesForService", () => {
+  test("matches rule paths and the default backend, with host + path notes", () => {
+    const ingresses = [
+      res("shop-public", {
+        rules: [
+          { host: "shop.example.com", http: { paths: [{ path: "/", backend: { service: { name: "web" } } }, { path: "/api", backend: { service: { name: "api" } } }] } },
+          { http: { paths: [{ backend: { service: { name: "web" } } }] } },
+        ],
+      }),
+      res("fallback", { defaultBackend: { service: { name: "web" } } }),
+      res("other", { rules: [{ host: "x", http: { paths: [{ path: "/", backend: { service: { name: "api" } } }] } }] }),
+    ];
+    expect(ingressesForService(ingresses, "web")).toEqual([
+      { name: "shop-public", routes: ["shop.example.com /", "* /"] },
+      { name: "fallback", routes: ["default backend"] },
+    ]);
+    expect(ingressesForService(ingresses, "nothing")).toEqual([]);
+  });
+});
+
+describe("podControllers / podsMissingFromSlices", () => {
+  test("dedupes controllers in first-seen order", () => {
+    const pods = [
+      res("a", {}, [{ kind: "ReplicaSet", name: "web-1" }]),
+      res("b", {}, [{ kind: "ReplicaSet", name: "web-1" }]),
+      res("c", {}, [{ kind: "StatefulSet", name: "db" }]),
+      res("d"),
+    ];
+    expect(podControllers(pods)).toEqual([{ kind: "ReplicaSet", name: "web-1" }, { kind: "StatefulSet", name: "db" }]);
+  });
+
+  test("pods not listed by any endpoint address", () => {
+    const pods = [res("a"), res("b"), res("c")];
+    const addresses = [
+      { address: "1", ready: true, serving: true, terminating: false, targetRef: { kind: "Pod", name: "a" } },
+      { address: "2", ready: false, serving: false, terminating: false },
+    ];
+    expect(podsMissingFromSlices(pods, addresses).map((p) => p.metadata.name)).toEqual(["b", "c"]);
+  });
+
+  test("slice summary line", () => {
+    expect(sliceSummaryLine([])).toBe("");
+    expect(sliceSummaryLine([res("web-9xk2m", { addressType: "IPv4" }), res("web-abc", { addressType: "IPv4" })])).toBe("EndpointSlice web-9xk2m, web-abc · IPv4");
+  });
+});

--- a/src/lib/components/details/service-details.test.ts
+++ b/src/lib/components/details/service-details.test.ts
@@ -32,6 +32,9 @@ describe("ingressesForService", () => {
       { name: "fallback", routes: ["default backend"] },
     ]);
     expect(ingressesForService(ingresses, "nothing")).toEqual([]);
+    // Scoped to a namespace, an Ingress from another namespace does not count.
+    expect(ingressesForService(ingresses, "web", "ns")).toHaveLength(2);
+    expect(ingressesForService(ingresses, "web", "elsewhere")).toEqual([]);
   });
 });
 

--- a/src/lib/components/table/ColumnPicker.svelte
+++ b/src/lib/components/table/ColumnPicker.svelte
@@ -62,7 +62,7 @@
           title={autoHidden ? "Hidden while one namespace is selected" : undefined}
         >
           <Checkbox
-            checked={!tablePrefs.isHidden(resourceType, column.key) && !autoHidden}
+            checked={!tablePrefs.isHidden(resourceType, column.key, column.defaultHidden) && !autoHidden}
             disabled={locked || autoHidden}
             onCheckedChange={() => tablePrefs.toggleColumn(resourceType, column.key)}
             aria-label="Show {column.label} column"

--- a/src/lib/components/table/ResourceTable.svelte
+++ b/src/lib/components/table/ResourceTable.svelte
@@ -22,6 +22,7 @@
   import { isInputElement } from "$lib/utils/keyboard";
   import { costStore } from "$lib/stores/cost.svelte";
   import { metricsStore, POD_METRICS_TTL_MS } from "$lib/stores/metrics.svelte";
+  import { endpointsStore, ENDPOINTS_TTL_MS } from "$lib/stores/endpoints.svelte";
   import { liveValues } from "$lib/stores/live-values.svelte";
   import { resourceTypeLabel as catalogLabel } from "$lib/resource-catalog";
   import { contextMenuStore } from "$lib/stores/context-menu.svelte";
@@ -46,7 +47,7 @@
   let namespaceAutoHidden = $derived(!!k8sStore.currentNamespace && allColumns.some((c) => c.key === "namespace"));
   let columns = $derived(
     allColumns.filter(
-      (c) => !(c.key === "namespace" && namespaceAutoHidden) && !tablePrefs.isHidden(k8sStore.selectedResourceType, c.key),
+      (c) => !(c.key === "namespace" && namespaceAutoHidden) && !tablePrefs.isHidden(k8sStore.selectedResourceType, c.key, c.defaultHidden),
     ),
   );
 
@@ -64,6 +65,7 @@
     if (prevCtx && (ctx !== prevCtx || ns !== prevNs)) {
       costStore.reset();
       metricsStore.reset();
+      endpointsStore.reset();
       // Flashes are keyed by uid; a uid from the cluster we just left would
       // highlight an unrelated row that happens to reuse the key.
       liveValues.clear();
@@ -99,6 +101,19 @@
     return () => clearInterval(timer);
   });
 
+  // EndpointSlices back the Services table's Endpoints column: fetched on
+  // entry, then polled at the store's TTL while the view stays open.
+  $effect(() => {
+    if (k8sStore.selectedResourceType !== "services") return;
+    const ns = k8sStore.currentNamespace;
+    void endpointsStore.load(ns, true);
+    const timer = setInterval(() => {
+      if (document.hidden) return;
+      void endpointsStore.load(ns);
+    }, ENDPOINTS_TTL_MS);
+    return () => clearInterval(timer);
+  });
+
   // Track resized column widths per resource type: { [resourceType]: { [colKey]: widthPx } }
   let columnWidthOverrides: Record<string, Record<string, number>> = $state({});
 
@@ -119,6 +134,7 @@
       nodeMetrics: costStore.getNodeMetrics(r.metadata.name),
       nodeCost: costStore.getNodeCost(r.metadata.name),
       podUsage: metricsStore.getPodUsage(r.metadata.namespace, r.metadata.name),
+      endpoints: endpointsStore.summaryFor(r.metadata.namespace, r.metadata.name),
     };
   }
 

--- a/src/lib/components/table/ResourceTable.test.ts
+++ b/src/lib/components/table/ResourceTable.test.ts
@@ -510,7 +510,9 @@ describe("ResourceTable — filter pipeline", () => {
     expect(applyFilterState(items, { statFilter: "needsAttention", facets: [], text: "" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-2"]);
     expect(applyFilterState(items, { statFilter: null, facets: [{ key: "restarts", op: ">", value: "0" }], text: "" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-2"]);
     expect(applyFilterState(items, { statFilter: null, facets: [], text: "job" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["job-1"]);
-    expect(applyFilterState(items, { statFilter: null, facets: [{ key: "status", op: ":", value: "running" }], text: "api-2" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-2"]);
+    // Status is the effective state, so api-2 (CrashLoopBackOff) is no longer "running".
+    expect(applyFilterState(items, { statFilter: null, facets: [{ key: "status", op: ":", value: "running" }], text: "api" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-1"]);
+    expect(applyFilterState(items, { statFilter: null, facets: [{ key: "status", op: ":", value: "crash" }], text: "api" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-2"]);
   });
   test("countActiveFilters counts each kind once", () => {
     expect(countActiveFilters({ facets: [], text: "", statFilter: null })).toBe(0);

--- a/src/lib/components/table/TableRow.svelte
+++ b/src/lib/components/table/TableRow.svelte
@@ -7,6 +7,7 @@
   import { k8sStore } from "$lib/stores/k8s.svelte";
   import { costStore } from "$lib/stores/cost.svelte";
   import { metricsStore } from "$lib/stores/metrics.svelte";
+  import { endpointsStore } from "$lib/stores/endpoints.svelte";
   import { extensions } from "$lib/extensions";
   import { KIND_TO_RESOURCE_TYPE } from "$lib/resource-catalog";
   import { openRelatedResourceTab } from "$lib/actions/navigation";
@@ -20,7 +21,13 @@
     isStatusColumn,
     isTagColumn,
     isUsageColumn,
+    statusDetail,
   } from "./cell-values";
+  import { podReadyCount, podRestarts } from "$lib/utils/pod-status";
+  import { replicaSegments, shortImage, templateImages } from "$lib/utils/workload-status";
+  import { serviceExternal } from "$lib/utils/service-info";
+  import { formatAge } from "$lib/utils/age";
+  import ReplicaBar from "$lib/components/common/ReplicaBar.svelte";
   import { statusCategory, statusColor, isQuietStatus, rowSeverity } from "./status-category";
   import { splitPodName } from "./table-filter";
   import { ROW_HEIGHT, DENSITY_CLASSES } from "./table-density";
@@ -73,6 +80,9 @@
     nodeMetrics: costStore.getNodeMetrics(resource.metadata.name),
     podUsage: metricsStore.getPodUsage(resource.metadata.namespace, resource.metadata.name),
     autoscaler: flavor ? autoscalerSummary(resource, flavor) : undefined,
+    endpoints: resourceType === "services"
+      ? endpointsStore.summaryFor(resource.metadata.namespace, resource.metadata.name)
+      : undefined,
   });
 
   // Which of this row's values moved on the last watch delta. Bailing out
@@ -235,19 +245,103 @@
             </span>
           {/if}
         </span>
+      {:else if column.key === "podReady"}
+        <!-- Tiles say which container; the fraction says how many. Amber when
+             not every container is ready, so a 1/2 stands out from a 2/2. -->
+        {@const ready = podReadyCount(resource)}
+        <div class="flex items-center gap-2 overflow-hidden">
+          <ContainersCell {resource} {density} />
+          <span
+            class="shrink-0 font-mono tabular-nums"
+            style:color={ready.total > 0 && ready.ready < ready.total ? "var(--status-pending)" : "var(--text-secondary)"}
+          >{ready.ready}/{ready.total}</span>
+        </div>
+      {:else if column.key === "deployReady"}
+        {@const seg = replicaSegments(resource)}
+        <div class="flex items-center gap-2.5 overflow-hidden">
+          <span
+            class="shrink-0 font-mono tabular-nums"
+            style:color={seg.ready < seg.desired ? "var(--status-pending)" : "var(--text-secondary)"}
+          >{seg.ready}/{seg.desired}</span>
+          <ReplicaBar ready={seg.ready} pending={seg.pending} missing={seg.missing} />
+        </div>
+      {:else if column.key === "images"}
+        {@const images = templateImages(resource)}
+        {#if images.length === 0}
+          <span class="text-[var(--text-muted)]">—</span>
+        {:else}
+          <div class="flex items-center gap-1.5 overflow-hidden">
+            {#each images.slice(0, 2) as image (image)}
+              <Badge appearance="surface" size="sm" bordered mono class="max-w-[220px] truncate px-1.5" title={image}>{shortImage(image)}</Badge>
+            {/each}
+            {#if images.length > 2}
+              <Badge appearance="surface" size="sm" bordered mono class="px-1.5" title={images.slice(2).join(", ")}>+{images.length - 2}</Badge>
+            {/if}
+          </div>
+        {/if}
+      {:else if column.key === "endpoints"}
+        {@const summary = cellCtx.endpoints}
+        {#if summary === undefined}
+          <!-- Slices not loaded yet: blank rather than a wrong zero. -->
+          <span></span>
+        {:else if summary === null}
+          <span class="text-[var(--text-muted)]" title="No EndpointSlice for this service">—</span>
+        {:else if summary.total === 0}
+          <span class="inline-flex items-center gap-1.5" title="No endpoints: nothing backs this service">
+            <span class="h-[5px] w-[5px] shrink-0 rounded-full bg-[var(--status-failed)]"></span>
+            <span class="font-mono tabular-nums text-[var(--status-failed)]">0</span>
+            <span class="truncate text-[11px] text-[var(--status-failed)]">no backends</span>
+          </span>
+        {:else}
+          <span
+            class="font-mono tabular-nums"
+            style:color={summary.ready < summary.total ? "var(--status-pending)" : "var(--text-secondary)"}
+            title="{summary.ready} ready of {summary.total}{summary.terminating ? ` · ${summary.terminating} terminating` : ''}"
+          >{summary.ready}/{summary.total}</span>
+        {/if}
+      {:else if column.key === "externalIP"}
+        {@const external = serviceExternal(resource)}
+        {#if external.label}
+          <span class="block truncate font-mono tabular-nums text-[var(--text-secondary)]" title={external.label}>{external.label}</span>
+        {:else if external.pending}
+          <span class="inline-flex max-w-full items-center gap-1.5 overflow-hidden" title="LoadBalancer has no address yet">
+            <span
+              class="inline-flex shrink-0 items-center gap-1.5 rounded-sm px-1.5 text-[11px] font-medium leading-4"
+              style="color: var(--status-pending); background-color: color-mix(in srgb, var(--status-pending) 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-pending) 25%, transparent);"
+            >
+              <span class="h-[5px] w-[5px] rounded-full bg-[var(--status-pending)]"></span>Pending
+            </span>
+            <span class="truncate text-[11px] text-[var(--text-muted)]">no address yet</span>
+          </span>
+        {:else}
+          <span class="text-[var(--text-muted)]">—</span>
+        {/if}
+      {:else if column.key === "controlledBy"}
+        {@const owner = getCellValue(resource, column.key, cellCtx)}
+        {#if owner === "-"}
+          <span class="text-[var(--text-muted)]">—</span>
+        {:else}
+          {@const slash = owner.indexOf("/")}
+          <span class="flex items-center gap-1.5 overflow-hidden" title={owner}>
+            <span class="shrink-0 text-[10px] font-medium uppercase tracking-[0.04em] text-[var(--text-muted)]">{owner.slice(0, slash)}</span>
+            <span class="truncate font-mono text-[11px] text-[var(--text-secondary)]">{owner.slice(slash + 1)}</span>
+          </span>
+        {/if}
       {:else if isStatusColumn(column.key)}
         {@const val = getCellValue(resource, column.key, cellCtx)}
+        {@const detail = statusDetail(resource, column.key)}
         {#if val === "-"}
           <span class="text-[var(--text-muted)]">-</span>
         {:else}
           {@const category = statusCategory(val)}
+          <span class="flex items-center gap-1.5 overflow-hidden">
           {#if isQuietStatus(category)}
             <!-- Healthy / finished: plain muted text. Colour is reserved for
                  rows that need a look. -->
-            <span class="block truncate text-[var(--text-muted)]" title={val}>{val}</span>
+            <span class="truncate text-[var(--text-muted)]" title={val}>{val}</span>
           {:else if d.pill}
             <span
-              class="inline-flex max-w-full items-center gap-1.5 truncate rounded-sm px-1.5 text-[11px] font-medium leading-4"
+              class="inline-flex max-w-full shrink-0 items-center gap-1.5 truncate rounded-sm px-1.5 text-[11px] font-medium leading-4"
               style="color: {statusColor(category)}; background-color: color-mix(in srgb, {statusColor(category)} 12%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, {statusColor(category)} 25%, transparent);"
               title={val}
             >
@@ -255,19 +349,33 @@
               <span class="truncate">{val}</span>
             </span>
           {:else}
-            <span class="block truncate font-medium" style="color: {statusColor(category)}" title={val}>{val}</span>
+            <span class="truncate font-medium" style="color: {statusColor(category)}" title={val}>{val}</span>
           {/if}
+          {#if detail}
+            <!-- The reason behind the word: Unschedulable, MinimumReplicasUnavailable… -->
+            <span class="truncate text-[11px] text-[var(--text-muted)]" title={detail}>{detail}</span>
+          {/if}
+          </span>
         {/if}
       {:else if column.key === "restarts"}
-        {@const restarts = parseInt(getCellValue(resource, "restarts", cellCtx), 10) || 0}
-        <span
-          class={cn("font-mono tabular-nums", restarts > 5 && "font-medium")}
-          style:color={restarts > 5
-            ? "var(--status-failed)"
-            : restarts > 0
-              ? "var(--status-pending)"
-              : "color-mix(in srgb, var(--text-muted) 55%, var(--bg-primary))"}
-        >{restarts}</span>
+        {@const restartInfo = podRestarts(resource)}
+        {@const restarts = restartInfo.count}
+        <span class="inline-flex items-baseline justify-end gap-1.5 overflow-hidden">
+          <span
+            class={cn("font-mono tabular-nums", restarts > 5 && "font-medium")}
+            style:color={restarts > 5
+              ? "var(--status-failed)"
+              : restarts > 0
+                ? "var(--status-pending)"
+                : "color-mix(in srgb, var(--text-muted) 55%, var(--bg-primary))"}
+          >{restarts}</span>
+          {#if restarts > 0 && restartInfo.lastAt}
+            <!-- When the last one happened: 7 restarts three days ago is not
+                 7 restarts in the last hour. ageTick keeps it live. -->
+            {@const _tick = cellCtx.ageTick}
+            <span class="shrink-0 font-mono text-[10px] text-[var(--text-muted)]" title="Last restart {restartInfo.lastAt}">↻ {formatAge(restartInfo.lastAt)}</span>
+          {/if}
+        </span>
       {:else if column.key === "eventObject" && eventObjectTarget}
         {@const label = getCellValue(resource, column.key, cellCtx)}
         {@const target = eventObjectTarget}

--- a/src/lib/components/table/cell-values.test.ts
+++ b/src/lib/components/table/cell-values.test.ts
@@ -90,6 +90,42 @@ describe("getCellValue — pods and workloads", () => {
 });
 
 describe("getCellValue — services and endpoints", () => {
+  test("pods: effective status, ready fraction, owner", () => {
+    const crashing = res({
+      status: { phase: "Running", containerStatuses: [{ name: "a", ready: true, restartCount: 0, state: { running: {} } }, { name: "b", ready: false, restartCount: 3, state: { waiting: { reason: "CrashLoopBackOff" } } }] },
+    });
+    crashing.kind = "Pod";
+    expect(getCellValue(crashing, "status")).toBe("CrashLoopBackOff");
+    expect(getCellValue(crashing, "podReady")).toBe("1/2");
+    const notPod = res({ status: { phase: "Running" } });
+    expect(getCellValue(notPod, "status")).toBe("Running");
+    const owned = res({});
+    owned.metadata.owner_references = [{ api_version: "apps/v1", kind: "ReplicaSet", name: "api-7d9f", uid: "o", controller: true }];
+    expect(getCellValue(owned, "controlledBy")).toBe("rs/api-7d9f");
+    expect(getCellValue(res({}), "controlledBy")).toBe("-");
+  });
+
+  test("deployments: derived status, images, pod count", () => {
+    const d = res({
+      spec: { replicas: 3, template: { spec: { containers: [{ image: "ghcr.io/shop/api:2.4.1" }, { image: "otel/collector:0.98.0" }] } } },
+      status: { replicas: 4, readyReplicas: 3, updatedReplicas: 1, conditions: [{ type: "Progressing", status: "True", reason: "ReplicaSetUpdated" }] },
+    });
+    expect(getCellValue(d, "deployStatus")).toBe("Progressing");
+    expect(getCellValue(d, "images")).toBe("api:2.4.1, collector:0.98.0");
+    expect(getCellValue(d, "pods")).toBe("4");
+    expect(getCellValue(res({}), "images")).toBe("-");
+  });
+
+  test("services: external pending, ports with targets, endpoints from context", () => {
+    expect(getCellValue(res({ spec: { type: "LoadBalancer" } }), "externalIP")).toBe("<pending>");
+    expect(getCellValue(res({ spec: { ports: [{ port: 80, targetPort: 8080 }, { port: 443, targetPort: 443, nodePort: 30443 }] } }), "ports")).toBe("80→8080/TCP, 443/TCP :30443");
+    expect(getCellValue(res({ spec: { selector: { app: "web" } } }), "selector")).toBe("app=web");
+    const svc = res({});
+    expect(getCellValue(svc, "endpoints")).toBe("");
+    expect(getCellValue(svc, "endpoints", { ageTick: 0, endpoints: null })).toBe("-");
+    expect(getCellValue(svc, "endpoints", { ageTick: 0, endpoints: { ready: 2, total: 3, terminating: 0 } })).toBe("2/3");
+  });
+
   test("externalIP prefers the load balancer, then spec.externalIPs", () => {
     const lb = res({ status: { loadBalancer: { ingress: [{ ip: "1.2.3.4" }] } } });
     expect(getCellValue(lb, "externalIP")).toBe("1.2.3.4");

--- a/src/lib/components/table/cell-values.ts
+++ b/src/lib/components/table/cell-values.ts
@@ -11,6 +11,9 @@ import { formatAge } from "$lib/utils/age";
 import { cpuCell, memoryCell, formatCpu, formatBytes } from "$lib/stores/metrics.logic";
 import type { AutoscalerSummary } from "$lib/utils/autoscaler";
 import { formatReplicas, formatTargets } from "$lib/utils/autoscaler";
+import { podOwner, podReadyCount, podStatus } from "$lib/utils/pod-status";
+import { deploymentStatus, shortImage, templateImages } from "$lib/utils/workload-status";
+import { serviceExternal, servicePortsLabel, serviceSelector, type EndpointSummary } from "$lib/utils/service-info";
 
 /**
  * Everything a cell needs that does not live on the Resource itself. The row
@@ -33,6 +36,11 @@ export interface CellContext {
    * for the same answer.
    */
   autoscaler?: AutoscalerSummary;
+  /**
+   * EndpointSlice summary for a Service row: undefined while the slices for
+   * its namespace are not loaded, null when it has none.
+   */
+  endpoints?: EndpointSummary | null;
 }
 
 /** Placeholder for "this resource has no such value". */
@@ -99,6 +107,9 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
       return formatAge(meta.creation_timestamp);
     case "status":
     case "phase":
+      // A pod's status is what kubectl prints, not its phase: a Running pod
+      // with a crash-looping container reads CrashLoopBackOff.
+      if (resource.kind === "Pod") return podStatus(resource).label;
       return str(status.phase ?? status.status);
     case "data": {
       const data = resource.data ?? spec.data ?? status.data;
@@ -116,6 +127,14 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
       if (!statuses) return "0";
       return statuses.reduce((sum, c) => sum + (c.restartCount ?? 0), 0).toString();
     }
+    case "podReady": {
+      const { ready: r, total } = podReadyCount(resource);
+      return `${r}/${total}`;
+    }
+    case "controlledBy": {
+      const owner = podOwner(resource);
+      return owner ? `${owner.short}/${owner.name}` : NONE;
+    }
     case "node":
       return str(spec.nodeName ?? status.nodeName);
     case "ip":
@@ -124,6 +143,12 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
     // --- Workloads ---------------------------------------------------------
     case "deployReady":
       return `${(status.readyReplicas as number) ?? 0}/${(spec.replicas as number) ?? 0}`;
+    case "deployStatus":
+      return deploymentStatus(resource).label;
+    case "images":
+      return summarize(templateImages(resource).map(shortImage), 3);
+    case "pods":
+      return ((status.replicas as number) ?? 0).toString();
     case "upToDate":
       return ((status.updatedReplicas as number) ?? 0).toString();
     case "available":
@@ -135,14 +160,20 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
     case "clusterIP":
       return str(spec.clusterIP);
     case "externalIP": {
-      const lb = status.loadBalancer as { ingress?: Array<{ ip: string }> } | undefined;
-      if (lb?.ingress?.length) return lb.ingress.map((e) => e.ip).join(", ");
-      return (spec.externalIPs as string[])?.join(", ") ?? NONE;
+      const external = serviceExternal(resource);
+      if (external.label) return external.label;
+      return external.pending ? "<pending>" : NONE;
     }
-    case "ports": {
-      const ports = spec.ports as Array<{ port: number; protocol?: string }> | undefined;
-      if (!ports) return NONE;
-      return ports.map((p) => `${p.port}/${p.protocol ?? "TCP"}`).join(", ");
+    case "ports":
+      return servicePortsLabel(resource) || NONE;
+    case "selector":
+      return summarize(serviceSelector(resource), 3);
+    case "endpoints": {
+      // Blank (not "-") until the slices are loaded, so a half-rendered table
+      // never claims a service has no backends.
+      if (ctx.endpoints === undefined) return "";
+      if (ctx.endpoints === null) return NONE;
+      return `${ctx.endpoints.ready}/${ctx.endpoints.total}`;
     }
     case "endpointAddresses": {
       // Endpoints keeps addresses under subsets[]; show the first few with the
@@ -287,7 +318,7 @@ export function getCellValue(resource: Resource, key: string, ctx: CellContext):
 
 /** Numeric / identifier cells, rendered in monospace tabular figures. */
 const MONO_COLUMNS = new Set([
-  "age", "ready", "deployReady", "upToDate", "available",
+  "age", "ready", "podReady", "controlledBy", "deployReady", "upToDate", "available", "pods", "endpoints", "selector",
   "rsDesired", "rsCurrent", "rsReady", "stsReady",
   "dsDesired", "dsCurrent", "dsReady", "dsAvailable",
   "jobCompletions", "jobDuration", "cjSchedule", "cjActive", "cjLastSchedule",
@@ -318,7 +349,18 @@ export const isMonoColumn = (key: string): boolean => MONO_COLUMNS.has(key);
 export const isTagColumn = (key: string): boolean => TAG_COLUMNS.has(key);
 export const isUsageColumn = (key: string): boolean => USAGE_COLUMNS.has(key);
 export const isStatusColumn = (key: string): boolean =>
-  key === "status" || key === "phase" || key === "eventType";
+  key === "status" || key === "phase" || key === "eventType" || key === "deployStatus";
+
+/**
+ * The muted note a status cell carries after its pill: why a pod is Pending
+ * (Unschedulable), the condition reason behind a Deployment's state
+ * (MinimumReplicasUnavailable). Empty when the word says it all.
+ */
+export function statusDetail(resource: Resource, key: string): string {
+  if (key === "deployStatus") return deploymentStatus(resource).detail ?? "";
+  if ((key === "status" || key === "phase") && resource.kind === "Pod") return podStatus(resource).reason ?? "";
+  return "";
+}
 export const isContainersColumn = (key: string): boolean => key === "containers";
 
 // ---------------------------------------------------------------------------

--- a/src/lib/components/table/saved-views.ts
+++ b/src/lib/components/table/saved-views.ts
@@ -20,7 +20,10 @@ const BUILTINS: Record<string, Array<Omit<SavedView, "resourceType">>> = {
   ],
   deployments: [
     ALL,
-    { id: "degraded", name: "Degraded", facets: [], text: "", statFilter: "degraded", builtin: true },
+    // "Degraded" alone missed the deployments with zero available replicas
+    // (classified as failing), which is the first thing the view is for.
+    { id: "unhealthy", name: "Unhealthy", facets: [], text: "", statFilter: "unhealthy", builtin: true },
+    { id: "rolling-out", name: "Rolling out", facets: [], text: "", statFilter: "rollingOut", builtin: true },
   ],
   nodes: [
     ALL,

--- a/src/lib/components/table/status-category.test.ts
+++ b/src/lib/components/table/status-category.test.ts
@@ -10,6 +10,21 @@ describe("status category", () => {
     expect(statusCategory("Terminating")).toBe("orange");
     expect(statusCategory("whatever")).toBe("muted");
   });
+  test("derived pod and workload statuses", () => {
+    expect(statusCategory("Init:1/2")).toBe("warning");
+    expect(statusCategory("Init:CrashLoopBackOff")).toBe("error");
+    expect(statusCategory("Init:Error")).toBe("error");
+    expect(statusCategory("ExitCode:137")).toBe("error");
+    expect(statusCategory("Signal:9")).toBe("error");
+    expect(statusCategory("NotReady")).toBe("warning");
+    expect(statusCategory("CreateContainerConfigError")).toBe("error");
+    expect(statusCategory("Progressing")).toBe("warning");
+    expect(statusCategory("Paused")).toBe("warning");
+    expect(statusCategory("Unavailable")).toBe("error");
+    expect(statusCategory("Scaled to 0")).toBe("muted");
+    expect(statusCategory("SomethingBackOff")).toBe("error");
+    expect(statusCategory("ContainerCreating")).toBe("warning");
+  });
   test("healthy and finished rows are quiet; problems are not", () => {
     expect(isQuietStatus("success")).toBe(true);
     expect(isQuietStatus("info")).toBe(true);

--- a/src/lib/components/table/status-category.ts
+++ b/src/lib/components/table/status-category.ts
@@ -26,10 +26,32 @@ const STATUS_CATEGORY: Record<string, StatusCategory> = {
   "false": "error",
   terminating: "orange",
   unknown: "muted",
+  // Pods: what podStatus() derives from container states
+  notready: "warning",
+  podinitializing: "warning",
+  unschedulable: "warning",
+  createcontainerconfigerror: "error",
+  createcontainererror: "error",
+  invalidimagename: "error",
+  runcontainererror: "error",
+  containercannotrun: "error",
+  deadlineexceeded: "error",
+  nodelost: "error",
+  shutdown: "error",
+  // Workloads: deploymentStatus()
+  progressing: "warning",
+  paused: "warning",
+  unavailable: "error",
+  replicafailure: "error",
+  "scaled to 0": "muted",
   // core/v1 Event types (global Events view)
   normal: "muted",
   warning: "warning",
 };
+
+/** Reasons the map does not spell out, by shape. */
+const ERROR_SHAPE = /error|backoff|crash|oom|fail|invalid|exceeded|killed/;
+const WARNING_SHAPE = /pending|waiting|creating|initializing|progressing|terminat/;
 
 const CATEGORY_COLOR: Record<StatusCategory, string> = {
   success: "var(--status-running)",
@@ -41,7 +63,18 @@ const CATEGORY_COLOR: Record<StatusCategory, string> = {
 };
 
 export function statusCategory(status: string): StatusCategory {
-  return STATUS_CATEGORY[status.toLowerCase()] ?? "muted";
+  const lower = status.toLowerCase();
+  const known = STATUS_CATEGORY[lower];
+  if (known) return known;
+  // "Init:CrashLoopBackOff" takes its inner reason's colour; "Init:1/2" is progress.
+  if (lower.startsWith("init:")) {
+    const inner = lower.slice(5);
+    return STATUS_CATEGORY[inner] ?? (ERROR_SHAPE.test(inner) ? "error" : "warning");
+  }
+  if (lower.startsWith("exitcode:") || lower.startsWith("signal:")) return "error";
+  if (ERROR_SHAPE.test(lower)) return "error";
+  if (WARNING_SHAPE.test(lower)) return "warning";
+  return "muted";
 }
 
 export function statusColor(category: StatusCategory): string {

--- a/src/lib/components/table/table-columns.test.ts
+++ b/src/lib/components/table/table-columns.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { columnsByType, migrateHiddenPrefs, minimumTableWidth } from "./table-columns";
+
+describe("migrateHiddenPrefs", () => {
+  test("drops v1 entries for columns that are hidden by default, keeps the rest", () => {
+    // A v1 user who hid Up-to-date (then shown by default) and Age: Up-to-date
+    // is now defaultHidden, so its entry would flip it visible — drop it.
+    expect(migrateHiddenPrefs({ deployments: ["upToDate", "age"], pods: ["node"] })).toEqual({
+      deployments: ["age"],
+      pods: ["node"],
+    });
+  });
+
+  test("unknown types fall back to the default columns; empty lists vanish", () => {
+    expect(migrateHiddenPrefs({ widgets: ["age"], services: ["selector"] })).toEqual({ widgets: ["age"] });
+  });
+});
+
+describe("columns", () => {
+  test("every default-hidden column still exists for the picker", () => {
+    const hidden = Object.values(columnsByType).flat().filter((c) => c.defaultHidden).map((c) => c.key);
+    expect(hidden).toEqual(expect.arrayContaining(["ip", "upToDate", "available", "selector"]));
+  });
+
+  test("the pods table fits a 1280px window once the namespace column is auto-hidden", () => {
+    const visible = columnsByType.pods.filter((c) => !c.defaultHidden && c.key !== "namespace");
+    expect(minimumTableWidth(visible)).toBeLessThanOrEqual(1280);
+  });
+});

--- a/src/lib/components/table/table-columns.ts
+++ b/src/lib/components/table/table-columns.ts
@@ -6,32 +6,50 @@ import { clampColumnWidth } from "./resource-table";
 // ---------------------------------------------------------------------------
 
 export const columnsByType: Record<string, Column[]> = {
+  // Pods read like `kubectl get pods -o wide`, plus live usage: the Ready
+  // column carries the container tiles with the fraction, Status is the
+  // effective state (CrashLoopBackOff, Init:1/2, Terminating — not the phase),
+  // Restarts says when the last one happened, and the owner is visible so a
+  // long list groups by eye.
   pods: [
     { key: "name", label: "Name", sortable: true },
-    { key: "containers", label: "Containers", sortable: false, width: "120px" },
     { key: "namespace", label: "Namespace", sortable: true, width: "150px" },
-    { key: "status", label: "Status", sortable: true, width: "120px" },
-    { key: "podCpu", label: "CPU", sortable: false, width: "140px" },
-    { key: "podMemory", label: "Memory", sortable: false, width: "150px" },
-    { key: "restarts", label: "Restarts", sortable: true, width: "90px" },
+    { key: "podReady", label: "Ready", sortable: true, width: "112px" },
+    { key: "status", label: "Status", sortable: true, width: "160px" },
+    { key: "restarts", label: "Restarts", sortable: true, width: "110px" },
+    { key: "podCpu", label: "CPU", sortable: false, width: "160px" },
+    { key: "podMemory", label: "Memory", sortable: false, width: "160px" },
     { key: "age", label: "Age", sortable: true, width: "70px" },
-    { key: "node", label: "Node", sortable: true },
+    { key: "controlledBy", label: "Controlled by", sortable: true, width: "180px" },
+    { key: "node", label: "Node", sortable: true, width: "150px" },
+    { key: "ip", label: "IP", sortable: false, width: "120px", defaultHidden: true },
   ],
+  // One Ready cell (fraction + ready/pending/missing bar) and one Status word
+  // from the conditions replace three bare counts, which stay one click away
+  // in the column picker.
   deployments: [
     { key: "name", label: "Name", sortable: true },
     { key: "namespace", label: "Namespace", sortable: true, width: "150px" },
-    { key: "deployReady", label: "Ready", sortable: false, width: "80px" },
-    { key: "upToDate", label: "Up-to-date", sortable: false, width: "90px" },
-    { key: "available", label: "Available", sortable: false, width: "90px" },
+    { key: "deployReady", label: "Ready", sortable: true, width: "150px" },
+    { key: "deployStatus", label: "Status", sortable: true, width: "170px" },
+    { key: "images", label: "Images", sortable: false },
+    { key: "pods", label: "Pods", sortable: true, width: "80px" },
+    { key: "upToDate", label: "Up-to-date", sortable: false, width: "90px", defaultHidden: true },
+    { key: "available", label: "Available", sortable: false, width: "90px", defaultHidden: true },
     { key: "age", label: "Age", sortable: true, width: "80px" },
   ],
+  // Endpoints ready/total comes from EndpointSlices (see endpointsStore): a
+  // service with no backends is the first thing to look for and the one
+  // thing the spec cannot tell you.
   services: [
     { key: "name", label: "Name", sortable: true },
     { key: "namespace", label: "Namespace", sortable: true, width: "150px" },
-    { key: "type", label: "Type", sortable: true, width: "100px" },
+    { key: "type", label: "Type", sortable: true, width: "120px" },
     { key: "clusterIP", label: "Cluster IP", sortable: false, width: "130px" },
-    { key: "externalIP", label: "External IP", sortable: false, width: "130px" },
+    { key: "externalIP", label: "External", sortable: false, width: "200px" },
     { key: "ports", label: "Ports", sortable: false },
+    { key: "endpoints", label: "Endpoints", sortable: true, width: "130px" },
+    { key: "selector", label: "Selector", sortable: false, defaultHidden: true },
     { key: "age", label: "Age", sortable: true, width: "80px" },
   ],
   replicasets: [

--- a/src/lib/components/table/table-columns.ts
+++ b/src/lib/components/table/table-columns.ts
@@ -20,7 +20,7 @@ export const columnsByType: Record<string, Column[]> = {
     { key: "podCpu", label: "CPU", sortable: false, width: "160px" },
     { key: "podMemory", label: "Memory", sortable: false, width: "160px" },
     { key: "age", label: "Age", sortable: true, width: "70px" },
-    { key: "controlledBy", label: "Controlled by", sortable: true, width: "180px" },
+    { key: "controlledBy", label: "Controlled by", sortable: true, width: "170px" },
     { key: "node", label: "Node", sortable: true, width: "150px" },
     { key: "ip", label: "IP", sortable: false, width: "120px", defaultHidden: true },
   ],
@@ -282,6 +282,23 @@ export const defaultColumns: Column[] = [
   { key: "namespace", label: "Namespace", sortable: true, width: "150px" },
   { key: "age", label: "Age", sortable: true, width: "80px" },
 ];
+
+/**
+ * Migrate v1 column preferences. v1 stored the keys the user hid, when every
+ * column was shown by default; today a key in the list means "toggled away
+ * from the default", so a v1 entry for a column that is now `defaultHidden`
+ * (Up-to-date, Available, IP, Selector) would read as "shown" — the opposite
+ * of what the user chose. Dropping those entries keeps the column hidden.
+ */
+export function migrateHiddenPrefs(hidden: Record<string, string[]>): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const [type, keys] of Object.entries(hidden)) {
+    const columns = columnsByType[type] ?? defaultColumns;
+    const kept = keys.filter((key) => !columns.find((c) => c.key === key)?.defaultHidden);
+    if (kept.length > 0) out[type] = kept;
+  }
+  return out;
+}
 
 /** Width of the leading gutter column (severity bar + checkbox). */
 export const GUTTER_WIDTH = 28;

--- a/src/lib/components/table/table-filter.ts
+++ b/src/lib/components/table/table-filter.ts
@@ -24,6 +24,13 @@ const KEY_ALIASES: Record<string, string> = {
   cpu: "podCpu",
   mem: "podMemory",
   memory: "podMemory",
+  ready: "podReady",
+  owner: "controlledBy",
+  controller: "controlledBy",
+  image: "images",
+  ep: "endpoints",
+  endpoint: "endpoints",
+  external: "externalIP",
 };
 
 /** Accessors that work whether or not the type shows them as a column. */

--- a/src/lib/components/table/table-prefs.svelte.ts
+++ b/src/lib/components/table/table-prefs.svelte.ts
@@ -2,7 +2,13 @@
 // wide the detail aside is. localStorage (like the tab session) rather than
 // settings: not cluster state, cheap to lose, one object under one key.
 
-const STORAGE_KEY = "kdashboard-table-prefs-v1";
+import { migrateHiddenPrefs } from "./table-columns";
+
+// v2: hidden keys mean "toggled away from the column's default" (see
+// Column.defaultHidden). v1 (every column shown by default) is read once and
+// migrated — see migrateHiddenPrefs.
+const STORAGE_KEY = "kdashboard-table-prefs-v2";
+const LEGACY_STORAGE_KEY = "kdashboard-table-prefs-v1";
 
 export const ASIDE_MIN_WIDTH = 320;
 export const ASIDE_DEFAULT_WIDTH = 440;
@@ -23,12 +29,19 @@ const DEFAULTS: Prefs = { hidden: {}, asideWidth: ASIDE_DEFAULT_WIDTH };
 function load(): Prefs {
   if (typeof localStorage === "undefined") return DEFAULTS;
   try {
-    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null") as Partial<Prefs> | null;
+    let legacy = false;
+    let stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === null) {
+      stored = localStorage.getItem(LEGACY_STORAGE_KEY);
+      legacy = stored !== null;
+    }
+    const raw = JSON.parse(stored ?? "null") as Partial<Prefs> | null;
     if (!raw || typeof raw !== "object") return DEFAULTS;
-    const hidden: Prefs["hidden"] = {};
+    let hidden: Prefs["hidden"] = {};
     for (const [type, keys] of Object.entries(raw.hidden ?? {})) {
       if (Array.isArray(keys)) hidden[type] = keys.filter((k): k is string => typeof k === "string");
     }
+    if (legacy) hidden = migrateHiddenPrefs(hidden);
     // Only the floor is known here; the ceiling depends on the window, so the
     // aside clamps the rendered width to what the row can spare.
     const asideWidth =

--- a/src/lib/components/table/table-prefs.svelte.ts
+++ b/src/lib/components/table/table-prefs.svelte.ts
@@ -8,7 +8,11 @@ export const ASIDE_MIN_WIDTH = 320;
 export const ASIDE_DEFAULT_WIDTH = 440;
 
 interface Prefs {
-  /** Hidden column keys, per resource type. */
+  /**
+   * Column keys the user toggled away from their default, per resource type.
+   * For a column shown by default that means hidden; for one the type ships
+   * hidden (`Column.defaultHidden`) it means shown.
+   */
   hidden: Record<string, string[]>;
   /** Preferred width of the docked detail aside, in px; the aside caps it to the room it has. */
   asideWidth: number;
@@ -44,8 +48,9 @@ class TablePrefs {
     return this.prefs.asideWidth;
   }
 
-  isHidden(resourceType: string, key: string): boolean {
-    return this.prefs.hidden[resourceType]?.includes(key) ?? false;
+  isHidden(resourceType: string, key: string, defaultHidden = false): boolean {
+    const toggled = this.prefs.hidden[resourceType]?.includes(key) ?? false;
+    return toggled !== defaultHidden;
   }
 
   hiddenCount(resourceType: string): number {

--- a/src/lib/stores/endpoints.logic.test.ts
+++ b/src/lib/stores/endpoints.logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import { SERVICE_NAME_LABEL } from "$lib/utils/service-info";
+import { ENDPOINTS_TTL_MS, EndpointsStoreLogic } from "./endpoints.logic";
+
+function slice(service: string, namespace: string, addresses: string[], ready = true): Resource {
+  return {
+    kind: "EndpointSlice",
+    api_version: "discovery.k8s.io/v1",
+    metadata: { name: `${service}-x`, namespace, uid: "u", creation_timestamp: "", labels: { [SERVICE_NAME_LABEL]: service }, annotations: {}, resource_version: "1", owner_references: [] },
+    spec: { endpoints: [{ addresses, conditions: { ready } }] },
+    status: {},
+  };
+}
+
+describe("EndpointsStoreLogic", () => {
+  test("undefined before a load, null for a service without slices, counts otherwise", () => {
+    const s = new EndpointsStoreLogic();
+    expect(s.summaryFor("ns", "web")).toBeUndefined();
+    s.apply([slice("web", "ns", ["10.0.0.1", "10.0.0.2"]), slice("web", "ns", ["10.0.0.3"], false)], "ns", 1000);
+    expect(s.summaryFor("ns", "web")).toEqual({ ready: 2, total: 3, terminating: 0 });
+    expect(s.summaryFor("ns", "other")).toBeNull();
+    expect(s.slicesFor("ns", "web")).toHaveLength(2);
+  });
+
+  test("a namespace load does not answer for another namespace; an all-namespaces load does", () => {
+    const s = new EndpointsStoreLogic();
+    s.apply([slice("web", "a", ["1"])], "a", 1000);
+    expect(s.summaryFor("b", "web")).toBeUndefined();
+    s.apply([slice("web", "a", ["1"]), slice("web", "b", ["2", "3"])], null, 2000);
+    expect(s.summaryFor("a", "web")?.total).toBe(1);
+    expect(s.summaryFor("b", "web")?.total).toBe(2);
+  });
+
+  test("staleness: never loaded, other namespace, or past the TTL", () => {
+    const s = new EndpointsStoreLogic();
+    expect(s.isStale(0, "a")).toBe(true);
+    s.apply([], "a", 1000);
+    expect(s.isStale(1000 + ENDPOINTS_TTL_MS - 1, "a")).toBe(false);
+    expect(s.isStale(1000 + ENDPOINTS_TTL_MS, "a")).toBe(true);
+    expect(s.isStale(1001, "b")).toBe(true);
+  });
+
+  test("reset forgets everything and invalidates in-flight loads", () => {
+    const s = new EndpointsStoreLogic();
+    s.apply([slice("web", "a", ["1"])], "a", 1000);
+    const id = s._requestId;
+    s.reset();
+    expect(s.summaryFor("a", "web")).toBeUndefined();
+    expect(s._requestId).toBe(id + 1);
+  });
+});

--- a/src/lib/stores/endpoints.logic.test.ts
+++ b/src/lib/stores/endpoints.logic.test.ts
@@ -8,7 +8,8 @@ function slice(service: string, namespace: string, addresses: string[], ready = 
     kind: "EndpointSlice",
     api_version: "discovery.k8s.io/v1",
     metadata: { name: `${service}-x`, namespace, uid: "u", creation_timestamp: "", labels: { [SERVICE_NAME_LABEL]: service }, annotations: {}, resource_version: "1", owner_references: [] },
-    spec: { endpoints: [{ addresses, conditions: { ready } }] },
+    // One endpoint per address: that is how the controller writes slices.
+    spec: { endpoints: addresses.map((a) => ({ addresses: [a], conditions: { ready } })) },
     status: {},
   };
 }

--- a/src/lib/stores/endpoints.logic.ts
+++ b/src/lib/stores/endpoints.logic.ts
@@ -1,0 +1,74 @@
+// EndpointSlices for the Services table and detail: which backends each
+// service really has. Loaded per namespace, indexed by service, refreshed on
+// a TTL like pod metrics. The `.svelte.ts` subclass adds the IPC and $state.
+
+import type { Resource } from "$lib/types";
+import { endpointSummary, SERVICE_NAME_LABEL, type EndpointSummary } from "$lib/utils/service-info";
+
+/** How long a loaded set of slices is trusted before the next table poll refreshes it. */
+export const ENDPOINTS_TTL_MS = 15_000;
+
+export function serviceKey(namespace: string | undefined | null, name: string): string {
+  return `${namespace ?? ""}/${name}`;
+}
+
+export class EndpointsStoreLogic {
+  /** Slices grouped by `${namespace}/${service}`. */
+  byService: Record<string, Resource[]> = {};
+  /** The namespace the slices were loaded for; null = all namespaces. */
+  loadedNamespace: string | null | undefined = undefined;
+  _loading = false;
+  _fetchedAt = 0;
+  _requestId = 0;
+
+  /**
+   * Ready/total for a service. `undefined` while nothing has been loaded for
+   * its namespace (the cell shows nothing rather than a misleading 0); null
+   * when loaded and the service has no slice.
+   */
+  summaryFor(namespace: string | undefined | null, name: string): EndpointSummary | null | undefined {
+    if (!this.covers(namespace)) return undefined;
+    const slices = this.byService[serviceKey(namespace, name)];
+    if (!slices) return null;
+    return endpointSummary(slices, name, namespace);
+  }
+
+  /** The raw slices for one service (detail views). */
+  slicesFor(namespace: string | undefined | null, name: string): Resource[] {
+    return this.byService[serviceKey(namespace, name)] ?? [];
+  }
+
+  /** Whether the loaded set includes this namespace. */
+  covers(namespace: string | undefined | null): boolean {
+    if (this.loadedNamespace === undefined) return false;
+    if (this.loadedNamespace === null || this.loadedNamespace === "") return true;
+    return this.loadedNamespace === (namespace ?? "");
+  }
+
+  isStale(now: number, namespace: string | null): boolean {
+    if (this._fetchedAt === 0) return true;
+    if (!this.covers(namespace)) return true;
+    return now - this._fetchedAt >= ENDPOINTS_TTL_MS;
+  }
+
+  apply(slices: Resource[], namespace: string | null, now: number): void {
+    const map: Record<string, Resource[]> = {};
+    for (const s of slices) {
+      const service = s.metadata?.labels?.[SERVICE_NAME_LABEL];
+      if (!service) continue;
+      const key = serviceKey(s.metadata.namespace, service);
+      (map[key] ??= []).push(s);
+    }
+    this.byService = map;
+    this.loadedNamespace = namespace;
+    this._fetchedAt = now;
+  }
+
+  reset(): void {
+    this.byService = {};
+    this.loadedNamespace = undefined;
+    this._loading = false;
+    this._fetchedAt = 0;
+    this._requestId += 1;
+  }
+}

--- a/src/lib/stores/endpoints.svelte.ts
+++ b/src/lib/stores/endpoints.svelte.ts
@@ -1,0 +1,45 @@
+import { invoke } from "$lib/ipc/core";
+import type { Resource, ResourceList } from "$lib/types";
+import { unshadowState } from "./_unshadow.js";
+import { EndpointsStoreLogic, ENDPOINTS_TTL_MS } from "./endpoints.logic";
+
+class EndpointsStore extends EndpointsStoreLogic {
+  // $state.raw: rebuilt wholesale on every load; the slices are immutable snapshots.
+  override byService = $state.raw<Record<string, Resource[]>>({});
+  override loadedNamespace = $state<string | null | undefined>(undefined);
+
+  constructor() {
+    super();
+    unshadowState(this);
+  }
+
+  /**
+   * Load the EndpointSlices of a namespace ("" / null = all). Self-throttled
+   * to ENDPOINTS_TTL_MS so the table's poll can call it freely.
+   */
+  async load(namespace: string | null, force = false): Promise<void> {
+    const ns = namespace || null;
+    if (this._loading && !force) return;
+    if (!force && !this.isStale(Date.now(), ns)) return;
+    this._loading = true;
+    const requestId = ++this._requestId;
+    try {
+      const result = await invoke<ResourceList>("list_resources", { resourceType: "endpointslices", namespace: ns ?? "" });
+      if (requestId !== this._requestId) return;
+      this.apply(result.items, ns, Date.now());
+    } catch {
+      // No discovery API or no permission: the Endpoints cell stays blank.
+    } finally {
+      if (requestId === this._requestId) this._loading = false;
+    }
+  }
+
+  override reset(): void {
+    super.reset();
+    this.byService = {};
+    this.loadedNamespace = undefined;
+  }
+}
+
+export const endpointsStore = new EndpointsStore();
+export { ENDPOINTS_TTL_MS };

--- a/src/lib/types/kubernetes.ts
+++ b/src/lib/types/kubernetes.ts
@@ -12,6 +12,8 @@ export interface ResourceMetadata {
   namespace?: string;
   uid: string;
   creation_timestamp: string;
+  /** Present once the object is being deleted — the row reads "Terminating". */
+  deletion_timestamp?: string | null;
   labels: Record<string, string>;
   annotations: Record<string, string>;
   owner_references: OwnerReference[];
@@ -92,6 +94,8 @@ export interface Column {
   label: string;
   sortable: boolean;
   width?: string;
+  /** Off by default; the column picker can turn it on. */
+  defaultHidden?: boolean;
 }
 
 export interface ContainerStatus {
@@ -100,6 +104,7 @@ export interface ContainerStatus {
   ready: boolean;
   restartCount: number;
   state: Record<string, unknown>;
+  lastState?: Record<string, unknown>;
   started?: boolean;
 }
 

--- a/src/lib/utils/pod-status.test.ts
+++ b/src/lib/utils/pod-status.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import { orderedPodConditions, podOwner, podProblem, podReadyCount, podRestarts, podStatus } from "./pod-status";
+
+function pod(partial: {
+  phase?: string;
+  reason?: string;
+  deleting?: boolean;
+  containers?: unknown[];
+  init?: unknown[];
+  conditions?: unknown[];
+  owners?: Array<{ kind: string; name: string; controller?: boolean }>;
+  specContainers?: number;
+}): Resource {
+  return {
+    kind: "Pod",
+    api_version: "v1",
+    metadata: {
+      name: "p",
+      namespace: "ns",
+      uid: "u",
+      creation_timestamp: "",
+      deletion_timestamp: partial.deleting ? "2024-01-01T00:00:00Z" : null,
+      labels: {},
+      annotations: {},
+      resource_version: "1",
+      owner_references: (partial.owners ?? []).map((o) => ({ api_version: "apps/v1", uid: "o", ...o })),
+    },
+    spec: { containers: Array.from({ length: partial.specContainers ?? 0 }, (_, i) => ({ name: `c${i}` })) },
+    status: {
+      phase: partial.phase ?? "Running",
+      ...(partial.reason ? { reason: partial.reason } : {}),
+      ...(partial.containers ? { containerStatuses: partial.containers } : {}),
+      ...(partial.init ? { initContainerStatuses: partial.init } : {}),
+      ...(partial.conditions ? { conditions: partial.conditions } : {}),
+    },
+  };
+}
+
+const running = (name = "app", ready = true) => ({ name, ready, restartCount: 0, state: { running: { startedAt: "t" } } });
+
+describe("podStatus", () => {
+  test("a healthy pod is Running", () => {
+    expect(podStatus(pod({ containers: [running()] }))).toEqual({ label: "Running" });
+  });
+
+  test("a waiting container's reason wins over phase Running", () => {
+    const p = pod({ containers: [running("sidecar"), { name: "app", ready: false, restartCount: 7, state: { waiting: { reason: "CrashLoopBackOff" } } }] });
+    expect(podStatus(p).label).toBe("CrashLoopBackOff");
+  });
+
+  test("ImagePullBackOff on a Pending pod", () => {
+    const p = pod({ phase: "Pending", containers: [{ name: "app", ready: false, state: { waiting: { reason: "ImagePullBackOff" } } }] });
+    expect(podStatus(p).label).toBe("ImagePullBackOff");
+  });
+
+  test("init containers: progress, then a failing one", () => {
+    const pending = pod({
+      phase: "Pending",
+      init: [{ name: "i0", state: { terminated: { exitCode: 0 } } }, { name: "i1", state: { waiting: { reason: "PodInitializing" } } }],
+    });
+    expect(podStatus(pending).label).toBe("Init:1/2");
+    const failing = pod({
+      phase: "Pending",
+      init: [{ name: "i0", state: { waiting: { reason: "CrashLoopBackOff" } } }],
+    });
+    expect(podStatus(failing).label).toBe("Init:CrashLoopBackOff");
+    const crashed = pod({ phase: "Pending", init: [{ name: "i0", state: { terminated: { exitCode: 1 } } }] });
+    expect(podStatus(crashed).label).toBe("Init:ExitCode:1");
+  });
+
+  test("a started sidecar init container does not block", () => {
+    const p = pod({
+      init: [{ name: "proxy", started: true, state: { running: {} } }],
+      containers: [running()],
+    });
+    expect(podStatus(p).label).toBe("Running");
+  });
+
+  test("terminated containers: Completed, Error, or the exit code", () => {
+    expect(podStatus(pod({ phase: "Succeeded", containers: [{ name: "job", ready: false, state: { terminated: { reason: "Completed", exitCode: 0 } } }] })).label).toBe("Completed");
+    expect(podStatus(pod({ phase: "Failed", containers: [{ name: "job", ready: false, state: { terminated: { reason: "Error", exitCode: 1 } } }] })).label).toBe("Error");
+    expect(podStatus(pod({ phase: "Failed", containers: [{ name: "job", ready: false, state: { terminated: { exitCode: 137 } } }] })).label).toBe("ExitCode:137");
+    expect(podStatus(pod({ phase: "Failed", containers: [{ name: "job", ready: false, state: { terminated: { exitCode: 0, signal: 9 } } }] })).label).toBe("Signal:9");
+  });
+
+  test("a Completed main container next to a running one reads Running / NotReady", () => {
+    const base = { containers: [{ name: "job", ready: false, state: { terminated: { reason: "Completed", exitCode: 0 } } }, running("sidecar")] };
+    expect(podStatus(pod({ ...base, conditions: [{ type: "Ready", status: "True" }] })).label).toBe("Running");
+    expect(podStatus(pod({ ...base, conditions: [{ type: "Ready", status: "False" }] })).label).toBe("NotReady");
+  });
+
+  test("deletion timestamp means Terminating, unless the node is lost", () => {
+    expect(podStatus(pod({ deleting: true, containers: [running()] })).label).toBe("Terminating");
+    expect(podStatus(pod({ deleting: true, reason: "NodeLost", containers: [running()] })).label).toBe("Unknown");
+  });
+
+  test("status.reason (Evicted) replaces the phase", () => {
+    expect(podStatus(pod({ phase: "Failed", reason: "Evicted" })).label).toBe("Evicted");
+  });
+
+  test("a Pending pod carries the scheduler's reason", () => {
+    const p = pod({ phase: "Pending", conditions: [{ type: "PodScheduled", status: "False", reason: "Unschedulable", message: "0/3 nodes" }] });
+    expect(podStatus(p)).toEqual({ label: "Pending", reason: "Unschedulable" });
+  });
+});
+
+describe("podReadyCount / podRestarts / podOwner", () => {
+  test("ready fraction from statuses, spec fallback before statuses exist", () => {
+    expect(podReadyCount(pod({ containers: [running("a"), running("b", false)] }))).toEqual({ ready: 1, total: 2 });
+    expect(podReadyCount(pod({ phase: "Pending", specContainers: 2 }))).toEqual({ ready: 0, total: 2 });
+  });
+
+  test("restarts sum across init and app containers; lastAt is the newest termination", () => {
+    const p = pod({
+      init: [{ name: "i", restartCount: 1, lastState: { terminated: { finishedAt: "2024-01-01T00:00:00Z" } } }],
+      containers: [
+        { name: "a", restartCount: 3, lastState: { terminated: { finishedAt: "2024-01-02T00:00:00Z" } } },
+        { name: "b", restartCount: 0 },
+      ],
+    });
+    expect(podRestarts(p)).toEqual({ count: 4, lastAt: "2024-01-02T00:00:00Z" });
+    expect(podRestarts(pod({ containers: [running()] }))).toEqual({ count: 0, lastAt: null });
+  });
+
+  test("owner prefers the controller reference and abbreviates the kind", () => {
+    expect(podOwner(pod({ owners: [{ kind: "ConfigMap", name: "x" }, { kind: "ReplicaSet", name: "api-7d9f", controller: true }] }))).toEqual({ kind: "ReplicaSet", name: "api-7d9f", short: "rs" });
+    expect(podOwner(pod({ owners: [{ kind: "StatefulSet", name: "db" }] }))?.short).toBe("sts");
+    expect(podOwner(pod({ owners: [{ kind: "Foo", name: "f" }] }))?.short).toBe("foo");
+    expect(podOwner(pod({}))).toBeNull();
+  });
+});
+
+describe("podProblem", () => {
+  test("null for a healthy or finished pod", () => {
+    expect(podProblem(pod({ containers: [running()] }))).toBeNull();
+    expect(podProblem(pod({ phase: "Succeeded", containers: [{ name: "j", state: { terminated: { reason: "Completed", exitCode: 0 } } }] }))).toBeNull();
+  });
+
+  test("a crash-looping container, with its last termination", () => {
+    const p = pod({
+      containers: [
+        running("sidecar"),
+        {
+          name: "app", ready: false, restartCount: 7,
+          state: { waiting: { reason: "CrashLoopBackOff", message: "back-off 5m0s" } },
+          lastState: { terminated: { reason: "Error", exitCode: 1, finishedAt: "2024-01-02T00:00:00Z" } },
+        },
+      ],
+    });
+    expect(podProblem(p)).toEqual({
+      container: "app", init: false, reason: "CrashLoopBackOff", message: "back-off 5m0s",
+      exitCode: 1, lastReason: "Error", lastFinishedAt: "2024-01-02T00:00:00Z", restartCount: 7,
+    });
+  });
+
+  test("a failed init container comes first", () => {
+    const p = pod({
+      init: [{ name: "migrate", restartCount: 2, state: { terminated: { reason: "Error", exitCode: 2, finishedAt: "t" } } }],
+      containers: [{ name: "app", state: { waiting: { reason: "PodInitializing" } } }],
+    });
+    expect(podProblem(p)).toMatchObject({ container: "migrate", init: true, reason: "Error", exitCode: 2 });
+  });
+
+  test("an unschedulable pod names the scheduler's reason", () => {
+    const p = pod({ phase: "Pending", conditions: [{ type: "PodScheduled", status: "False", reason: "Unschedulable", message: "0/3 nodes are available: 3 Insufficient cpu." }] });
+    expect(podProblem(p)).toEqual({ reason: "Unschedulable", message: "0/3 nodes are available: 3 Insufficient cpu.", restartCount: 0 });
+  });
+
+  test("ContainerCreating is not a problem", () => {
+    expect(podProblem(pod({ phase: "Pending", containers: [{ name: "app", state: { waiting: { reason: "ContainerCreating" } } }] }))).toBeNull();
+  });
+});
+
+describe("orderedPodConditions", () => {
+  test("lifecycle order regardless of API order", () => {
+    const p = pod({ conditions: [{ type: "Ready", status: "False" }, { type: "Custom", status: "True" }, { type: "PodScheduled", status: "True" }, { type: "ContainersReady", status: "False" }] });
+    expect(orderedPodConditions(p).map((c) => c.type)).toEqual(["PodScheduled", "ContainersReady", "Ready", "Custom"]);
+  });
+});

--- a/src/lib/utils/pod-status.ts
+++ b/src/lib/utils/pod-status.ts
@@ -1,0 +1,263 @@
+// The pod as kubectl reads it: one status word, a ready fraction, restarts
+// with when the last one happened, the controller that owns it, and — when
+// something is wrong — which container and why.
+//
+// `status.phase` alone is not a status: a pod whose container is in
+// CrashLoopBackOff still has phase Running. These helpers walk the container
+// statuses the way `kubectl get pods` does (printers.go / printPod), so the
+// table and the detail panel agree with what an operator sees in a terminal.
+// Pure: runs under bun with no Svelte runtime.
+
+import type { Resource } from "$lib/types";
+
+type Json = Record<string, unknown>;
+
+interface ContainerState {
+  running?: { startedAt?: string };
+  waiting?: { reason?: string; message?: string };
+  terminated?: { reason?: string; message?: string; exitCode?: number; signal?: number; finishedAt?: string; startedAt?: string };
+}
+
+export interface ContainerStatusLike {
+  name?: string;
+  ready?: boolean;
+  started?: boolean;
+  restartCount?: number;
+  image?: string;
+  state?: ContainerState;
+  lastState?: ContainerState;
+}
+
+export interface PodCondition {
+  type: string;
+  status: string;
+  reason?: string;
+  message?: string;
+}
+
+/** The one word a row shows, plus the short "why" a Pending pod carries. */
+export interface PodStatusInfo {
+  label: string;
+  /** Why the pod is where it is, when the label alone does not say ("Unschedulable"). */
+  reason?: string;
+}
+
+function statuses(resource: Resource, key: "containerStatuses" | "initContainerStatuses"): ContainerStatusLike[] {
+  const list = (resource.status as Json | undefined)?.[key];
+  return Array.isArray(list) ? (list as ContainerStatusLike[]) : [];
+}
+
+export function podConditions(resource: Resource): PodCondition[] {
+  const list = (resource.status as Json | undefined)?.conditions;
+  return Array.isArray(list) ? (list as PodCondition[]).filter((c) => c && typeof c.type === "string") : [];
+}
+
+function condition(resource: Resource, type: string): PodCondition | undefined {
+  return podConditions(resource).find((c) => c.type === type);
+}
+
+/** "ExitCode:137" / "Signal:9" — what kubectl prints for an unexplained termination. */
+function terminationLabel(t: NonNullable<ContainerState["terminated"]>): string {
+  if (t.signal !== undefined && t.signal !== 0) return `Signal:${t.signal}`;
+  return `ExitCode:${t.exitCode ?? 0}`;
+}
+
+/**
+ * The kubectl STATUS column for a pod. Init containers first (`Init:1/2`,
+ * `Init:CrashLoopBackOff`), then the app containers' waiting / terminated
+ * reasons, then the phase; a pod being deleted reads Terminating regardless.
+ */
+export function podStatus(resource: Resource): PodStatusInfo {
+  const status = (resource.status ?? {}) as Json;
+  const phase = typeof status.phase === "string" ? status.phase : "Unknown";
+  let reason = typeof status.reason === "string" && status.reason ? status.reason : phase;
+
+  const init = statuses(resource, "initContainerStatuses");
+  let initializing = false;
+  for (let i = 0; i < init.length; i++) {
+    const cs = init[i];
+    const t = cs.state?.terminated;
+    const w = cs.state?.waiting;
+    if (t && (t.exitCode ?? 0) === 0) continue;
+    if (t) {
+      reason = t.reason ? `Init:${t.reason}` : `Init:${terminationLabel(t)}`;
+      initializing = true;
+      break;
+    }
+    // A sidecar (restartable init container) that has started is done.
+    if (cs.state?.running && cs.started) continue;
+    if (w?.reason && w.reason !== "PodInitializing") {
+      reason = `Init:${w.reason}`;
+    } else {
+      reason = `Init:${i}/${init.length}`;
+    }
+    initializing = true;
+    break;
+  }
+
+  if (!initializing) {
+    let hasRunning = false;
+    const cs = statuses(resource, "containerStatuses");
+    for (let i = cs.length - 1; i >= 0; i--) {
+      const c = cs[i];
+      const w = c.state?.waiting;
+      const t = c.state?.terminated;
+      if (w?.reason) {
+        reason = w.reason;
+      } else if (t?.reason) {
+        reason = t.reason;
+      } else if (t) {
+        reason = terminationLabel(t);
+      } else if (c.ready && c.state?.running) {
+        hasRunning = true;
+      }
+    }
+    // Every container finished but the pod is still Running: the kubelet has
+    // not caught up, or a sidecar is still up. kubectl reports Running / NotReady.
+    if (reason === "Completed" && hasRunning) {
+      reason = condition(resource, "Ready")?.status === "True" ? "Running" : "NotReady";
+    }
+  }
+
+  const deleting = Boolean(resource.metadata?.deletion_timestamp);
+  if (deleting && status.reason === "NodeLost") reason = "Unknown";
+  else if (deleting) reason = "Terminating";
+
+  const info: PodStatusInfo = { label: reason };
+  if (reason === "Pending") {
+    const scheduled = condition(resource, "PodScheduled");
+    if (scheduled && scheduled.status !== "True" && scheduled.reason) info.reason = scheduled.reason;
+  }
+  return info;
+}
+
+/** Ready containers over the total, as the table's Ready column and kubectl show it. */
+export function podReadyCount(resource: Resource): { ready: number; total: number } {
+  const cs = statuses(resource, "containerStatuses");
+  if (cs.length === 0) {
+    // No statuses yet (Pending, or a lean row): fall back to the spec count.
+    const spec = (resource.spec as Json | undefined)?.containers;
+    return { ready: 0, total: Array.isArray(spec) ? spec.length : 0 };
+  }
+  return { ready: cs.filter((c) => c.ready).length, total: cs.length };
+}
+
+/** Total restarts across containers, and when the most recent one happened. */
+export function podRestarts(resource: Resource): { count: number; lastAt: string | null } {
+  let count = 0;
+  let lastAt: string | null = null;
+  for (const c of [...statuses(resource, "initContainerStatuses"), ...statuses(resource, "containerStatuses")]) {
+    count += c.restartCount ?? 0;
+    const finished = c.lastState?.terminated?.finishedAt;
+    if (typeof finished === "string" && finished && (!lastAt || finished > lastAt)) lastAt = finished;
+  }
+  return { count, lastAt };
+}
+
+const OWNER_SHORT: Record<string, string> = {
+  ReplicaSet: "rs",
+  StatefulSet: "sts",
+  DaemonSet: "ds",
+  Job: "job",
+  CronJob: "cj",
+  Node: "node",
+  ReplicationController: "rc",
+  Deployment: "deploy",
+};
+
+export interface PodOwner {
+  kind: string;
+  name: string;
+  /** kubectl-style short kind for the cell ("rs", "sts", "job"). */
+  short: string;
+}
+
+/** The controller that owns the pod (the owner reference flagged `controller`, else the first). */
+export function podOwner(resource: Resource): PodOwner | null {
+  const refs = resource.metadata?.owner_references ?? [];
+  const ref = refs.find((r) => r.controller) ?? refs[0];
+  if (!ref?.kind || !ref.name) return null;
+  return { kind: ref.kind, name: ref.name, short: OWNER_SHORT[ref.kind] ?? ref.kind.toLowerCase() };
+}
+
+/** Which container state reasons mean "this is broken", as opposed to "still coming up". */
+const BROKEN_REASON = /error|crash|backoff|oom|invalid|cannotrun|deadline|killed/i;
+
+export interface PodProblem {
+  /** The container at fault; undefined when the pod itself cannot start (Unschedulable). */
+  container?: string;
+  /** Whether it is an init container. */
+  init?: boolean;
+  reason: string;
+  message?: string;
+  /** Exit code of the last termination (current or previous state). */
+  exitCode?: number;
+  /** Reason of the last termination, when the container is now waiting (CrashLoopBackOff → Error). */
+  lastReason?: string;
+  /** When the last termination finished. */
+  lastFinishedAt?: string;
+  restartCount: number;
+}
+
+/**
+ * The first thing wrong with the pod, for the detail panel's attention block:
+ * an init container that failed, an app container waiting on an error or
+ * terminated non-zero, or a Pending pod the scheduler cannot place. Null when
+ * nothing is wrong (or the pod finished on purpose).
+ */
+export function podProblem(resource: Resource): PodProblem | null {
+  const fromContainer = (c: ContainerStatusLike, init: boolean): PodProblem | null => {
+    const w = c.state?.waiting;
+    const t = c.state?.terminated;
+    const last = c.lastState?.terminated;
+    if (w?.reason && BROKEN_REASON.test(w.reason)) {
+      return {
+        container: c.name,
+        init,
+        reason: w.reason,
+        message: w.message,
+        exitCode: last?.exitCode,
+        lastReason: last?.reason,
+        lastFinishedAt: last?.finishedAt,
+        restartCount: c.restartCount ?? 0,
+      };
+    }
+    if (t && (t.exitCode ?? 0) !== 0) {
+      return {
+        container: c.name,
+        init,
+        reason: t.reason ?? terminationLabel(t),
+        message: t.message,
+        exitCode: t.exitCode,
+        lastFinishedAt: t.finishedAt,
+        restartCount: c.restartCount ?? 0,
+      };
+    }
+    return null;
+  };
+  for (const c of statuses(resource, "initContainerStatuses")) {
+    const p = fromContainer(c, true);
+    if (p) return p;
+  }
+  for (const c of statuses(resource, "containerStatuses")) {
+    const p = fromContainer(c, false);
+    if (p) return p;
+  }
+  const scheduled = condition(resource, "PodScheduled");
+  if (scheduled && scheduled.status !== "True" && scheduled.reason) {
+    return { reason: scheduled.reason, message: scheduled.message, restartCount: 0 };
+  }
+  return null;
+}
+
+/** The order the four standard conditions are worth reading in. */
+const CONDITION_ORDER = ["PodScheduled", "PodReadyToStartContainers", "Initialized", "ContainersReady", "Ready"];
+
+/** Pod conditions in lifecycle order, unknown ones after. */
+export function orderedPodConditions(resource: Resource): PodCondition[] {
+  const rank = (t: string) => {
+    const i = CONDITION_ORDER.indexOf(t);
+    return i === -1 ? CONDITION_ORDER.length : i;
+  };
+  return [...podConditions(resource)].sort((a, b) => rank(a.type) - rank(b.type));
+}

--- a/src/lib/utils/service-info.test.ts
+++ b/src/lib/utils/service-info.test.ts
@@ -78,9 +78,10 @@ describe("endpointSummary / endpointAddresses", () => {
     slice("web", [{ addresses: ["10.1.0.1"] }], "elsewhere"),
   ];
 
-  test("counts only the service's slices in the namespace", () => {
-    expect(endpointSummary(slices, "web", "ns")).toEqual({ ready: 2, total: 5, terminating: 1 });
-    expect(endpointSummary(slices, "web")).toEqual({ ready: 3, total: 6, terminating: 1 });
+  test("counts endpoints (not addresses) of the service's slices in the namespace", () => {
+    // The second endpoint lists two addresses but is one backend.
+    expect(endpointSummary(slices, "web", "ns")).toEqual({ ready: 2, total: 4, terminating: 1 });
+    expect(endpointSummary(slices, "web")).toEqual({ ready: 3, total: 5, terminating: 1 });
   });
 
   test("null when no slice exists, zero when the slice is empty", () => {
@@ -88,12 +89,12 @@ describe("endpointSummary / endpointAddresses", () => {
     expect(endpointSummary([slice("empty", [])], "empty", "ns")).toEqual({ ready: 0, total: 0, terminating: 0 });
   });
 
-  test("addresses flatten with the slice port and endpoint metadata", () => {
+  test("one row per endpoint (its first address) with the slice port and endpoint metadata", () => {
     const rows = endpointAddresses(slices, "web", "ns");
-    expect(rows.map((r) => r.address)).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.1.1"]);
+    expect(rows.map((r) => r.address)).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.4", "10.0.1.1"]);
     expect(rows[0]).toEqual({ address: "10.0.0.1", port: 8080, ready: true, serving: true, terminating: false, targetRef: { kind: "Pod", name: "web-1" }, nodeName: "n1", zone: "a" });
     expect(rows[1].ready).toBe(false);
-    expect(rows[3].terminating).toBe(true);
+    expect(rows[2].terminating).toBe(true);
   });
 
   test("reads a full EndpointSlice object (endpoints at the top level) too", () => {

--- a/src/lib/utils/service-info.test.ts
+++ b/src/lib/utils/service-info.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import {
+  endpointAddresses,
+  endpointSummary,
+  isHeadless,
+  serviceExternal,
+  servicePortLabel,
+  servicePortsLabel,
+  serviceSelector,
+  SERVICE_NAME_LABEL,
+} from "./service-info";
+
+function svc(spec: Record<string, unknown>, status: Record<string, unknown> = {}): Resource {
+  return {
+    kind: "Service",
+    api_version: "v1",
+    metadata: { name: "svc", namespace: "ns", uid: "u", creation_timestamp: "", labels: {}, annotations: {}, resource_version: "1", owner_references: [] },
+    spec,
+    status,
+  };
+}
+
+function slice(service: string, endpoints: unknown[], namespace = "ns", ports: unknown[] = [{ port: 8080 }]): Resource {
+  return {
+    kind: "EndpointSlice",
+    api_version: "discovery.k8s.io/v1",
+    metadata: { name: `${service}-abc`, namespace, uid: "u", creation_timestamp: "", labels: { [SERVICE_NAME_LABEL]: service }, annotations: {}, resource_version: "1", owner_references: [] },
+    spec: { addressType: "IPv4", endpoints, ports },
+    status: {},
+  };
+}
+
+describe("serviceExternal", () => {
+  test("load balancer ingress, ip or hostname", () => {
+    expect(serviceExternal(svc({ type: "LoadBalancer" }, { loadBalancer: { ingress: [{ ip: "1.2.3.4" }] } }))).toEqual({ label: "1.2.3.4", pending: false });
+    expect(serviceExternal(svc({ type: "LoadBalancer" }, { loadBalancer: { ingress: [{ hostname: "a.elb.amazonaws.com" }] } }))).toEqual({ label: "a.elb.amazonaws.com", pending: false });
+  });
+
+  test("a LoadBalancer without an address is pending; a ClusterIP simply has none", () => {
+    expect(serviceExternal(svc({ type: "LoadBalancer" }))).toEqual({ label: "", pending: true });
+    expect(serviceExternal(svc({ type: "ClusterIP" }))).toEqual({ label: "", pending: false });
+  });
+
+  test("externalIPs and ExternalName", () => {
+    expect(serviceExternal(svc({ type: "ClusterIP", externalIPs: ["10.0.0.1"] })).label).toBe("10.0.0.1");
+    expect(serviceExternal(svc({ type: "ExternalName", externalName: "db.internal" })).label).toBe("db.internal");
+  });
+});
+
+describe("ports", () => {
+  test("port→target/protocol, collapsing an identical target, with node port", () => {
+    expect(servicePortLabel({ port: 80, targetPort: 8080 })).toBe("80→8080/TCP");
+    expect(servicePortLabel({ port: 443, targetPort: 443, protocol: "TCP" })).toBe("443/TCP");
+    expect(servicePortLabel({ port: 80, targetPort: "http", protocol: "UDP" })).toBe("80→http/UDP");
+    expect(servicePortLabel({ port: 9090, nodePort: 30090 })).toBe("9090/TCP :30090");
+    expect(servicePortsLabel(svc({ ports: [{ port: 80, targetPort: 8080 }, { port: 443, targetPort: 8443 }] }))).toBe("80→8080/TCP, 443→8443/TCP");
+    expect(servicePortsLabel(svc({}))).toBe("");
+  });
+
+  test("headless and selector", () => {
+    expect(isHeadless(svc({ clusterIP: "None" }))).toBe(true);
+    expect(isHeadless(svc({ clusterIP: "10.0.0.1" }))).toBe(false);
+    expect(serviceSelector(svc({ selector: { app: "web", tier: "fe" } }))).toEqual(["app=web", "tier=fe"]);
+    expect(serviceSelector(svc({}))).toEqual([]);
+  });
+});
+
+describe("endpointSummary / endpointAddresses", () => {
+  const slices = [
+    slice("web", [
+      { addresses: ["10.0.0.1"], conditions: { ready: true }, targetRef: { kind: "Pod", name: "web-1" }, nodeName: "n1", zone: "a" },
+      { addresses: ["10.0.0.2", "10.0.0.3"], conditions: { ready: false, serving: false }, targetRef: { kind: "Pod", name: "web-2" } },
+      { addresses: ["10.0.0.4"], conditions: { ready: false, terminating: true } },
+    ]),
+    slice("web", [{ addresses: ["10.0.1.1"] }]),
+    slice("other", [{ addresses: ["10.0.9.9"] }]),
+    slice("web", [{ addresses: ["10.1.0.1"] }], "elsewhere"),
+  ];
+
+  test("counts only the service's slices in the namespace", () => {
+    expect(endpointSummary(slices, "web", "ns")).toEqual({ ready: 2, total: 5, terminating: 1 });
+    expect(endpointSummary(slices, "web")).toEqual({ ready: 3, total: 6, terminating: 1 });
+  });
+
+  test("null when no slice exists, zero when the slice is empty", () => {
+    expect(endpointSummary(slices, "missing", "ns")).toBeNull();
+    expect(endpointSummary([slice("empty", [])], "empty", "ns")).toEqual({ ready: 0, total: 0, terminating: 0 });
+  });
+
+  test("addresses flatten with the slice port and endpoint metadata", () => {
+    const rows = endpointAddresses(slices, "web", "ns");
+    expect(rows.map((r) => r.address)).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.1.1"]);
+    expect(rows[0]).toEqual({ address: "10.0.0.1", port: 8080, ready: true, serving: true, terminating: false, targetRef: { kind: "Pod", name: "web-1" }, nodeName: "n1", zone: "a" });
+    expect(rows[1].ready).toBe(false);
+    expect(rows[3].terminating).toBe(true);
+  });
+
+  test("reads a full EndpointSlice object (endpoints at the top level) too", () => {
+    const full = { ...slice("web", []), endpoints: [{ addresses: ["10.2.0.1"] }], ports: [{ port: 80 }] } as unknown as Resource;
+    expect(endpointSummary([full], "web", "ns")).toEqual({ ready: 1, total: 1, terminating: 0 });
+    expect(endpointAddresses([full], "web", "ns")[0].port).toBe(80);
+  });
+});

--- a/src/lib/utils/service-info.ts
+++ b/src/lib/utils/service-info.ts
@@ -133,19 +133,22 @@ function sliceEndpoints(slice: Resource): SliceEndpoint[] {
 export function endpointSummary(slices: Resource[], serviceName: string, namespace?: string | null): EndpointSummary | null {
   const mine = slicesForService(slices, serviceName, namespace);
   if (mine.length === 0) return null;
+  // One endpoint is one backend: `addresses` is an array for historical
+  // reasons, the controller writes exactly one and kube-proxy reads only the
+  // first — so count endpoints, not addresses.
   let ready = 0, total = 0, terminating = 0;
   for (const slice of mine) {
     for (const ep of sliceEndpoints(slice)) {
-      const n = ep.addresses?.length ?? 0;
-      total += n;
-      if (ep.conditions?.ready !== false) ready += n;
-      if (ep.conditions?.terminating === true) terminating += n;
+      if (!ep.addresses?.length) continue;
+      total += 1;
+      if (ep.conditions?.ready !== false) ready += 1;
+      if (ep.conditions?.terminating === true) terminating += 1;
     }
   }
   return { ready, total, terminating };
 }
 
-/** One row per address across the service's slices, with the slice's first port. */
+/** One row per endpoint (its first address) across the service's slices, with the slice's first port. */
 export function endpointAddresses(slices: Resource[], serviceName: string, namespace?: string | null): EndpointAddress[] {
   const out: EndpointAddress[] = [];
   for (const slice of slicesForService(slices, serviceName, namespace)) {
@@ -153,18 +156,18 @@ export function endpointAddresses(slices: Resource[], serviceName: string, names
     const ports = (Array.isArray(topPorts) ? topPorts : (slice.spec as Json | undefined)?.ports) as Array<{ port?: number }> | undefined;
     const port = ports?.[0]?.port;
     for (const ep of sliceEndpoints(slice)) {
-      for (const address of ep.addresses ?? []) {
-        out.push({
-          address,
-          port,
-          ready: ep.conditions?.ready !== false,
-          serving: ep.conditions?.serving !== false,
-          terminating: ep.conditions?.terminating === true,
-          targetRef: ep.targetRef,
-          nodeName: ep.nodeName,
-          zone: ep.zone,
-        });
-      }
+      const address = ep.addresses?.[0];
+      if (!address) continue;
+      out.push({
+        address,
+        port,
+        ready: ep.conditions?.ready !== false,
+        serving: ep.conditions?.serving !== false,
+        terminating: ep.conditions?.terminating === true,
+        targetRef: ep.targetRef,
+        nodeName: ep.nodeName,
+        zone: ep.zone,
+      });
     }
   }
   return out;

--- a/src/lib/utils/service-info.ts
+++ b/src/lib/utils/service-info.ts
@@ -1,0 +1,171 @@
+// What a Service row and its detail need beyond the raw spec: where it is
+// reachable from outside (and whether that address is still pending), its
+// ports as "port→target/protocol", and — from EndpointSlices — how many
+// backends it actually has. Pure.
+
+import type { Resource } from "$lib/types";
+
+type Json = Record<string, unknown>;
+
+/** The label an EndpointSlice carries to name its Service. */
+export const SERVICE_NAME_LABEL = "kubernetes.io/service-name";
+
+export interface ServiceExternal {
+  /** Addresses, comma-joined; empty when the service has none. */
+  label: string;
+  /** A LoadBalancer still waiting for the cloud to hand it an address. */
+  pending: boolean;
+}
+
+/**
+ * The External cell: load-balancer ingress (IP or hostname), then explicit
+ * externalIPs, then an ExternalName target. A LoadBalancer with no ingress
+ * yet is `pending`, which is the state worth showing in colour.
+ */
+export function serviceExternal(resource: Resource): ServiceExternal {
+  const spec = (resource.spec ?? {}) as Json;
+  const status = (resource.status ?? {}) as Json;
+  const lb = status.loadBalancer as { ingress?: Array<{ ip?: string; hostname?: string }> } | undefined;
+  const ingress = (lb?.ingress ?? []).map((e) => e.ip ?? e.hostname ?? "").filter(Boolean);
+  const externalIPs = Array.isArray(spec.externalIPs) ? (spec.externalIPs as string[]) : [];
+  const parts = [...ingress, ...externalIPs];
+  if (typeof spec.externalName === "string" && spec.externalName) parts.push(spec.externalName);
+  if (parts.length > 0) return { label: parts.join(", "), pending: false };
+  return { label: "", pending: spec.type === "LoadBalancer" };
+}
+
+export interface ServicePort {
+  name?: string;
+  port?: number;
+  targetPort?: string | number;
+  protocol?: string;
+  nodePort?: number;
+  appProtocol?: string;
+}
+
+export function servicePorts(resource: Resource): ServicePort[] {
+  const ports = (resource.spec as Json | undefined)?.ports;
+  return Array.isArray(ports) ? (ports as ServicePort[]) : [];
+}
+
+/** `80→8080/TCP`, `443/TCP` when the target is the same, ` :30080` when a node port is open. */
+export function servicePortLabel(p: ServicePort): string {
+  const port = p.port ?? "";
+  const target = p.targetPort;
+  const differs = target !== undefined && target !== "" && String(target) !== String(port);
+  let label = differs ? `${port}→${target}` : `${port}`;
+  label += `/${p.protocol ?? "TCP"}`;
+  if (p.nodePort) label += ` :${p.nodePort}`;
+  return label;
+}
+
+/** Every port of the service, comma-joined — the Ports cell. */
+export function servicePortsLabel(resource: Resource): string {
+  return servicePorts(resource).map(servicePortLabel).join(", ");
+}
+
+/** A headless service: ClusterIP explicitly "None". */
+export function isHeadless(resource: Resource): boolean {
+  return (resource.spec as Json | undefined)?.clusterIP === "None";
+}
+
+/** The selector as `k=v` terms. */
+export function serviceSelector(resource: Resource): string[] {
+  const sel = (resource.spec as Json | undefined)?.selector;
+  if (!sel || typeof sel !== "object") return [];
+  return Object.entries(sel as Record<string, string>).map(([k, v]) => `${k}=${v}`);
+}
+
+// ---------------------------------------------------------------------------
+// EndpointSlices
+// ---------------------------------------------------------------------------
+
+export interface EndpointSummary {
+  /** Endpoints whose `ready` condition is not false. */
+  ready: number;
+  /** Every endpoint in the service's slices. */
+  total: number;
+  /** Endpoints that are terminating. */
+  terminating: number;
+}
+
+export interface EndpointAddress {
+  address: string;
+  port?: number;
+  ready: boolean;
+  serving: boolean;
+  terminating: boolean;
+  targetRef?: { kind?: string; name?: string; namespace?: string };
+  nodeName?: string;
+  zone?: string;
+}
+
+interface SliceEndpoint {
+  addresses?: string[];
+  conditions?: { ready?: boolean; serving?: boolean; terminating?: boolean };
+  targetRef?: { kind?: string; name?: string; namespace?: string };
+  nodeName?: string;
+  zone?: string;
+}
+
+/** The slices that belong to `serviceName` (by the service-name label), in `namespace` when given. */
+export function slicesForService(slices: Resource[], serviceName: string, namespace?: string | null): Resource[] {
+  return slices.filter(
+    (s) =>
+      s.metadata?.labels?.[SERVICE_NAME_LABEL] === serviceName &&
+      (namespace == null || namespace === "" || s.metadata?.namespace === namespace),
+  );
+}
+
+function sliceEndpoints(slice: Resource): SliceEndpoint[] {
+  // The list projection copies `endpoints` into a synthetic spec; a full
+  // object keeps it at the top level.
+  const top = (slice as unknown as Json).endpoints;
+  const list = Array.isArray(top) ? top : (slice.spec as Json | undefined)?.endpoints;
+  return Array.isArray(list) ? (list as SliceEndpoint[]) : [];
+}
+
+/**
+ * Ready / total over the service's slices. Null when the service has no
+ * slice at all (ExternalName, or the controller has not written one yet) —
+ * distinct from zero, which means "a slice exists and it is empty".
+ */
+export function endpointSummary(slices: Resource[], serviceName: string, namespace?: string | null): EndpointSummary | null {
+  const mine = slicesForService(slices, serviceName, namespace);
+  if (mine.length === 0) return null;
+  let ready = 0, total = 0, terminating = 0;
+  for (const slice of mine) {
+    for (const ep of sliceEndpoints(slice)) {
+      const n = ep.addresses?.length ?? 0;
+      total += n;
+      if (ep.conditions?.ready !== false) ready += n;
+      if (ep.conditions?.terminating === true) terminating += n;
+    }
+  }
+  return { ready, total, terminating };
+}
+
+/** One row per address across the service's slices, with the slice's first port. */
+export function endpointAddresses(slices: Resource[], serviceName: string, namespace?: string | null): EndpointAddress[] {
+  const out: EndpointAddress[] = [];
+  for (const slice of slicesForService(slices, serviceName, namespace)) {
+    const topPorts = (slice as unknown as Json).ports;
+    const ports = (Array.isArray(topPorts) ? topPorts : (slice.spec as Json | undefined)?.ports) as Array<{ port?: number }> | undefined;
+    const port = ports?.[0]?.port;
+    for (const ep of sliceEndpoints(slice)) {
+      for (const address of ep.addresses ?? []) {
+        out.push({
+          address,
+          port,
+          ready: ep.conditions?.ready !== false,
+          serving: ep.conditions?.serving !== false,
+          terminating: ep.conditions?.terminating === true,
+          targetRef: ep.targetRef,
+          nodeName: ep.nodeName,
+          zone: ep.zone,
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/src/lib/utils/workload-stats.ts
+++ b/src/lib/utils/workload-stats.ts
@@ -537,8 +537,13 @@ export function matchesStatFilter(resource: Resource, resourceType: string, filt
   switch (resourceType) {
     case "pods":
       return classifyPodStatus(resource) === filterKey;
-    case "deployments":
-      return classifyDeployment(resource) === filterKey;
+    case "deployments": {
+      const c = classifyDeployment(resource);
+      // "unhealthy" is the saved view's question — anything short of healthy
+      // that is not a rollout in progress — so it spans degraded and failing.
+      if (filterKey === "unhealthy") return c === "degraded" || c === "failing";
+      return c === filterKey;
+    }
     case "services": {
       const type = (resource.spec?.type as string) ?? "ClusterIP";
       if (filterKey === "clusterIP") return type === "ClusterIP";

--- a/src/lib/utils/workload-status.test.ts
+++ b/src/lib/utils/workload-status.test.ts
@@ -67,7 +67,7 @@ describe("shortImage / templateImages", () => {
 
   test("digest-pinned images keep a short digest", () => {
     expect(shortImage("ghcr.io/shop/api@sha256:0123456789abcdef")).toBe("api@0123456");
-    expect(shortImage("ghcr.io/shop/api:2.4.1@sha256:0123456789abcdef")).toBe("api:2.4.1");
+    expect(shortImage("ghcr.io/shop/api:2.4.1@sha256:0123456789abcdef")).toBe("api:2.4.1@0123456");
   });
 
   test("template images in container order", () => {

--- a/src/lib/utils/workload-status.test.ts
+++ b/src/lib/utils/workload-status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { Resource } from "$lib/types";
+import { deploymentStatus, replicaSegments, shortImage, templateImages } from "./workload-status";
+
+function deploy(spec: Record<string, unknown>, status: Record<string, unknown> = {}): Resource {
+  return {
+    kind: "Deployment",
+    api_version: "apps/v1",
+    metadata: { name: "d", namespace: "ns", uid: "u", creation_timestamp: "", labels: {}, annotations: {}, resource_version: "1", owner_references: [] },
+    spec,
+    status,
+  };
+}
+
+const avail = (status: string, reason?: string) => ({ type: "Available", status, reason });
+const prog = (status: string, reason?: string) => ({ type: "Progressing", status, reason });
+
+describe("deploymentStatus", () => {
+  test("Available when every replica is ready and up to date", () => {
+    const d = deploy({ replicas: 3 }, { replicas: 3, readyReplicas: 3, updatedReplicas: 3, availableReplicas: 3, conditions: [avail("True"), prog("True", "NewReplicaSetAvailable")] });
+    expect(deploymentStatus(d)).toEqual({ label: "Available" });
+  });
+
+  test("Progressing while updated replicas trail the desired count", () => {
+    const d = deploy({ replicas: 3 }, { replicas: 4, readyReplicas: 3, updatedReplicas: 1, conditions: [avail("True"), prog("True", "ReplicaSetUpdated")] });
+    expect(deploymentStatus(d)).toEqual({ label: "Progressing", detail: "ReplicaSetUpdated" });
+  });
+
+  test("Unavailable carries the Available condition's reason", () => {
+    const d = deploy({ replicas: 2 }, { replicas: 2, readyReplicas: 0, updatedReplicas: 2, conditions: [avail("False", "MinimumReplicasUnavailable"), prog("True")] });
+    expect(deploymentStatus(d)).toEqual({ label: "Unavailable", detail: "MinimumReplicasUnavailable" });
+  });
+
+  test("a rollout past its deadline is Failed, a ReplicaFailure is its own word", () => {
+    expect(deploymentStatus(deploy({ replicas: 2 }, { conditions: [prog("False", "ProgressDeadlineExceeded")] }))).toEqual({ label: "Failed", detail: "ProgressDeadlineExceeded" });
+    expect(deploymentStatus(deploy({ replicas: 2 }, { conditions: [{ type: "ReplicaFailure", status: "True", reason: "FailedCreate" }] }))).toEqual({ label: "ReplicaFailure", detail: "FailedCreate" });
+  });
+
+  test("Paused and Scaled to 0 are deliberate states, checked first", () => {
+    expect(deploymentStatus(deploy({ replicas: 4, paused: true }, { readyReplicas: 4, updatedReplicas: 4, replicas: 4 }))).toEqual({ label: "Paused" });
+    expect(deploymentStatus(deploy({ replicas: 0 }, { conditions: [avail("False")] }))).toEqual({ label: "Scaled to 0" });
+  });
+
+  test("spec.replicas omitted defaults to 1", () => {
+    expect(deploymentStatus(deploy({}, { replicas: 1, readyReplicas: 1, updatedReplicas: 1 }))).toEqual({ label: "Available" });
+  });
+});
+
+describe("replicaSegments", () => {
+  test("ready / pending / missing add up to the desired count", () => {
+    expect(replicaSegments(deploy({ replicas: 3 }, { replicas: 3, readyReplicas: 2 }))).toEqual({ desired: 3, ready: 2, pending: 1, missing: 0 });
+    expect(replicaSegments(deploy({ replicas: 3 }, { replicas: 1, readyReplicas: 0 }))).toEqual({ desired: 3, ready: 0, pending: 1, missing: 2 });
+    expect(replicaSegments(deploy({ replicas: 2 }, {}))).toEqual({ desired: 2, ready: 0, pending: 0, missing: 2 });
+  });
+
+  test("a surplus during a rollout shows as pending, never negative", () => {
+    expect(replicaSegments(deploy({ replicas: 3 }, { replicas: 4, readyReplicas: 3 }))).toEqual({ desired: 3, ready: 3, pending: 1, missing: 0 });
+  });
+});
+
+describe("shortImage / templateImages", () => {
+  test("drops registry and path, keeps the tag", () => {
+    expect(shortImage("ghcr.io/shop/api:2.4.1")).toBe("api:2.4.1");
+    expect(shortImage("nginx")).toBe("nginx");
+    expect(shortImage("registry:5000/team/app:1.0")).toBe("app:1.0");
+  });
+
+  test("digest-pinned images keep a short digest", () => {
+    expect(shortImage("ghcr.io/shop/api@sha256:0123456789abcdef")).toBe("api@0123456");
+    expect(shortImage("ghcr.io/shop/api:2.4.1@sha256:0123456789abcdef")).toBe("api:2.4.1");
+  });
+
+  test("template images in container order", () => {
+    const d = deploy({ template: { spec: { initContainers: [{ image: "busybox" }], containers: [{ image: "ghcr.io/shop/api:2.4.1" }, { image: "otel/collector:0.98.0" }] } } });
+    expect(templateImages(d)).toEqual(["ghcr.io/shop/api:2.4.1", "otel/collector:0.98.0"]);
+    expect(templateImages(deploy({}))).toEqual([]);
+  });
+});

--- a/src/lib/utils/workload-status.ts
+++ b/src/lib/utils/workload-status.ts
@@ -100,8 +100,9 @@ export function shortImage(image: string): string {
   const lastSlash = ref.lastIndexOf("/");
   const name = lastSlash === -1 ? ref : ref.slice(lastSlash + 1);
   if (digest) {
+    // A digest pin is the identity even when a tag rides along: keep both.
     const hex = digest.replace(/^sha256:/, "");
-    return name.includes(":") ? name : `${name}@${hex.slice(0, 7)}`;
+    return `${name}@${hex.slice(0, 7)}`;
   }
   return name;
 }

--- a/src/lib/utils/workload-status.ts
+++ b/src/lib/utils/workload-status.ts
@@ -1,0 +1,115 @@
+// What a Deployment row says about itself beyond three replica counts: one
+// status word derived from its conditions, the replica count split into the
+// segments a bar can paint, and the images its template runs. Pure.
+
+import type { Resource } from "$lib/types";
+
+type Json = Record<string, unknown>;
+
+interface Condition {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+}
+
+export interface WorkloadStatus {
+  /** "Available" · "Progressing" · "Unavailable" · "Paused" · "Scaled to 0" · "Failed" · "ReplicaFailure". */
+  label: string;
+  /** The condition reason behind a non-healthy label (MinimumReplicasUnavailable, ProgressDeadlineExceeded…). */
+  detail?: string;
+}
+
+function conditions(resource: Resource): Condition[] {
+  const list = (resource.status as Json | undefined)?.conditions;
+  return Array.isArray(list) ? (list as Condition[]) : [];
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/**
+ * The Deployment's state, in the order an operator cares: paused and scaled
+ * to zero are deliberate; a failed rollout or unavailable replicas need a
+ * look; a rollout in progress is transient; otherwise it is simply available.
+ */
+export function deploymentStatus(resource: Resource): WorkloadStatus {
+  const spec = (resource.spec ?? {}) as Json;
+  const status = (resource.status ?? {}) as Json;
+  const desired = spec.replicas === undefined ? 1 : num(spec.replicas);
+  const ready = num(status.readyReplicas);
+  const updated = num(status.updatedReplicas);
+  const current = num(status.replicas);
+  const cond = (type: string) => conditions(resource).find((c) => c.type === type);
+
+  if (spec.paused === true) return { label: "Paused" };
+  if (desired === 0) return { label: "Scaled to 0" };
+
+  const failure = cond("ReplicaFailure");
+  if (failure?.status === "True") return { label: "ReplicaFailure", detail: failure.reason };
+  const progressing = cond("Progressing");
+  if (progressing?.status === "False") return { label: "Failed", detail: progressing.reason };
+  const available = cond("Available");
+  if (available?.status === "False") return { label: "Unavailable", detail: available.reason };
+
+  if (updated < desired || current > desired || ready < desired) {
+    return { label: "Progressing", detail: progressing?.reason };
+  }
+  return { label: "Available" };
+}
+
+export interface ReplicaSegments {
+  desired: number;
+  /** Pods that are ready. */
+  ready: number;
+  /** Pods that exist but are not ready yet (creating, starting, failing probes). */
+  pending: number;
+  /** Pods the controller has not created yet (or that are missing). */
+  missing: number;
+}
+
+/**
+ * The Ready cell's bar: ready, then pods that exist but are not ready, then
+ * the gap to the desired count. Works for Deployments, ReplicaSets and
+ * StatefulSets (`spec.replicas` / `status.readyReplicas` / `status.replicas`).
+ */
+export function replicaSegments(resource: Resource): ReplicaSegments {
+  const spec = (resource.spec ?? {}) as Json;
+  const status = (resource.status ?? {}) as Json;
+  const desired = spec.replicas === undefined ? 1 : num(spec.replicas);
+  const ready = num(status.readyReplicas);
+  const current = num(status.replicas);
+  const pending = Math.max(0, current - ready);
+  const missing = Math.max(0, desired - ready - pending);
+  return { desired, ready, pending, missing };
+}
+
+/**
+ * `ghcr.io/shop/api:2.4.1` → `api:2.4.1`; a digest-pinned image keeps a short
+ * digest instead of a tag. The registry and path are in the tooltip.
+ */
+export function shortImage(image: string): string {
+  let ref = image;
+  let digest = "";
+  const at = ref.indexOf("@");
+  if (at !== -1) {
+    digest = ref.slice(at + 1);
+    ref = ref.slice(0, at);
+  }
+  const lastSlash = ref.lastIndexOf("/");
+  const name = lastSlash === -1 ? ref : ref.slice(lastSlash + 1);
+  if (digest) {
+    const hex = digest.replace(/^sha256:/, "");
+    return name.includes(":") ? name : `${name}@${hex.slice(0, 7)}`;
+  }
+  return name;
+}
+
+/** Images of the pod template's containers, in order (init containers excluded). */
+export function templateImages(resource: Resource): string[] {
+  const spec = (resource.spec ?? {}) as Json;
+  const template = spec.template as { spec?: { containers?: Array<{ image?: string }> } } | undefined;
+  const containers = template?.spec?.containers ?? [];
+  return containers.map((c) => c.image).filter((i): i is string => typeof i === "string" && i !== "");
+}


### PR DESCRIPTION
## Summary

Redesign of the Pods / Deployments / Services tables and of the Pod, Deployment and Service detail views (docked aside and full tab), following the design canvas we iterated on. The goal: a table that answers "what is wrong and where" in one sweep, and a detail view that opens on the summary and the *why*, not on Metadata.

### Tables
- **Pods** — Status is the effective state kubectl prints (`CrashLoopBackOff`, `Init:1/2`, `ExitCode:137`, `Terminating`…) instead of `status.phase`; Ready merges the container tiles with the `r/t` fraction; Restarts shows when the last one happened (`↻ 3m`); new *Controlled by* column; IP hidden by default.
- **Deployments** — Ready is fraction + a ready/pending/missing bar; Status is derived from conditions (Available · Progressing · Unavailable · Paused · Scaled to 0 · Failed · ReplicaFailure) with the reason next to it; Images and Pods columns; Up-to-date / Available hidden by default (one click away in the column picker).
- **Services** — External unifies LB ingress / externalIPs / ExternalName and flags a pending LoadBalancer; Ports read `80→8080/TCP :30080`; new **Endpoints** column (ready/total from EndpointSlices — `0 · no backends` in red is the first thing to look for and the one thing the spec cannot tell you).
- `Column.defaultHidden` (prefs stay backward compatible), new facet aliases (`ready:`, `owner:`, `image:`, `ep:`, `external:`), Deployments saved views become *Unhealthy* (degraded + failing) and *Rolling out*.

### Detail views
- Shared atoms: `SummaryStrip`/`SummaryCell`, `AttentionBlock`, `ConditionsList`, `LinkRow`, `RecentEventsCard`, `DetailColumns` (two columns in the tab via a container query, one in the aside). `DetailPanel` passes the layout.
- **Pod**: summary strip → "why" block built from `podProblem` (last exit code, message, Logs / Events shortcuts) → containers, usage, port-forward, config, recent events | conditions, network, related, labels | metadata and the rarely-read cards collapsed at the foot.
- **Deployment**: rollout (bar, conditions, ReplicaSets with rollback), pods of the selector, template containers with request totals, HPA in *Scaling*, related.
- **Service**: "No endpoints" / "LB pending" blocks, ports, endpoints (address · pod · node · zone · status), selector → pods, traffic, related (controllers, Ingresses routing here, EndpointSlices).
- Fix: the event-fetch `$effect`s now depend on primitive deriveds — the `resource` prop is replaced on every watch delta, which re-ran the fetch and cancelled it forever on a crash-looping pod — and tolerate `Date` timestamps over IPC.

### Backend / projection
- `ResourceMetadata` carries `deletion_timestamp` (Terminating was invisible); the pod list projection keeps `lastState` and condition `reason`.
- New `endpointsStore` (EndpointSlices per namespace, TTL, loaded by the Services table and detail).

### e2e
- `bun run dev` has no `window.electronAPI`, so the specs importing `./helpers` never rendered a row. `helpers.ts` now boots a small mock cluster before the app loads; `resource-table` and `detail-panel` specs are rewritten against the current UI; `events-view` follows the shared search box.

## Test plan
- [x] `bun test` (1352) and `bun test ./electron` (148) green; new pure modules covered (`pod-status`, `workload-status`, `service-info`, `endpoints.logic`, per-view `*-details.logic`).
- [x] `bun run typecheck:electron`; `bunx svelte-check` with no new errors (the pre-existing `bun:test` / `node:` typing errors in test files remain).
- [x] `bunx playwright test e2e/resource-table.spec.ts e2e/detail-panel.spec.ts e2e/events-view.spec.ts` — 22 passed.
- [x] Manually against the seeded Kind cluster (`./scripts/dev-cluster.sh` + a CrashLoopBackOff pod, an ImagePullBackOff pod, a Service with no backends and a pending LoadBalancer): screenshots at 1600/1280/1000 (tables + aside) and 1400/1000 (tab) — two-column layout collapses below ~900px of content width, summary cells stay legible, tables in the aside scroll inside their own container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsMpJNqscfMcdasvVwFbtE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Pod, Deployment, and Service detail views with clearer health summaries, conditions, metadata, related resources, events, networking, and configuration.
  * Added endpoint and readiness information to Service views, including external addresses, ports, backend status, and endpoint counts.
  * Improved resource tables with readiness, restart timing, ownership, images, replica status, endpoints, and external IP columns.
  * Added richer status and facet filtering, plus new **Unhealthy** and **Rolling out** saved views.
  * Added clearer pod problem messages and deployment replica visualizations.

* **Bug Fixes**
  * Improved status handling for pod failures, terminating resources, rollout states, and container restart details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->