### PR TITLE
perf: benchmark harnesses, memory-leak fixes, cache consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ out/
 # OpenAPI schema cache written when handlers run outside Electron (integration
 # harness); inside the app this lives under userData instead.
 .cache/
+
+# Production build used by the frontend benchmark (scripts/bench/frontend.sh)
+dist-bench/

--- a/e2e/perf-bench.spec.ts
+++ b/e2e/perf-bench.spec.ts
@@ -15,9 +15,50 @@
  * Run:  npx playwright test e2e/perf-bench.spec.ts --project=chromium --reporter=line
  * The webServer block in playwright.config.ts starts `npm run dev` automatically.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
 const SIZES = [200, 2000, 10000];
+
+// BENCH_OUT=path makes every test append its section to one JSON document, so
+// scripts/bench/frontend.sh can collect repeated runs and
+// scripts/bench/compare.ts can diff two labels. Tests run serially under the
+// harness (--workers=1), so a plain read-modify-write is enough.
+function record(section: string, data: unknown) {
+  const out = process.env.BENCH_OUT;
+  if (!out) return;
+  const doc = existsSync(out) ? JSON.parse(readFileSync(out, "utf8")) : {};
+  doc[section] = data;
+  writeFileSync(out, JSON.stringify(doc, null, 2));
+}
+
+interface HeapSample {
+  /** JS heap in use after a forced GC, MB. */
+  heapMB: number;
+  /** Live DOM nodes. */
+  nodes: number;
+  listeners: number;
+}
+
+// Forces a GC first so the reading is retained memory, not garbage waiting to
+// be collected — the number that tells you whether a list leaks.
+async function sampleHeap(page: Page): Promise<HeapSample> {
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send("HeapProfiler.enable");
+    await client.send("HeapProfiler.collectGarbage");
+    await client.send("Performance.enable");
+    const { metrics } = await client.send("Performance.getMetrics");
+    const get = (name: string) => metrics.find((m) => m.name === name)?.value ?? 0;
+    return {
+      heapMB: round(get("JSHeapUsedSize") / 1024 / 1024),
+      nodes: get("Nodes"),
+      listeners: get("JSEventListeners"),
+    };
+  } finally {
+    await client.detach();
+  }
+}
 const FRAME_BUDGET_MS = 8; // main-thread budget/frame to leave room for paint+composite at 60fps
 
 // Generated in-page (keeps the Playwright payload tiny). Produces pods rich
@@ -114,6 +155,7 @@ test.describe("frontend perf bench", () => {
     });
 
     const report: Record<string, unknown> = {};
+    const heapEmpty = await sampleHeap(page);
 
     for (const size of SIZES) {
       // ---- MOUNT (cold): assign dataset -> rows painted ----
@@ -159,23 +201,33 @@ test.describe("frontend perf bench", () => {
       // ---- FILTER: keystroke -> filtered repaint (true end-to-end latency) ----
       const filter = await page.evaluate(async () => {
         const { uiStore } = (window as any).__kdash;
-        const countRows = () => document.querySelectorAll('tbody tr').length;
-        const before = countRows();
+        const NEEDLE = "workload-001"; // matches a block of pods -> row set must shrink
+        const nameCells = () => Array.from(document.querySelectorAll('tbody tr [data-testid="cell-name"]'));
+        // Done when rows are painted and every painted row matches the filter.
+        // (Counting rows is not enough: the virtualizer's spacer rows come and
+        // go with the scroll position, which made an early exit look like a
+        // 9 ms filter while the debounce had not even fired.)
+        const settled = () => {
+          const cells = nameCells();
+          return cells.length > 0 && cells.every((c) => (c.textContent ?? "").includes(NEEDLE));
+        };
         const t0 = performance.now();
-        uiStore.setFilter("workload-001"); // matches a single pod -> row set must shrink
-        // Poll each frame until the rendered set reflects the filter (debounce + derive + paint).
+        uiStore.setFilter(NEEDLE);
         let waited = 0;
-        while (countRows() >= before && waited < 1500) {
+        while (!settled() && waited < 1500) {
           await new Promise<void>((r) => requestAnimationFrame(() => r()));
           waited = performance.now() - t0;
         }
         const t1 = performance.now();
-        const rendered = countRows();
+        const rendered = nameCells().length;
         uiStore.setFilter("");
         await new Promise((r) => setTimeout(r, 80));
         await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
         return { ms: t1 - t0, rendered };
       });
+
+      // ---- MEMORY: retained heap with this list mounted (GC forced) ----
+      const heap = await sampleHeap(page);
 
       report[`n=${size}`] = {
         mountMs: round(mount.ms),
@@ -183,15 +235,34 @@ test.describe("frontend perf bench", () => {
         scroll: scroll ? summarize(scroll, FRAME_BUDGET_MS) : "no-container",
         filterMs: round(filter.ms),
         filterRendered: filter.rendered,
+        heapMB: heap.heapMB,
+        domNodes: heap.nodes,
       };
     }
+
+    // Memory released once the list is gone: growth over the empty baseline
+    // after the 10k list is replaced by an empty one is what leaks look like.
+    await page.evaluate(async () => {
+      const { k8sStore } = (window as any).__kdash;
+      k8sStore.resources = { items: [], resource_type: "pods" };
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    });
+    const heapAfter = await sampleHeap(page);
+    report.memory = {
+      emptyHeapMB: heapEmpty.heapMB,
+      afterClearHeapMB: heapAfter.heapMB,
+      retainedAfterClearMB: round(heapAfter.heapMB - heapEmpty.heapMB),
+      emptyDomNodes: heapEmpty.nodes,
+      afterClearDomNodes: heapAfter.nodes,
+    };
 
     // eslint-disable-next-line no-console
     console.log("\n__PERF_BENCH__" + JSON.stringify(report, null, 2));
     console.log("console.errors:", consoleErrors.slice(0, 5));
+    record("table", report);
 
     // Smoke assertion: the harness produced data for every size.
-    expect(Object.keys(report).length).toBe(SIZES.length);
+    for (const size of SIZES) expect(report[`n=${size}`]).toBeDefined();
   });
 
   test("navigation: type switch + detail open + watch churn", async ({ page }) => {
@@ -285,8 +356,33 @@ test.describe("frontend perf bench", () => {
       };
     }, { gen: GEN });
 
+    // ---- CHURN MEMORY: 40 more wholesale replacements must not grow the heap ----
+    const heapBefore = await sampleHeap(page);
+    await page.evaluate(async ({ gen }) => {
+      const { k8sStore } = (window as any).__kdash;
+      const pods = (eval(gen))(1500);
+      const raf2 = () => new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+      for (let i = 0; i < 40; i++) {
+        const next = pods.slice();
+        for (let j = 0; j < 150; j++) {
+          const idx = (i * 150 + j) % next.length;
+          next[idx] = { ...next[idx], status: { ...next[idx].status, phase: j % 2 ? "Running" : "Pending" } };
+        }
+        k8sStore.resources = { items: next, resource_type: "pods" };
+        await raf2();
+      }
+    }, { gen: GEN });
+    const heapAfterChurn = await sampleHeap(page);
+    const result = {
+      ...r,
+      heapMB: heapAfterChurn.heapMB,
+      churnHeapGrowthMB: round(heapAfterChurn.heapMB - heapBefore.heapMB),
+      domNodes: heapAfterChurn.nodes,
+    };
+
     // eslint-disable-next-line no-console
-    console.log("\n__NAV_BENCH__" + JSON.stringify(r, null, 2));
+    console.log("\n__NAV_BENCH__" + JSON.stringify(result, null, 2));
+    record("nav", result);
     expect(r.navMedianMs).toBeGreaterThan(0);
   });
 
@@ -365,6 +461,7 @@ test.describe("frontend perf bench", () => {
 
     // eslint-disable-next-line no-console
     console.log("\n__CRD_BENCH__" + JSON.stringify(r, null, 2));
+    record("crd", r);
     // Virtualization invariant: the DOM must hold a window of rows, not the list.
     expect(r.renderedRows).toBeGreaterThan(0);
     expect(r.renderedRows).toBeLessThan(200);

--- a/e2e/resource-table.spec.ts
+++ b/e2e/resource-table.spec.ts
@@ -94,8 +94,12 @@ test.describe("ResourceTable", () => {
 
   test.describe("Bulk selection", () => {
     test("checking rows shows the bulk action bar with the count", async ({ page }) => {
+      // The checkbox mounts when the pointer reaches the row (it is hover-only
+      // chrome until a selection exists), so hover before clicking.
+      await tableRows(page).nth(0).hover();
       await tableRows(page).nth(0).locator('[data-testid="row-checkbox"]').click({ force: true });
       await expect(page.getByText("1 resource selected")).toBeVisible();
+      await tableRows(page).nth(1).hover();
       await tableRows(page).nth(1).locator('[data-testid="row-checkbox"]').click({ force: true });
       await expect(page.getByText("2 resources selected")).toBeVisible();
     });

--- a/electron/handlers/app.ts
+++ b/electron/handlers/app.ts
@@ -226,6 +226,26 @@ interface BenchConfig {
   resource_types: string | null;
 }
 
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+// Cumulative CPU time of a pid from /proc (Linux); null elsewhere. Electron's
+// percentCPUUsage reads 0 for every process on some setups, and a delta of
+// this over a window is unambiguous.
+function procCpuMs(pid: number): number | null {
+  if (process.platform !== 'linux') return null;
+  try {
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+    // Fields after the ")" of the comm: state is index 0, utime 11, stime 12.
+    const rest = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+    const ticks = Number(rest[11]) + Number(rest[12]);
+    return Math.round((ticks * 1000) / 100); // CLK_TCK is 100 on Linux
+  } catch {
+    return null;
+  }
+}
+
 function parseEnvU32(key: string, fallback: number): number {
   const raw = process.env[key];
   if (raw === undefined) return fallback;
@@ -415,6 +435,28 @@ export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
       resource_types: optEnv('KDASH_BENCH_TYPES'),
     };
     return config;
+  });
+
+  // --- bench_process_metrics ---
+  // Benchmark-only: per-process CPU (percent since the previous call, so two
+  // samples bracket a window) and memory, for scripts/bench/run.sh. Refused
+  // outside benchmark mode.
+  handlers.set('bench_process_metrics', () => {
+    if (process.env.KDASH_BENCH !== '1') throw new Error('bench_process_metrics: not in benchmark mode');
+    const mem = process.memoryUsage();
+    return {
+      uptime_ms: Math.round(process.uptime() * 1000),
+      main_heap_used_mb: round1(mem.heapUsed / 1048576),
+      main_rss_mb: round1(mem.rss / 1048576),
+      processes: app.getAppMetrics().map((m) => ({
+        type: m.type,
+        pid: m.pid,
+        cpu_percent: round1(m.cpu.percentCPUUsage),
+        cpu_ms: procCpuMs(m.pid),
+        working_set_mb: round1(m.memory.workingSetSize / 1024),
+        private_mb: round1((m.memory.privateBytes ?? 0) / 1024),
+      })),
+    };
   });
 
   // --- write_bench_results ---

--- a/electron/handlers/crd.ts
+++ b/electron/handlers/crd.ts
@@ -24,10 +24,11 @@ import {
 } from '@kubernetes/client-node';
 
 import type { HandlerCtx, HandlerMap } from '../dispatch';
-import { getActiveContextName, makeApiClient } from '../k8s/client';
+import { getActiveContextName, makeApiClient, onConfigChange } from '../k8s/client';
 import type { RawObject, Resource } from '../k8s/resource-types';
-import { dynamicToResource } from '../k8s/resource-mapping';
+import { listDynamicToResource } from '../k8s/resource-mapping';
 import { apiGet } from '../k8s/api';
+import { createTtlCache } from '../util/ttl-cache';
 
 // ===========================================================================
 // Result types — snake_case wire casing, consumed by the renderer CRD stores.
@@ -269,37 +270,21 @@ async function discoverCrds(): Promise<CrdGroup[]> {
 
 const CRD_CACHE_TTL_MS = 30_000;
 
-interface CacheEntry<T> {
-  at: number;
-  promise: Promise<T>;
-}
-
 function contextKey(): string {
   return getActiveContextName() ?? '';
 }
 
-function cacheGet<T>(
-  cache: Map<string, CacheEntry<T>>,
-  key: string,
-  fetch: () => Promise<T>,
-): Promise<T> {
-  const now = Date.now();
-  const hit = cache.get(key);
-  if (hit && now - hit.at < CRD_CACHE_TTL_MS) return hit.promise;
-  const promise = fetch();
-  cache.set(key, { at: now, promise });
-  // Never cache failures — the next call retries.
-  promise.catch(() => {
-    if (cache.get(key)?.promise === promise) cache.delete(key);
-  });
-  return promise;
-}
-
-const discoveryCache = new Map<string, CacheEntry<CrdGroup[]>>();
-const columnsCache = new Map<string, CacheEntry<CrdColumn[]>>();
+const discoveryCache = createTtlCache<CrdGroup[]>(CRD_CACHE_TTL_MS);
+const columnsCache = createTtlCache<CrdColumn[]>(CRD_CACHE_TTL_MS);
+// Keys embed the context, so a switch cannot serve the wrong cluster — but
+// without this the previous cluster's discovery stayed resident for the TTL.
+onConfigChange(() => {
+  discoveryCache.clear();
+  columnsCache.clear();
+});
 
 function discoverCrdsCached(): Promise<CrdGroup[]> {
-  return cacheGet(discoveryCache, contextKey(), discoverCrds);
+  return discoveryCache.get(contextKey(), discoverCrds);
 }
 
 function getCrdColumnsCached(
@@ -308,7 +293,7 @@ function getCrdColumnsCached(
   plural: string,
 ): Promise<CrdColumn[]> {
   const key = `${contextKey()}|${group}|${version}|${plural}`;
-  return cacheGet(columnsCache, key, () => getCrdColumns(group, version, plural));
+  return columnsCache.get(key, () => getCrdColumns(group, version, plural));
 }
 
 // ===========================================================================
@@ -479,7 +464,7 @@ async function listCrdResources(
       }
 
       for (const obj of list.items ?? []) {
-        items.push(dynamicToResource(obj, apiVersion, kind));
+        items.push(listDynamicToResource(obj, apiVersion, kind));
       }
 
       const token = list.metadata?.continue;

--- a/electron/handlers/logs.test.ts
+++ b/electron/handlers/logs.test.ts
@@ -153,6 +153,23 @@ describe('stream_pod_logs', () => {
     expect(out[1]).toBe('next');
   });
 
+  test('an oversized line already newline-terminated within one chunk is still capped', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    // The whole 600 KiB line plus its terminator arrives in a single chunk —
+    // the cap must not rely on the line still being assembled across reads.
+    body.push('before\n' + 'y'.repeat(600 * 1024) + '\nafter\n');
+    await settle();
+
+    const out = lines();
+    expect(out).toEqual([
+      'before',
+      'y'.repeat(512 * 1024) + ' …[line truncated]',
+      'after',
+    ]);
+  });
+
   // A clean end already worked before; the marker and status must both fire.
   test('a graceful end emits the [stream ended] marker and an ended status', async () => {
     const body = stagedBody();

--- a/electron/handlers/logs.test.ts
+++ b/electron/handlers/logs.test.ts
@@ -123,6 +123,36 @@ describe('stream_pod_logs', () => {
     expect(lines()).toEqual(['half-and-half']);
   });
 
+  test('many lines in one chunk come out in order, CR stripped', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    const chunk = Array.from({ length: 50 }, (_, i) => `line-${i}${i % 2 ? '\r' : ''}\n`).join('');
+    body.push(chunk + 'tail');
+    await settle();
+
+    expect(lines()).toEqual(Array.from({ length: 50 }, (_, i) => `line-${i}`));
+    body.push('-end\n');
+    await settle();
+    expect(lines().at(-1)).toBe('tail-end');
+  });
+
+  test('a newline-free line past the cap is truncated and the rest dropped', async () => {
+    const body = stagedBody();
+    await handlers.get('stream_pod_logs')!({ name: 'web-0', namespace: 'default' }, ctx);
+
+    // 600 KiB without a newline, in 100 KiB chunks, then a normal line.
+    for (let i = 0; i < 6; i++) body.push('x'.repeat(100 * 1024));
+    body.push('still-the-same-line\nnext\n');
+    await settle();
+
+    const out = lines();
+    expect(out).toHaveLength(2);
+    expect(out[0].length).toBe(512 * 1024 + ' …[line truncated]'.length);
+    expect(out[0].endsWith(' …[line truncated]')).toBe(true);
+    expect(out[1]).toBe('next');
+  });
+
   // A clean end already worked before; the marker and status must both fire.
   test('a graceful end emits the [stream ended] marker and an ended status', async () => {
     const body = stagedBody();

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -50,12 +50,19 @@ import { AddOptionsToSearchParams, type LogOptions } from '@kubernetes/client-no
 
 import type { HandlerCtx, HandlerMap } from '../dispatch';
 import { apiStream } from '../k8s/api';
+import { mapWithConcurrency } from '../util/concurrency';
 
 const LOG_CHANNEL = 'log-lines';
 const STATUS_CHANNEL = 'log-stream-status';
 
 /** Maximum lines to buffer before emitting a batch. */
+// Longest single line forwarded to the renderer; the rest of the line is
+// dropped with a marker. Bounds main-process memory on newline-free output.
+const LOG_MAX_LINE_CHARS = 512 * 1024;
+const LOG_TRUNCATED_MARKER = ' …[line truncated]';
 const LOG_BATCH_SIZE = 20;
+/** How many pod log streams are dialled at once for a multi-pod session. */
+const MULTI_POD_DIAL_CONCURRENCY = 8;
 /** Maximum time (ms) to wait before flushing a partial batch. */
 const LOG_FLUSH_INTERVAL_MS = 50;
 
@@ -178,6 +185,8 @@ async function pumpBody(
   const decoder = new TextDecoder();
   const reader = body.getReader();
   let partial = '';
+  // True while the rest of an over-long line is being discarded.
+  let dropping = false;
 
   try {
     for (;;) {
@@ -186,20 +195,38 @@ async function pumpBody(
       // Stop feeding a stream nobody is listening to any more.
       if (isStale(session)) return;
       partial += decoder.decode(value, { stream: true });
-      let idx = partial.indexOf('\n');
+      // Split with a moving offset and slice the remainder ONCE per chunk: a
+      // `tail` of thousands of lines arrives in big chunks, and re-slicing the
+      // remainder after every line copied the chunk once per line (O(n²)).
+      let start = 0;
+      let idx = partial.indexOf('\n', start);
       while (idx !== -1) {
-        // Strip the trailing '\n' (and a preceding '\r' if present) — the
-        // renderer expects complete lines with no trailing newline.
-        let line = partial.slice(0, idx);
-        if (line.endsWith('\r')) line = line.slice(0, -1);
-        batcher.push(line);
-        partial = partial.slice(idx + 1);
-        idx = partial.indexOf('\n');
+        if (dropping) {
+          dropping = false;
+        } else {
+          // Strip the trailing '\n' (and a preceding '\r' if present) — the
+          // renderer expects complete lines with no trailing newline.
+          const end = idx > start && partial.charCodeAt(idx - 1) === 13 ? idx - 1 : idx;
+          batcher.push(partial.slice(start, end));
+        }
+        start = idx + 1;
+        idx = partial.indexOf('\n', start);
+      }
+      partial = start > 0 ? partial.slice(start) : partial;
+      // A line with no newline in sight keeps growing in main-process memory
+      // (single-line JSON dumps, binary to stdout): cap it, ship what fits with
+      // a marker, and skip to the next newline.
+      if (!dropping && partial.length > LOG_MAX_LINE_CHARS) {
+        batcher.push(partial.slice(0, LOG_MAX_LINE_CHARS) + LOG_TRUNCATED_MARKER);
+        partial = '';
+        dropping = true;
+      } else if (dropping) {
+        partial = '';
       }
     }
     // A trailing line with no newline terminator from the server.
     partial += decoder.decode();
-    if (partial.length > 0) batcher.push(partial);
+    if (partial.length > 0 && !dropping) batcher.push(partial);
   } finally {
     reader.releaseLock();
     // In the `finally` so a mid-stream failure still delivers what was already
@@ -359,16 +386,18 @@ async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx
   const session = beginSession();
   const drains: Array<Promise<void>> = [];
 
-  for (const podName of pods) {
-    // Bail out of the loop if a stop/restart raced in between iterations.
-    if (isStale(session)) return null;
-
+  // Dial pods concurrently (bounded): serially, 30 pods meant 30 round-trips
+  // before the last one showed a line. Order of the error lines follows
+  // completion order, which is fine — each carries its pod name.
+  const dial = async (podName: string): Promise<void> => {
+    // Bail out if a stop/restart raced in.
+    if (isStale(session)) return;
     try {
       const { drained } = await openStream(ctx, session, namespace, podName, container, args, podName);
-      // Attach a no-op handler NOW: reportWhenDrained only subscribes once the
-      // whole loop has finished dialling, and a reader that dies in the gap
-      // would be an unhandled rejection — fatal to the main process under
-      // Node's default --unhandled-rejections=throw. allSettled still sees the
+      // Attach a no-op handler NOW: reportWhenDrained only subscribes once
+      // every pod has been dialled, and a reader that dies in the gap would be
+      // an unhandled rejection — fatal to the main process under Node's
+      // default --unhandled-rejections=throw. allSettled still sees the
       // original rejection.
       void drained.catch(() => {});
       drains.push(drained);
@@ -378,7 +407,8 @@ async function streamMultiPodLogs(args: Record<string, unknown>, ctx: HandlerCtx
         ctx.emit(LOG_CHANNEL, [`[${podName}] [error: ${messageOf(err)}]`]);
       }
     }
-  }
+  };
+  await mapWithConcurrency(pods, MULTI_POD_DIAL_CONCURRENCY, dial);
 
   if (isStale(session)) return null;
 

--- a/electron/handlers/logs.ts
+++ b/electron/handlers/logs.ts
@@ -207,7 +207,15 @@ async function pumpBody(
           // Strip the trailing '\n' (and a preceding '\r' if present) — the
           // renderer expects complete lines with no trailing newline.
           const end = idx > start && partial.charCodeAt(idx - 1) === 13 ? idx - 1 : idx;
-          batcher.push(partial.slice(start, end));
+          // A line can arrive already newline-terminated within a single
+          // chunk, long before the growing-`partial` check below ever runs —
+          // cap it here too, or a big enough read() bypasses the bound.
+          const len = end - start;
+          batcher.push(
+            len > LOG_MAX_LINE_CHARS
+              ? partial.slice(start, start + LOG_MAX_LINE_CHARS) + LOG_TRUNCATED_MARKER
+              : partial.slice(start, end),
+          );
         }
         start = idx + 1;
         idx = partial.indexOf('\n', start);

--- a/electron/handlers/metrics.ts
+++ b/electron/handlers/metrics.ts
@@ -16,6 +16,7 @@ import { podUsage, podUsageFrom, type ContainerUsage, type PodUsageInfo } from '
 import { promQuery } from '../k8s/prometheus.js';
 import { getPrometheusUrl } from '../k8s/runtime-config.js';
 import { optStr, type HandlerMap } from '../dispatch.js';
+import { createTtlCache } from '../util/ttl-cache.js';
 
 export { podUsageFrom, type ContainerUsage, type PodUsageInfo };
 
@@ -59,18 +60,12 @@ export interface PrometheusResult {
  * the request without visible staleness. Cleared on context switch.
  */
 const POD_METRICS_COALESCE_MS = 5_000;
-const podMetricsCache = new Map<string, { at: number; promise: Promise<PodMetricsResult> }>();
+const podMetricsCache = createTtlCache<PodMetricsResult>(POD_METRICS_COALESCE_MS);
 onConfigChange(() => podMetricsCache.clear());
 
 async function getPodMetrics(args: Record<string, unknown>): Promise<PodMetricsResult> {
   const namespace = optStr(args, 'namespace');
-  const key = namespace ?? '';
-  const now = Date.now();
-  const hit = podMetricsCache.get(key);
-  if (hit && now - hit.at < POD_METRICS_COALESCE_MS) return hit.promise;
-  const promise = fetchPodMetrics(namespace);
-  podMetricsCache.set(key, { at: now, promise });
-  return promise;
+  return podMetricsCache.get(namespace ?? '', () => fetchPodMetrics(namespace));
 }
 
 async function fetchPodMetrics(namespace: string | undefined): Promise<PodMetricsResult> {

--- a/electron/handlers/overview.ts
+++ b/electron/handlers/overview.ts
@@ -22,9 +22,10 @@ import type {
 } from '@kubernetes/client-node';
 
 import { optStr, type HandlerCtx, type HandlerMap } from '../dispatch';
-import { getAppsV1Api, getBatchV1Api, getCoreV1Api } from '../k8s/client';
+import { getActiveContextName, getAppsV1Api, getBatchV1Api, getCoreV1Api, onConfigChange } from '../k8s/client';
 import { listScoped } from '../k8s/list-scope';
 import { nodeUsage as readNodeUsage, podUsageScoped, type NodeUsage } from '../k8s/metrics-source';
+import { createTtlCache } from '../util/ttl-cache';
 import {
   foldPodsIntoOwners,
   nodeProblems,
@@ -120,6 +121,20 @@ export async function getClusterOverview(namespace: string | null): Promise<Clus
   };
 }
 
+// Short TTL + single-flight: Overview and Problems share this payload, and
+// hopping between them (or two tabs mounting at once) re-listed every pod,
+// workload and warning event in the cluster per call. Ten seconds is below
+// anything a person would call stale; failures are never cached.
+const OVERVIEW_CACHE_TTL_MS = 10_000;
+const OVERVIEW_CACHE_MAX_ENTRIES = 4;
+const overviewCache = createTtlCache<ClusterOverview>(OVERVIEW_CACHE_TTL_MS, { maxEntries: OVERVIEW_CACHE_MAX_ENTRIES });
+onConfigChange(() => overviewCache.clear());
+
+export function getClusterOverviewCached(namespace: string | null): Promise<ClusterOverview> {
+  const key = `${getActiveContextName() ?? ''}|${namespace ?? ''}`;
+  return overviewCache.get(key, () => getClusterOverview(namespace));
+}
+
 export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {
-  handlers.set('get_cluster_overview', async (args) => getClusterOverview(optStr(args, 'namespace') ?? null));
+  handlers.set('get_cluster_overview', async (args) => getClusterOverviewCached(optStr(args, 'namespace') ?? null));
 }

--- a/electron/handlers/rbac.ts
+++ b/electron/handlers/rbac.ts
@@ -14,9 +14,10 @@ import { optStr, type HandlerCtx, type HandlerMap } from '../dispatch';
 import { getActiveContextName, getRbacAuthorizationV1Api, onConfigChange } from '../k8s/client';
 import { listScoped } from '../k8s/list-scope';
 import { collectSubjects, effectivePermissions, type RbacInput, type SubjectKind } from '../k8s/rbac';
+import { createTtlCache } from '../util/ttl-cache';
 
 const CACHE_TTL_MS = 30_000;
-const cache = new Map<string, { at: number; promise: Promise<RbacInput> }>();
+const cache = createTtlCache<RbacInput>(CACHE_TTL_MS);
 onConfigChange(() => cache.clear());
 
 async function fetchRbac(namespace: string | null): Promise<RbacInput> {
@@ -32,12 +33,7 @@ async function fetchRbac(namespace: string | null): Promise<RbacInput> {
 
 function loadRbac(namespace: string | null): Promise<RbacInput> {
   const key = `${getActiveContextName() ?? ''}|${namespace ?? ''}`;
-  const hit = cache.get(key);
-  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.promise;
-  const promise = fetchRbac(namespace);
-  cache.set(key, { at: Date.now(), promise });
-  promise.catch(() => cache.delete(key));
-  return promise;
+  return cache.get(key, () => fetchRbac(namespace));
 }
 
 export function register(handlers: HandlerMap, _ctx: HandlerCtx): void {

--- a/electron/handlers/resources.ts
+++ b/electron/handlers/resources.ts
@@ -34,7 +34,7 @@ import type {
   ResourceMetadata,
 } from '../k8s/resource-types';
 import { metaFrom, listMetaFrom, listProjectionFor } from '../k8s/resource-mapping';
-import { apiVersionOf, resolveKindOrThrow, resolveResourceType } from '../k8s/kinds';
+import { RESOURCE_TYPES, apiVersionOf, resolveKindOrThrow, resolveResourceType } from '../k8s/kinds';
 import type { Handler, HandlerMap } from '../dispatch';
 
 // ---------------------------------------------------------------------------
@@ -209,7 +209,17 @@ async function listResources(resourceType: string, namespace?: string): Promise<
   const ar = apiResourceForType(resourceType);
   const project = listProjectionFor(resourceType);
   if (!ar || !project) throw new Error(`Unknown resource type: ${resourceType}`);
-  const { items: raw, resourceVersion } = await listRaw({ ar, namespace });
+  // A kind whose projection keeps nothing but metadata (Role, ClusterRole)
+  // is listed metadata-only: the full bodies (rules…) were downloaded and
+  // parsed just to be thrown away. The registry is the authority on that.
+  const fields = RESOURCE_TYPES[resourceType]?.list;
+  const metaOnly =
+    !!fields && !fields.spec && !fields.status && !fields.data && !(fields.synth && fields.synth.length > 0);
+  const { items: raw, resourceVersion } = await listRaw({
+    ar,
+    namespace,
+    accept: metaOnly ? META_ACCEPT : undefined,
+  });
   const out: ResourceList = { items: raw.map(project), resource_type: resourceType };
   if (resourceVersion) out.resource_version = resourceVersion;
   return out;

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -35,10 +35,10 @@
 
 import { Watch } from '@kubernetes/client-node';
 
-import { kc } from '../k8s/client';
+import { getActiveContextName, kc, onConfigChange } from '../k8s/client';
 import { apiGet, META_ACCEPT } from '../k8s/api';
 import type { RawObject, Resource } from '../k8s/resource-types';
-import { dynamicToResource, listProjectionFor } from '../k8s/resource-mapping';
+import { listDynamicToResource, listProjectionFor } from '../k8s/resource-mapping';
 import { apiVersionOf, resolveResourceType } from '../k8s/kinds';
 import type { Handler, HandlerCtx, HandlerMap } from '../dispatch';
 
@@ -108,7 +108,7 @@ function watchPath(ar: ApiResource, namespace?: string): string {
 
 // Projections live in electron/k8s/resource-mapping.ts (shared with the
 // resources and CRD paths): listProjectionFor gives the per-kind lean list
-// shape; dynamicToResource is the verbatim fallback for unknown kinds.
+// shape; listDynamicToResource is the verbatim fallback for unknown kinds.
 
 // ---------------------------------------------------------------------------
 // Single active watch slot.
@@ -139,6 +139,8 @@ interface ActiveWatch {
    * which forces the classic replay + Resync path once.
    */
   lastRV: string | undefined;
+  /** Context the watch was opened against, to stop it when the user leaves. */
+  contextName: string | undefined;
 }
 
 // Identity of the live ActiveWatch is the generation token: callbacks captured
@@ -199,6 +201,7 @@ async function startResourceWatch(
     openedAt: 0,
     stopped: false,
     lastRV: listResourceVersion,
+    contextName: getActiveContextName(),
   };
   active = state;
 
@@ -209,7 +212,7 @@ async function startResourceWatch(
   // types on the generic verbatim shape.
   const project =
     listProjectionFor(resourceType) ??
-    ((obj: RawObject) => dynamicToResource(obj, ar.apiVersion, ar.kind));
+    ((obj: RawObject) => listDynamicToResource(obj, ar.apiVersion, ar.kind));
 
   const isCurrent = (): boolean => active === state && !state.stopped;
 
@@ -485,4 +488,20 @@ export function register(handlers: HandlerMap, ctx: HandlerCtx): void {
 
   handlers.set('start_resource_watch', startHandler);
   handlers.set('stop_resource_watch', stopHandler);
+
+  // The Watch captured the KubeConfig of the cluster it was opened against;
+  // after a context switch it kept streaming (and reconnecting, with backoff)
+  // from the OLD cluster until the renderer happened to start a new watch.
+  // Only a context change stops it: a kubeconfig rewrite that keeps the
+  // context (an import) must not silently end live updates.
+  onConfigChange(() => {
+    if (!active) return;
+    let current: string | undefined;
+    try {
+      current = getActiveContextName();
+    } catch {
+      current = undefined;
+    }
+    if (current !== active.contextName) clearActive();
+  });
 }

--- a/electron/handlers/watch.ts
+++ b/electron/handlers/watch.ts
@@ -141,6 +141,15 @@ interface ActiveWatch {
   lastRV: string | undefined;
   /** Context the watch was opened against, to stop it when the user leaves. */
   contextName: string | undefined;
+  /**
+   * Settles the pending `start_resource_watch` invoke with a rejection, set
+   * only while that first open is in flight. clearActive() calls this so a
+   * context switch (or a new/stopped watch) racing the first open can't leave
+   * the invoke's promise pending forever — the success/error paths inside
+   * connect() both no-op once `isCurrent()` is false, so nothing else would
+   * ever settle it.
+   */
+  cancelStart: ((err: unknown) => void) | null;
 }
 
 // Identity of the live ActiveWatch is the generation token: callbacks captured
@@ -168,6 +177,11 @@ function clearActive(): void {
       active.controller = null;
     }
     active.batch = [];
+    if (active.cancelStart) {
+      const cancel = active.cancelStart;
+      active.cancelStart = null;
+      cancel(new Error('watch cancelled before it finished opening'));
+    }
   }
   active = null;
 }
@@ -202,6 +216,7 @@ async function startResourceWatch(
     stopped: false,
     lastRV: listResourceVersion,
     contextName: getActiveContextName(),
+    cancelStart: null,
   };
   active = state;
 
@@ -271,15 +286,20 @@ async function startResourceWatch(
     const settleOk = (): void => {
       if (!settled) {
         settled = true;
+        state.cancelStart = null;
         resolve();
       }
     };
     const settleErr = (err: unknown): void => {
       if (!settled) {
         settled = true;
+        state.cancelStart = null;
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     };
+    // clearActive() calls this if the watch is torn down (context switch, a
+    // new start, or an explicit stop) before the first open settles either way.
+    state.cancelStart = settleErr;
 
     /**
      * Reconnecting with NO resourceVersion makes the apiserver replay the

--- a/electron/k8s/metrics-source.ts
+++ b/electron/k8s/metrics-source.ts
@@ -4,9 +4,9 @@
 // per-node usage shapes. cost, metrics, overview and rightsizing all used to
 // construct their own client and parse `usage.cpu` themselves.
 
-import { Metrics, type PodMetric } from '@kubernetes/client-node';
+import type { NodeMetric, PodMetric } from '@kubernetes/client-node';
 
-import { kc } from './client.js';
+import { apiGet } from './api.js';
 import { parseCpu, parseMemory } from './quantity.js';
 
 // ---------------------------------------------------------------------------
@@ -82,8 +82,21 @@ export function resetMetricsAvailability(): void {
 // Reads
 // ---------------------------------------------------------------------------
 
-export function getMetricsApi(): Metrics {
-  return new Metrics(kc());
+// Raw reads rather than client-node's `Metrics` class: that one builds its
+// own https.Agent per request (fresh TLS handshake, CA/cert file reads), which
+// the pods table paid once per poll. apiGet rides the shared auth cache and
+// keep-alive dispatcher like every other request.
+const METRICS_BASE = '/apis/metrics.k8s.io/v1beta1';
+
+function listPodMetrics(namespace?: string): Promise<{ items: PodMetric[] }> {
+  const path = namespace
+    ? `${METRICS_BASE}/namespaces/${encodeURIComponent(namespace)}/pods`
+    : `${METRICS_BASE}/pods`;
+  return apiGet<{ items: PodMetric[] }>(path);
+}
+
+function listNodeMetrics(): Promise<{ items: NodeMetric[] }> {
+  return apiGet<{ items: NodeMetric[] }>(`${METRICS_BASE}/nodes`);
 }
 
 /** Sum the per-container usage into the pod totals the table renders. */
@@ -112,7 +125,7 @@ export async function podUsage(namespace?: string): Promise<PodUsageInfo[]> {
     throw new Error('metrics-server pods endpoint marked unavailable; backing off');
   }
   try {
-    const list = await getMetricsApi().getPodMetrics(namespace);
+    const list = await listPodMetrics(namespace);
     markMetricsAvailable('pods');
     return list.items.map(podUsageFrom);
   } catch (err) {
@@ -137,7 +150,7 @@ export async function nodeUsage(): Promise<Map<string, NodeUsage>> {
     throw new Error('metrics-server nodes endpoint marked unavailable; backing off');
   }
   try {
-    const list = await getMetricsApi().getNodeMetrics();
+    const list = await listNodeMetrics();
     markMetricsAvailable('nodes');
     const map = new Map<string, NodeUsage>();
     for (const m of list.items) map.set(m.metadata.name, { cpu: parseCpu(m.usage.cpu), memory: parseMemory(m.usage.memory) });

--- a/electron/k8s/resource-mapping.ts
+++ b/electron/k8s/resource-mapping.ts
@@ -75,6 +75,18 @@ export function dynamicToResource(obj: RawObject, apiVersion: string, kind: stri
   return res;
 }
 
+/**
+ * dynamicToResource for LIST paths (CRD tables, the watch fallback for kinds
+ * outside the registry): same verbatim spec/status/data, but with
+ * listMetaFrom so the last-applied annotation — a full copy of the spec on
+ * every kubectl-applied object — is not shipped and kept resident per row.
+ */
+export function listDynamicToResource(obj: RawObject, apiVersion: string, kind: string): Resource {
+  const res = dynamicToResource(obj, apiVersion, kind);
+  res.metadata = listMetaFrom(obj.metadata);
+  return res;
+}
+
 // ---------------------------------------------------------------------------
 // Per-resource_type LIST projections — the lean shapes list_resources ships to
 // the renderer. The watch path MUST use the same projection: a watch event

--- a/electron/util/ttl-cache.ts
+++ b/electron/util/ttl-cache.ts
@@ -1,0 +1,47 @@
+// Small shared async utilities for the main process.
+
+interface CacheEntry<T> {
+  at: number;
+  promise: Promise<T>;
+}
+
+export interface TtlCache<T> {
+  /** Returns the cached promise for `key`, or calls `fetch` and caches its result. */
+  get(key: string, fetch: () => Promise<T>): Promise<T>;
+  /** Drops every entry — call on a context switch. */
+  clear(): void;
+}
+
+/**
+ * TTL-memoized, single-flight cache of promises. Concurrent callers for the
+ * same key share one in-flight fetch; a rejected fetch is evicted immediately
+ * (identified by reference, so a slower failure can't clobber a fresher
+ * success for the same key) so the next call retries instead of waiting out
+ * the TTL. Expired entries are swept on the way to a miss rather than kept
+ * resident until a context switch — each one can hold a full list response.
+ */
+export function createTtlCache<T>(ttlMs: number, opts: { maxEntries?: number } = {}): TtlCache<T> {
+  const cache = new Map<string, CacheEntry<T>>();
+
+  function get(key: string, fetch: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    const hit = cache.get(key);
+    if (hit && now - hit.at < ttlMs) return hit.promise;
+    for (const [k, v] of cache) if (now - v.at >= ttlMs) cache.delete(k);
+    if (opts.maxEntries !== undefined) {
+      while (cache.size >= opts.maxEntries) {
+        const oldest = cache.keys().next().value;
+        if (oldest === undefined) break;
+        cache.delete(oldest);
+      }
+    }
+    const promise = fetch();
+    cache.set(key, { at: now, promise });
+    promise.catch(() => {
+      if (cache.get(key)?.promise === promise) cache.delete(key);
+    });
+    return promise;
+  }
+
+  return { get, clear: () => cache.clear() };
+}

--- a/playwright.bench.config.ts
+++ b/playwright.bench.config.ts
@@ -2,9 +2,15 @@
 // another worktree's dev server (electron-vite uses it too), which silently
 // runs the e2e suite against the WRONG build. Use this config when 1420 may
 // be taken: npx playwright test -c playwright.bench.config.ts
+//
+// BENCH_PROD=1 serves a production build (vite build + vite preview) instead
+// of the dev server, so the perf benchmark measures the optimized bundle and
+// the production Svelte runtime — the numbers a user actually gets. The bench
+// store hook is opted in with VITE_KDASH_BENCH=1 (see src/main.ts).
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 1421;
+const PORT = Number(process.env.RENDERER_PORT ?? 1421);
+const PROD = process.env.BENCH_PROD === "1";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -29,11 +35,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `npm run dev -- --port ${PORT} --strictPort`,
+    command: PROD
+      ? `VITE_KDASH_BENCH=1 npx vite build --outDir dist-bench --logLevel warn && npx vite preview --outDir dist-bench --port ${PORT} --strictPort`
+      : `npm run dev -- --port ${PORT} --strictPort`,
     url: `http://localhost:${PORT}`,
     // Never reuse: a server already on this port may belong to another
     // checkout/worktree, which would run the suite against the wrong build.
     reuseExistingServer: false,
-    timeout: 120000,
+    timeout: 180000,
   },
 });

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,4 +1,33 @@
-# List benchmark harness
+# Benchmark harnesses
+
+Two harnesses, one comparer:
+
+| | what it measures | needs a cluster |
+|---|---|---|
+| `frontend.sh` | renderer only, production build: table mount / scroll / filter / type switch / watch churn, retained JS heap | no |
+| `run.sh` | the real Electron app: `list_resources` backend + paint per kind, sidebar counts, then an idle window on the pods table with a live watch — CPU % and memory per process | yes (`kind`) |
+
+Both write JSON under `benchmark-out/`; `compare.ts` diffs two of them.
+
+## Frontend (no cluster)
+
+```bash
+LABEL=baseline ./scripts/bench/frontend.sh          # 3 runs, production build, median
+# ...change code...
+LABEL=after ./scripts/bench/frontend.sh
+bun scripts/bench/compare.ts benchmark-out/frontend-baseline.json benchmark-out/frontend-after.json
+```
+
+It runs `e2e/perf-bench.spec.ts` against `vite build` + `vite preview` (the
+bench store hook is opted in with `VITE_KDASH_BENCH=1`, see `src/main.ts`), so
+the numbers are for the optimized bundle and the production Svelte runtime —
+`DEV=1` uses the dev server instead. `RUNS` sets the repetitions (median is
+reported per metric), `RENDERER_PORT` the port (default 1421).
+
+Heap numbers are taken after a forced GC (retained memory, not garbage), so
+`retainedAfterClearMB` and `churnHeapGrowthMB` are the leak detectors.
+
+## End-to-end list benchmark (`run.sh`)
 
 End-to-end benchmark for the resource-list path: it drives the **real**
 backend (kube list → serialize → IPC → Svelte render) against a local
@@ -14,6 +43,12 @@ backend (kube list → serialize → IPC → Svelte render) against a local
    `invoke("list_resources") → table painted` for each resource type, writes the
    results JSON, and exits the app.
 3. `run.sh` waits for the results file and prints a summary table.
+
+After the list phase the runner sits on the pods table with its watch running
+and samples `app.getAppMetrics()` over a 15 s window (`idle` in the JSON):
+CPU % per process type (browser = main, tab = renderer, GPU, utility), working
+set / private bytes per process, and the renderer's JS heap. That is the
+footprint a user pays for leaving the app open.
 
 Two numbers per type:
 

--- a/scripts/bench/compare.ts
+++ b/scripts/bench/compare.ts
@@ -1,0 +1,55 @@
+// Diff two benchmark JSON documents (frontend or e2e) as a markdown table.
+//
+//   bun scripts/bench/compare.ts before.json after.json
+//
+// Walks both documents, prints every numeric leaf side by side with the delta.
+// Negative deltas are improvements for everything except the few "higher is
+// better" metrics listed in HIGHER_IS_BETTER.
+import { readFileSync } from "node:fs";
+
+type Json = number | string | boolean | null | Json[] | { [k: string]: Json };
+
+const HIGHER_IS_BETTER = [/fps$/i, /rendered$/i, /renderedRows$/i, /itemCount$/i, /count$/i, /total$/i];
+const SKIP = [/^meta\./, /\.samples\./, /\.samples$/, /timestamp/, /DomNodes$/, /domNodes$/];
+
+function flatten(doc: Json, prefix = "", out = new Map<string, number>()): Map<string, number> {
+  if (typeof doc === "number") out.set(prefix, doc);
+  else if (Array.isArray(doc)) doc.forEach((d, i) => flatten(d, `${prefix}[${i}]`, out));
+  else if (doc && typeof doc === "object") {
+    for (const [k, v] of Object.entries(doc)) flatten(v, prefix ? `${prefix}.${k}` : k, out);
+  }
+  return out;
+}
+
+function fmt(n: number): string {
+  return Math.abs(n) >= 100 ? n.toFixed(0) : Math.abs(n) >= 10 ? n.toFixed(1) : n.toFixed(2);
+}
+
+export function compare(before: Json, after: Json): string {
+  const a = flatten(before);
+  const b = flatten(after);
+  const rows: string[] = [];
+  for (const [key, x] of a) {
+    if (SKIP.some((re) => re.test(key))) continue;
+    const y = b.get(key);
+    if (y === undefined) continue;
+    const higher = HIGHER_IS_BETTER.some((re) => re.test(key));
+    const delta = y - x;
+    const pct = x !== 0 ? (delta / Math.abs(x)) * 100 : 0;
+    const better = higher ? delta > 0 : delta < 0;
+    const mark = Math.abs(pct) < 3 ? "·" : better ? "✓" : "✗";
+    rows.push(`| ${key} | ${fmt(x)} | ${fmt(y)} | ${delta >= 0 ? "+" : ""}${fmt(delta)} | ${pct >= 0 ? "+" : ""}${pct.toFixed(0)}% ${mark} |`);
+  }
+  return ["| metric | before | after | Δ | Δ% |", "|---|---:|---:|---:|---:|", ...rows].join("\n");
+}
+
+if (import.meta.main) {
+  const [beforePath, afterPath] = process.argv.slice(2);
+  if (!beforePath || !afterPath) {
+    console.error("usage: compare.ts <before.json> <after.json>");
+    process.exit(2);
+  }
+  const before = JSON.parse(readFileSync(beforePath, "utf8")) as Json;
+  const after = JSON.parse(readFileSync(afterPath, "utf8")) as Json;
+  console.log(compare(before, after));
+}

--- a/scripts/bench/compare.ts
+++ b/scripts/bench/compare.ts
@@ -35,7 +35,11 @@ export function compare(before: Json, after: Json): string {
     if (y === undefined) continue;
     const higher = HIGHER_IS_BETTER.some((re) => re.test(key));
     const delta = y - x;
-    const pct = x !== 0 ? (delta / Math.abs(x)) * 100 : 0;
+    // A zero baseline has no meaningful percent change; report it as infinite
+    // (still marked ✓/✗ below) rather than "+0%", which would read as
+    // unchanged and hide exactly the regressions the leak-detector metrics
+    // (retainedAfterClearMB, churnHeapGrowthMB) are meant to catch: 0 -> 12.
+    const pct = x !== 0 ? (delta / Math.abs(x)) * 100 : delta === 0 ? 0 : delta > 0 ? Infinity : -Infinity;
     const better = higher ? delta > 0 : delta < 0;
     const mark = Math.abs(pct) < 3 ? "·" : better ? "✓" : "✗";
     rows.push(`| ${key} | ${fmt(x)} | ${fmt(y)} | ${delta >= 0 ? "+" : ""}${fmt(delta)} | ${pct >= 0 ? "+" : ""}${pct.toFixed(0)}% ${mark} |`);

--- a/scripts/bench/frontend.sh
+++ b/scripts/bench/frontend.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Reproducible FRONTEND benchmark — no cluster required.
+#
+# Runs e2e/perf-bench.spec.ts RUNS times against a PRODUCTION build of the
+# renderer (vite build + vite preview, bench store hook opted in with
+# VITE_KDASH_BENCH=1) and writes one JSON per run plus a median summary:
+#
+#   benchmark-out/frontend-<label>-run<N>.json
+#   benchmark-out/frontend-<label>.json          (median across runs)
+#
+# Usage:
+#   LABEL=baseline ./scripts/bench/frontend.sh
+#   LABEL=after RUNS=5 ./scripts/bench/frontend.sh
+#   DEV=1 LABEL=x ./scripts/bench/frontend.sh     # dev server instead of prod build
+#   bun scripts/bench/compare.ts benchmark-out/frontend-baseline.json benchmark-out/frontend-after.json
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+LABEL="${LABEL:-$(date +%Y%m%d-%H%M%S)}"
+RUNS="${RUNS:-3}"
+PORT="${RENDERER_PORT:-1421}"
+OUT_DIR="$ROOT_DIR/benchmark-out"
+mkdir -p "$OUT_DIR"
+
+if [[ "${DEV:-0}" == "1" ]]; then PROD=0; else PROD=1; fi
+echo "▸ label=$LABEL runs=$RUNS port=$PORT mode=$([[ $PROD == 1 ]] && echo prod || echo dev)"
+
+for i in $(seq 1 "$RUNS"); do
+  out="$OUT_DIR/frontend-${LABEL}-run${i}.json"
+  rm -f "$out"
+  echo "▸ run $i/$RUNS -> $out"
+  BENCH_OUT="$out" BENCH_PROD="$PROD" RENDERER_PORT="$PORT" \
+    npx playwright test -c playwright.bench.config.ts e2e/perf-bench.spec.ts \
+      --project=chromium --reporter=line --workers=1 >"$OUT_DIR/frontend-${LABEL}-run${i}.log" 2>&1 \
+    || { echo "✗ run $i failed — see $OUT_DIR/frontend-${LABEL}-run${i}.log"; exit 1; }
+done
+
+bun scripts/bench/summarize.ts "$OUT_DIR/frontend-${LABEL}.json" "$OUT_DIR"/frontend-"${LABEL}"-run*.json
+echo "✔ median of $RUNS runs -> $OUT_DIR/frontend-${LABEL}.json"

--- a/scripts/bench/run.sh
+++ b/scripts/bench/run.sh
@@ -83,6 +83,11 @@ if command -v jq >/dev/null 2>&1; then
   echo "  ───────────────────────────────────────────────"
   jq -r '.results[] | "  \(.resourceType | (. + "              ")[0:14])  \(.itemCount | tostring | (("     " + .)[-5:]))   \(.backendMs.median | tostring | (("        " + .)[-7:]))   \(.e2eMs.median | tostring | (("        " + .)[-7:]))"' "$OUT_FILE"
   echo ""
+  echo "  idle (pods table + watch, $(jq -r '.idle.window_ms // 0' "$OUT_FILE")ms window):"
+  echo "    cpu%        $(jq -c '.idle.cpu_percent // {}' "$OUT_FILE")"
+  echo "    working set $(jq -c '.idle.working_set_mb // {}' "$OUT_FILE") MB"
+  echo "    renderer js heap $(jq -r '.idle.renderer_js_heap_mb // "n/a"' "$OUT_FILE") MB   main heap $(jq -r '.idle.main_heap_used_mb // "n/a"' "$OUT_FILE") MB"
+  echo ""
   echo "  meta: $(jq -c '.meta' "$OUT_FILE")"
 else
   cat "$OUT_FILE"

--- a/scripts/bench/summarize.ts
+++ b/scripts/bench/summarize.ts
@@ -1,0 +1,47 @@
+// Median of N benchmark JSON documents with the same shape (numbers are
+// reduced element-wise, everything else is taken from the first run).
+//
+//   bun scripts/bench/summarize.ts out.json run1.json run2.json run3.json
+import { readFileSync, writeFileSync } from "node:fs";
+
+type Json = number | string | boolean | null | Json[] | { [k: string]: Json };
+
+function median(nums: number[]): number {
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  const m = s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  return Math.round(m * 100) / 100;
+}
+
+export function mergeMedian(docs: Json[]): Json {
+  const first = docs[0];
+  if (typeof first === "number") {
+    return median(docs.filter((d): d is number => typeof d === "number"));
+  }
+  if (Array.isArray(first)) {
+    return first.map((_, i) => mergeMedian(docs.map((d) => (d as Json[])[i])));
+  }
+  if (first && typeof first === "object") {
+    const out: { [k: string]: Json } = {};
+    for (const key of Object.keys(first)) {
+      const vals = docs
+        .filter((d) => d && typeof d === "object" && !Array.isArray(d) && key in d)
+        .map((d) => (d as { [k: string]: Json })[key]);
+      out[key] = mergeMedian(vals);
+    }
+    return out;
+  }
+  return first;
+}
+
+if (import.meta.main) {
+  const [out, ...inputs] = process.argv.slice(2);
+  if (!out || inputs.length === 0) {
+    console.error("usage: summarize.ts <out.json> <run.json>...");
+    process.exit(2);
+  }
+  const docs = inputs.map((p) => JSON.parse(readFileSync(p, "utf8")) as Json);
+  const merged = mergeMedian(docs) as { [k: string]: Json };
+  merged.meta = { runs: inputs.length, sources: inputs.map((p) => p.split("/").pop() ?? p) };
+  writeFileSync(out, JSON.stringify(merged, null, 2));
+}

--- a/src/lib/benchmark/e2e-runner.ts
+++ b/src/lib/benchmark/e2e-runner.ts
@@ -126,6 +126,97 @@ async function measureType(
   };
 }
 
+interface ProcessSample {
+  uptime_ms: number;
+  main_heap_used_mb: number;
+  main_rss_mb: number;
+  processes: Array<{ type: string; pid: number; cpu_percent: number; cpu_ms: number | null; working_set_mb: number; private_mb: number }>;
+}
+
+/**
+ * Resource footprint while the app sits on the pods table with a live watch:
+ * CPU per process over an idle window (the number a laptop battery feels) and
+ * memory per process plus the renderer's JS heap.
+ */
+interface IdleProfile {
+  window_ms: number;
+  pod_count: number;
+  cpu_percent: Record<string, number>;
+  working_set_mb: Record<string, number>;
+  private_mb: Record<string, number>;
+  main_heap_used_mb: number;
+  renderer_js_heap_mb: number | null;
+}
+
+const IDLE_WINDOW_MS = 10_000;
+const IDLE_WINDOWS = 3;
+
+async function sampleProcesses(): Promise<ProcessSample> {
+  return invoke<ProcessSample>("bench_process_metrics");
+}
+
+/** CPU % of one core per process type over one window, from /proc deltas. */
+function cpuByType(before: ProcessSample, after: ProcessSample, windowMs: number): Record<string, number> {
+  const prev = new Map(before.processes.map((p) => [p.pid, p.cpu_ms]));
+  const out: Record<string, number> = {};
+  for (const p of after.processes) {
+    const was = prev.get(p.pid);
+    // Electron's own percentCPUUsage reads 0 on some platforms; prefer /proc.
+    const pct = p.cpu_ms !== null && was !== null && was !== undefined ? ((p.cpu_ms - was) / windowMs) * 100 : p.cpu_percent;
+    out[p.type] = (out[p.type] ?? 0) + pct;
+  }
+  return out;
+}
+
+function medianByKey(samples: Array<Record<string, number>>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const key of new Set(samples.flatMap((s) => Object.keys(s)))) {
+    out[key] = stat(samples.map((s) => s[key] ?? 0)).median;
+  }
+  return out;
+}
+
+async function profileIdle(namespace: string | undefined): Promise<IdleProfile> {
+  // A real list + watch, the way a user sits on the pods table.
+  k8sStore.currentNamespace = namespace ?? "";
+  uiStore.backToTable();
+  k8sStore.setResourceType("pods");
+  await k8sStore.loadResources("pods");
+  await nextPaint();
+  // Let the post-list work (watch sync, counts, metrics poll) settle first.
+  await new Promise((r) => setTimeout(r, 3000));
+  // Several windows, median per process: one window is at the mercy of a
+  // repaint or a burst of watch events landing inside it.
+  const cpuSamples: Array<Record<string, number>> = [];
+  let before = await sampleProcesses();
+  let after = before;
+  for (let i = 0; i < IDLE_WINDOWS; i++) {
+    const t0 = performance.now();
+    await new Promise((r) => setTimeout(r, IDLE_WINDOW_MS));
+    after = await sampleProcesses();
+    cpuSamples.push(cpuByType(before, after, performance.now() - t0));
+    before = after;
+  }
+  const byType = (pick: (p: ProcessSample["processes"][number]) => number): Record<string, number> => {
+    const out: Record<string, number> = {};
+    for (const p of after.processes) {
+      // Several renderer/utility processes can exist; sum per type.
+      out[p.type] = round((out[p.type] ?? 0) + pick(p));
+    }
+    return out;
+  };
+  const mem = (performance as unknown as { memory?: { usedJSHeapSize: number } }).memory;
+  return {
+    window_ms: IDLE_WINDOW_MS * IDLE_WINDOWS,
+    pod_count: k8sStore.resources.items.length,
+    cpu_percent: medianByKey(cpuSamples),
+    working_set_mb: byType((p) => p.working_set_mb),
+    private_mb: byType((p) => p.private_mb),
+    main_heap_used_mb: after.main_heap_used_mb,
+    renderer_js_heap_mb: mem ? round(mem.usedJSHeapSize / 1048576) : null,
+  };
+}
+
 /** Returns true if benchmark mode was active and handled init (caller should stop). */
 export async function maybeRunBenchmark(): Promise<boolean> {
   let cfg: BenchConfig;
@@ -204,6 +295,14 @@ export async function maybeRunBenchmark(): Promise<boolean> {
       console.warn("[bench] get_resource_counts failed:", err);
     }
 
+    let idle: IdleProfile | null = null;
+    try {
+      idle = await profileIdle(namespace);
+      console.log(`[bench] idle ${idle.window_ms}ms: cpu%=${JSON.stringify(idle.cpu_percent)} ws_mb=${JSON.stringify(idle.working_set_mb)} renderer_heap=${idle.renderer_js_heap_mb}MB`);
+    } catch (err) {
+      console.warn("[bench] idle profile failed:", err);
+    }
+
     const payload = {
       meta: {
         timestamp: new Date().toISOString(),
@@ -217,6 +316,7 @@ export async function maybeRunBenchmark(): Promise<boolean> {
       },
       results,
       countsMs,
+      idle,
     };
 
     const json = JSON.stringify(payload, null, 2);

--- a/src/lib/components/sidebar/Sidebar.svelte
+++ b/src/lib/components/sidebar/Sidebar.svelte
@@ -123,16 +123,19 @@
   });
 
   // Flat list: every CRD group is always visible, so load counts for all of
-  // them (only fetch the ones not already loaded).
+  // them (only fetch the ones not already loaded). One call for every group:
+  // this effect reads crdCounts, which each response rewrites, so a call per
+  // group re-ran it once per response and re-requested every group still
+  // pending — O(groups²) get_crd_counts on connect. The store additionally
+  // skips CRDs whose count is already in flight.
   $effect(() => {
+    const missing: CrdInfo[] = [];
     for (const group of visibleCrdGroups) {
-      const missing = group.resources.filter(
-        (crd) => !(k8sStore.crdKey(crd) in k8sStore.crdCounts),
-      );
-      if (missing.length > 0) {
-        k8sStore.loadCrdCounts(missing);
+      for (const crd of group.resources) {
+        if (!(k8sStore.crdKey(crd) in k8sStore.crdCounts)) missing.push(crd);
       }
     }
+    if (missing.length > 0) k8sStore.loadCrdCounts(missing);
   });
 
 </script>

--- a/src/lib/components/table/ResourceTable.svelte
+++ b/src/lib/components/table/ResourceTable.svelte
@@ -29,7 +29,7 @@
   import WorkloadStats from "$lib/components/common/WorkloadStats.svelte";
   import { computeWorkloadStats } from "$lib/utils/workload-stats";
   import { createVirtualizer } from "@tanstack/svelte-virtual";
-  import { applyFilterState, countActiveFilters, sortResources, computeAllSelected as _computeAllSelected, computeSomeSelected as _computeSomeSelected, handleSelectAll as _handleSelectAll, MIN_COL_WIDTH as _MIN_COL_WIDTH, type FilterState } from "./resource-table";
+  import { applyFilterState, countViews, countActiveFilters, sortResources, computeAllSelected as _computeAllSelected, computeSomeSelected as _computeSomeSelected, handleSelectAll as _handleSelectAll, MIN_COL_WIDTH as _MIN_COL_WIDTH, type FilterState } from "./resource-table";
   import { columnsByType, defaultColumns, minimumTableWidth, GUTTER_WIDTH, getColumnWidth as _getColumnWidth, setColumnWidth as _setColumnWidth } from "./table-columns";
   import { tablePrefs } from "./table-prefs.svelte";
   import { ROW_HEIGHT, nextDensity, DENSITY_LABEL } from "./table-density";
@@ -129,12 +129,13 @@
   // columns ignore it. ageTick is deliberately NOT read here: formatAge works
   // from the clock, and reading the tick would re-filter the list every 30s.
   function facetCtxFor(r: Resource): CellContext {
+    const type = k8sStore.selectedResourceType;
     return {
       ageTick: 0,
-      nodeMetrics: costStore.getNodeMetrics(r.metadata.name),
-      nodeCost: costStore.getNodeCost(r.metadata.name),
-      podUsage: metricsStore.getPodUsage(r.metadata.namespace, r.metadata.name),
-      endpoints: endpointsStore.summaryFor(r.metadata.namespace, r.metadata.name),
+      nodeMetrics: type === "nodes" ? costStore.getNodeMetrics(r.metadata.name) : undefined,
+      nodeCost: type === "nodes" ? costStore.getNodeCost(r.metadata.name) : undefined,
+      podUsage: type === "pods" ? metricsStore.getPodUsage(r.metadata.namespace, r.metadata.name) : undefined,
+      endpoints: type === "services" ? endpointsStore.summaryFor(r.metadata.namespace, r.metadata.name) : undefined,
     };
   }
 
@@ -153,16 +154,11 @@
   // Row count per saved view, for the toolbar's view chips — through the same
   // pipeline, so a view's count and its rows can never disagree.
   let viewCounts = $derived.by((): Record<string, number> => {
-    const items = k8sStore.resources.items;
-    const out: Record<string, number> = {};
-    for (const view of viewsFor(k8sStore.selectedResourceType, settingsStore.savedViews)) {
-      out[view.id] = filter(items, {
-        statFilter: view.statFilter ?? null,
-        facets: view.facets ?? [],
-        text: view.text ?? "",
-      }).length;
-    }
-    return out;
+    const views = viewsFor(k8sStore.selectedResourceType, settingsStore.savedViews).map((view) => ({
+      id: view.id,
+      state: { statFilter: view.statFilter ?? null, facets: view.facets ?? [], text: view.text ?? "" },
+    }));
+    return countViews(k8sStore.resources.items, views, k8sStore.selectedResourceType, facetCtxFor);
   });
 
   function clearAllFilters() {

--- a/src/lib/components/table/ResourceTable.test.ts
+++ b/src/lib/components/table/ResourceTable.test.ts
@@ -9,6 +9,8 @@ import {
   clampColumnWidth,
   applyFilterState,
   countActiveFilters,
+  countViews,
+  compileFilterState,
 } from "./resource-table";
 import { minimumTableWidth, GUTTER_WIDTH, NAME_MIN_WIDTH, UNSIZED_MIN_WIDTH } from "./table-columns";
 
@@ -513,6 +515,37 @@ describe("ResourceTable — filter pipeline", () => {
     // Status is the effective state, so api-2 (CrashLoopBackOff) is no longer "running".
     expect(applyFilterState(items, { statFilter: null, facets: [{ key: "status", op: ":", value: "running" }], text: "api" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-1"]);
     expect(applyFilterState(items, { statFilter: null, facets: [{ key: "status", op: ":", value: "crash" }], text: "api" }, "pods", ctxFor).map((r) => r.metadata.name)).toEqual(["api-2"]);
+  });
+  test("compileFilterState returns null for the empty state and a predicate otherwise", () => {
+    expect(compileFilterState({ statFilter: null, facets: [], text: "" }, "pods", ctxFor)).toBeNull();
+    const test = compileFilterState({ statFilter: "running", facets: [], text: "api" }, "pods", ctxFor)!;
+    expect(items.filter(test).map((r) => r.metadata.name)).toEqual(["api-1"]);
+  });
+  test("countViews agrees with applyFilterState for every view, in one pass", () => {
+    const views = [
+      { id: "all", state: { statFilter: null, facets: [], text: "" } },
+      { id: "attention", state: { statFilter: "needsAttention", facets: [], text: "" } },
+      { id: "restarting", state: { statFilter: null, facets: [{ key: "restarts", op: ">" as const, value: "0" }], text: "" } },
+      { id: "jobs", state: { statFilter: null, facets: [], text: "job" } },
+    ];
+    let ctxCalls = 0;
+    const countingCtx = () => {
+      ctxCalls++;
+      return { ageTick: 0 };
+    };
+    const counts = countViews(items, views, "pods", countingCtx);
+    for (const v of views) {
+      expect(counts[v.id]).toBe(applyFilterState(items, v.state, "pods", ctxFor).length);
+    }
+    expect(counts).toEqual({ all: 3, attention: 1, restarting: 1, jobs: 1 });
+    // One context per row, shared by every facet view — not one per row per view.
+    expect(ctxCalls).toBe(items.length);
+  });
+  test("countViews with only the All view never walks the items", () => {
+    const counts = countViews(items, [{ id: "all", state: { statFilter: null, facets: [], text: "" } }], "pods", () => {
+      throw new Error("should not build a context");
+    });
+    expect(counts).toEqual({ all: 3 });
   });
   test("countActiveFilters counts each kind once", () => {
     expect(countActiveFilters({ facets: [], text: "", statFilter: null })).toBe(0);

--- a/src/lib/components/table/TableRow.svelte
+++ b/src/lib/components/table/TableRow.svelte
@@ -74,11 +74,16 @@
 
   // Everything the cell accessors need from the stores, gathered once per row
   // so cell-values.ts can stay a pure module.
+  // Each lookup is gated on the table that reads it: a row subscribes to the
+  // node-cost / pod-usage records it would otherwise never render, and every
+  // metrics poll re-ran every cell of every visible row on every table.
   let cellCtx = $derived({
     ageTick: k8sStore.ageTick,
-    nodeCost: costStore.getNodeCost(resource.metadata.name),
-    nodeMetrics: costStore.getNodeMetrics(resource.metadata.name),
-    podUsage: metricsStore.getPodUsage(resource.metadata.namespace, resource.metadata.name),
+    nodeCost: resourceType === "nodes" ? costStore.getNodeCost(resource.metadata.name) : undefined,
+    nodeMetrics: resourceType === "nodes" ? costStore.getNodeMetrics(resource.metadata.name) : undefined,
+    podUsage: resourceType === "pods"
+      ? metricsStore.getPodUsage(resource.metadata.namespace, resource.metadata.name)
+      : undefined,
     autoscaler: flavor ? autoscalerSummary(resource, flavor) : undefined,
     endpoints: resourceType === "services"
       ? endpointsStore.summaryFor(resource.metadata.namespace, resource.metadata.name)
@@ -130,6 +135,14 @@
   });
 
   let lastColumnIndex = $derived(columns.length - 1);
+
+  // The checkbox and the hover actions are invisible until the pointer is on
+  // the row (or it is keyboard-highlighted / part of a selection), yet they
+  // were mounted for every virtual row: a bits-ui checkbox plus two to four
+  // Buttons with lucide icons, i.e. most of the cost of creating a row — which
+  // is what scrolling does, tens of times per frame. Mount them on demand.
+  let hovered = $state(false);
+  let showChrome = $derived(hovered || highlighted || checkboxChecked || selectionActive);
 </script>
 
 <tr
@@ -146,6 +159,8 @@
   onclick={onclick}
   ondblclick={ondblclick}
   oncontextmenu={oncontextmenu}
+  onpointerenter={() => (hovered = true)}
+  onpointerleave={() => (hovered = false)}
   tabindex={highlighted ? 0 : -1}
   aria-selected={selected || highlighted}
   data-testid="resource-row"
@@ -166,7 +181,7 @@
         aria-hidden="true"
       ></span>
     {/if}
-    {#if oncheck}
+    {#if oncheck && showChrome}
       <span
         class={cn(
           "inline-flex items-center justify-center align-middle transition-opacity",
@@ -420,7 +435,7 @@
         >{cellValue}</span>
       {/if}
 
-      {#if ci === lastColumnIndex && onmore}
+      {#if ci === lastColumnIndex && onmore && showChrome}
         <RowActions {resource} {resourceType} {onmore} />
       {/if}
     </td>

--- a/src/lib/components/table/resource-table.ts
+++ b/src/lib/components/table/resource-table.ts
@@ -1,7 +1,7 @@
 import type { FilterState, Resource } from "$lib/types";
 import { isPodNeedingAttention, matchesStatFilter } from "$lib/utils/workload-stats";
 import { eventLastTimestamp, type CellContext } from "./cell-values";
-import { applyFacets } from "./table-filter";
+import { matchesFacet } from "./table-filter";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -39,20 +39,23 @@ export function clampColumnWidth(width: number): number {
 export function filterResources(items: Resource[], filterText: string): Resource[] {
   if (!filterText) return items;
   const lower = filterText.toLowerCase();
-  return items.filter((r) => {
-    if (
-      r.metadata.name.toLowerCase().includes(lower) ||
-      (r.metadata.namespace ?? "").toLowerCase().includes(lower)
-    ) {
-      return true;
-    }
-    if (r.kind !== "Event") return false;
-    const spec = r.spec as { reason?: unknown; message?: unknown } | undefined;
-    return (
-      (typeof spec?.reason === "string" && spec.reason.toLowerCase().includes(lower)) ||
-      (typeof spec?.message === "string" && spec.message.toLowerCase().includes(lower))
-    );
-  });
+  return items.filter((r) => matchesText(r, lower));
+}
+
+/** `lower` must already be lowercased — callers hoist that out of the loop. */
+export function matchesText(r: Resource, lower: string): boolean {
+  if (
+    r.metadata.name.toLowerCase().includes(lower) ||
+    (r.metadata.namespace ?? "").toLowerCase().includes(lower)
+  ) {
+    return true;
+  }
+  if (r.kind !== "Event") return false;
+  const spec = r.spec as { reason?: unknown; message?: unknown } | undefined;
+  return (
+    (typeof spec?.reason === "string" && spec.reason.toLowerCase().includes(lower)) ||
+    (typeof spec?.message === "string" && spec.message.toLowerCase().includes(lower))
+  );
 }
 
 export type { FilterState };
@@ -62,23 +65,87 @@ export type { FilterState };
  * shared by the visible list and by the saved-view counts in the toolbar, so
  * "Attention 3" and the rows you get on clicking it can never disagree.
  * `ctxFor` supplies per-resource cell context for facets on usage columns.
+ * Returns null when the state filters nothing, so callers can skip the pass.
  */
+export function compileFilterState(
+  state: FilterState,
+  resourceType: string,
+  ctxFor: (resource: Resource) => CellContext,
+): ((resource: Resource) => boolean) | null {
+  const tests: Array<(r: Resource) => boolean> = [];
+  if (state.statFilter) {
+    const key = state.statFilter;
+    tests.push(
+      key === "needsAttention"
+        ? isPodNeedingAttention
+        : (r) => matchesStatFilter(r, resourceType, key),
+    );
+  }
+  if (state.facets.length > 0) {
+    const facets = state.facets;
+    tests.push((r) => {
+      const ctx = ctxFor(r);
+      return facets.every((f) => matchesFacet(r, f, ctx));
+    });
+  }
+  if (state.text) {
+    const lower = state.text.toLowerCase();
+    tests.push((r) => matchesText(r, lower));
+  }
+  if (tests.length === 0) return null;
+  if (tests.length === 1) return tests[0];
+  return (r) => tests.every((t) => t(r));
+}
+
 export function applyFilterState(
   items: Resource[],
   state: FilterState,
   resourceType: string,
   ctxFor: (resource: Resource) => CellContext,
 ): Resource[] {
-  if (state.statFilter) {
-    const key = state.statFilter;
-    items =
-      key === "needsAttention"
-        ? items.filter(isPodNeedingAttention)
-        : items.filter((r) => matchesStatFilter(r, resourceType, key));
+  const test = compileFilterState(state, resourceType, ctxFor);
+  return test ? items.filter(test) : items;
+}
+
+/**
+ * Row count per saved view in ONE pass over the items. The toolbar needs a
+ * number per view on every watch flush; filtering the list once per view
+ * materialized K arrays and built a cell context per row per facet view.
+ * Here the context is built at most once per row and shared by every view.
+ */
+export function countViews(
+  items: Resource[],
+  views: Array<{ id: string; state: FilterState }>,
+  resourceType: string,
+  ctxFor: (resource: Resource) => CellContext,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  let current: Resource | null = null;
+  let currentCtx: CellContext | undefined;
+  const sharedCtx = (r: Resource) => {
+    if (r !== current) {
+      current = r;
+      currentCtx = ctxFor(r);
+    }
+    return currentCtx!;
+  };
+  const active: Array<{ id: string; test: (r: Resource) => boolean }> = [];
+  for (const view of views) {
+    const test = compileFilterState(view.state, resourceType, sharedCtx);
+    if (test) {
+      out[view.id] = 0;
+      active.push({ id: view.id, test });
+    } else {
+      out[view.id] = items.length;
+    }
   }
-  if (state.facets.length > 0) items = applyFacets(items, state.facets, ctxFor);
-  if (state.text) items = filterResources(items, state.text);
-  return items;
+  if (active.length === 0) return out;
+  for (const r of items) {
+    for (const view of active) {
+      if (view.test(r)) out[view.id]++;
+    }
+  }
+  return out;
 }
 
 /** How many things the status bar should say are filtering the view. */
@@ -152,12 +219,14 @@ export function sortResources(
 export function computeAllSelected(filteredResources: Resource[], selectedRows: Set<string>): boolean {
   return (
     filteredResources.length > 0 &&
+    selectedRows.size >= filteredResources.length &&
     filteredResources.every((r) => selectedRows.has(r.metadata.uid))
   );
 }
 
 /** Returns true when at least one filtered resource is in the selected set. */
 export function computeSomeSelected(filteredResources: Resource[], selectedRows: Set<string>): boolean {
+  if (selectedRows.size === 0) return false;
   return filteredResources.some((r) => selectedRows.has(r.metadata.uid));
 }
 

--- a/src/lib/components/topology/TopologyCanvas.svelte
+++ b/src/lib/components/topology/TopologyCanvas.svelte
@@ -248,14 +248,18 @@
 
   <!-- Edges -->
   {#each graph.edges as edge (edge.from + "-" + edge.to)}
+    <!-- One highlight test per edge per hover change, not four: a hover
+         re-evaluates every edge's attributes, and large graphs have thousands. -->
+    {@const hl = isEdgeHighlighted(edge)}
+    {@const dim = isEdgeDimmed(edge)}
     <path
       d={edgePath(edge)}
       fill="none"
-      stroke={isEdgeHighlighted(edge) ? "var(--accent)" : "var(--text-muted)"}
-      stroke-width={isEdgeHighlighted(edge) ? 2 : 1}
-      stroke-opacity={isEdgeDimmed(edge) ? 0.15 : isEdgeHighlighted(edge) ? 0.8 : 0.35}
-      marker-end={isEdgeHighlighted(edge) ? "url(#arrowhead-highlight)" : "url(#arrowhead)"}
-      class="transition-all duration-150"
+      stroke={hl ? "var(--accent)" : "var(--text-muted)"}
+      stroke-width={hl ? 2 : 1}
+      stroke-opacity={dim ? 0.15 : hl ? 0.8 : 0.35}
+      marker-end={hl ? "url(#arrowhead-highlight)" : "url(#arrowhead)"}
+      class="transition-[stroke,stroke-width,stroke-opacity] duration-150"
     />
   {/each}
 

--- a/src/lib/stores/k8s.svelte.ts
+++ b/src/lib/stores/k8s.svelte.ts
@@ -103,6 +103,13 @@ class K8sStore extends K8sStoreLogic {
   // `reinserted` records that transition and the flush honours it. Every other
   // case keeps the uid's existing position, matching a replay exactly.
   private _pendingWatchEvents = new Map<string, PendingWatchEvent>();
+  // uid → Resource index of `resources.items`, kept between watch flushes so a
+  // batch of M events costs O(M), not O(N+M). `_byUidItems` records which
+  // array it describes: any other writer replacing the list (refresh, tab
+  // switch) makes it stale and it is rebuilt on the next flush. Dropped — not
+  // kept stale — on replacement so it never pins a list the store let go of.
+  private _byUid: Map<string, Resource> | null = null;
+  private _byUidItems: Resource[] | null = null;
   /** Cancels the scheduled flush; null when no flush is pending. */
   private _cancelWatchFlush: (() => void) | null = null;
   // Serializes start/stop so two fire-and-forget callers can't race on the
@@ -474,7 +481,13 @@ class K8sStore extends K8sStoreLogic {
     this._watchOp = this._watchOp.then(async () => {
       await this._stopWatchInner();
       // Start age ticker every 30s to refresh displayed ages (1s is wasteful – age labels barely change)
-      this._ageInterval = setInterval(() => { this.ageTick++; }, 30_000);
+      // Skipped while the window is hidden: nothing is painted, and each tick
+      // re-renders every visible row's age cells. The first tick after the
+      // window comes back refreshes them, so nothing is lost.
+      this._ageInterval = setInterval(() => {
+        if (typeof document !== "undefined" && document.hidden) return;
+        this.ageTick++;
+      }, 30_000);
       try {
         // Listen for watch events from the backend
         this._watchUnlisten = await listen<import("./k8s.logic.js").WatchEvent | import("./k8s.logic.js").WatchEvent[]>("resource-watch-event", (event) => {
@@ -568,6 +581,14 @@ class K8sStore extends K8sStoreLogic {
   }
 
   /** Drop every buffered delta and cancel any scheduled flush. */
+  override _replaceResources(list: ResourceList, at: number): void {
+    if (this._byUidItems !== list.items) {
+      this._byUid = null;
+      this._byUidItems = null;
+    }
+    super._replaceResources(list, at);
+  }
+
   private _discardPendingWatchEvents(): void {
     this._pendingWatchEvents.clear();
     this._cancelWatchFlush?.();
@@ -585,17 +606,28 @@ class K8sStore extends K8sStoreLogic {
     // Guard: discard stale events if context/namespace changed during the frame
     const scopeGen = this._scopeGeneration;
 
-    // Build an ordered uid→Resource map once (O(N)) so each event is an O(1)
-    // upsert/delete instead of an O(N) findIndex/splice — turns the worst-case
-    // O(N·M) flush (M events over N items) into O(N+M). Map iteration order
-    // matches the current array and set() keeps an existing key's position, so
-    // an update lands in place; only a `reinserted` uid moves (see below).
-    // A fresh array is built at the end (required for $state.raw correctness).
-    const byUid = new Map<string, Resource>();
-    for (const r of this.resources.items) {
-      const uid = r.metadata?.uid;
-      if (uid) byUid.set(uid, r);
+    // Ordered uid→Resource map so each event is an O(1) upsert/delete instead
+    // of an O(N) findIndex/splice. Map iteration order matches the current
+    // array and set() keeps an existing key's position, so an update lands in
+    // place; only a `reinserted` uid moves (see below). The map survives
+    // between flushes (see _byUid): building it is the only O(N) step, and a
+    // rollout on a 5k-pod list used to pay it once per frame for batches of
+    // one event. A fresh array is still built at the end (required for
+    // $state.raw correctness).
+    let byUid: Map<string, Resource>;
+    if (this._byUid && this._byUidItems === this.resources.items) {
+      byUid = this._byUid;
+    } else {
+      byUid = new Map<string, Resource>();
+      for (const r of this.resources.items) {
+        const uid = r.metadata?.uid;
+        if (uid) byUid.set(uid, r);
+      }
     }
+    // Checked out for the duration of the batch: an early return below (scope
+    // changed mid-flush) leaves a half-applied map, which must not be reused.
+    this._byUid = null;
+    this._byUidItems = null;
 
     let selectedResourceUpdate: Resource | null | undefined;
     let changed = false;
@@ -648,7 +680,11 @@ class K8sStore extends K8sStoreLogic {
       // Trigger Svelte 5 reactivity ONCE for the entire batch
       this._replaceResources({ items, resource_type: this.resources.resource_type }, Date.now());
       this._setCount(this.selectedResourceType, items.length);
+      this._byUidItems = items;
+    } else {
+      this._byUidItems = this.resources.items;
     }
+    this._byUid = byUid;
 
     if (selectedResourceUpdate !== undefined) {
       this.selectedResource = selectedResourceUpdate;
@@ -761,8 +797,15 @@ class K8sStore extends K8sStoreLogic {
     }
   }
 
-  async loadCrdCounts(crds: CrdInfo[]): Promise<void> {
+  private _crdCountsInFlight = new Set<string>();
+  async loadCrdCounts(requested: CrdInfo[]): Promise<void> {
+    // A CRD whose count is already being fetched is not requested again: the
+    // sidebar effect re-runs on every partial result and would otherwise
+    // re-issue the whole remaining set each time.
+    const crds = requested.filter((crd) => !this._crdCountsInFlight.has(this.crdKey(crd)));
     if (crds.length === 0) return;
+    const keys = crds.map((crd) => this.crdKey(crd));
+    for (const key of keys) this._crdCountsInFlight.add(key);
     try {
       const counts = await invoke<Record<string, number>>("get_crd_counts", {
         crds,
@@ -771,6 +814,8 @@ class K8sStore extends K8sStoreLogic {
       this.crdCounts = { ...this.crdCounts, ...counts };
     } catch {
       // Silently fail — counts are non-essential
+    } finally {
+      for (const key of keys) this._crdCountsInFlight.delete(key);
     }
   }
 }

--- a/src/lib/stores/ui.logic.ts
+++ b/src/lib/stores/ui.logic.ts
@@ -159,8 +159,22 @@ export class UiStoreLogic {
   protected _debounceTimer: ReturnType<typeof setTimeout> | null = null;
   protected _debounceTarget: Tab | null = null;
 
+  // Memoized on (tabs array, index, id): every per-tab getter below goes
+  // through here, and the table reads several of them per visible row per
+  // render, so a linear scan over proxied tabs each time added up. Any
+  // mutation that moves or replaces the tab fails the index check and falls
+  // back to the scan; the reads still register the same reactive deps.
+  #cachedTab: Tab | undefined;
+  #cachedTabIdx = -1;
   get activeTab(): Tab | undefined {
-    return this.tabs.find((t) => t.id === this.activeTabId);
+    const id = this.activeTabId;
+    const tabs = this.tabs;
+    const cached = this.#cachedTab;
+    if (cached && cached.id === id && tabs[this.#cachedTabIdx] === cached) return cached;
+    const idx = tabs.findIndex((t) => t.id === id);
+    this.#cachedTabIdx = idx;
+    this.#cachedTab = idx >= 0 ? tabs[idx] : undefined;
+    return this.#cachedTab;
   }
 
   /**

--- a/src/lib/stores/ui.test.ts
+++ b/src/lib/stores/ui.test.ts
@@ -274,6 +274,31 @@ describe("UiStore", () => {
     });
   });
 
+  describe("activeTab memo", () => {
+    test("tracks the active tab across open, move, close and array replacement", () => {
+      const pods = store.activeTab!;
+      store.openTab("logs", { label: "logs" });
+      const logs = store.activeTab!;
+      expect(logs).not.toBe(pods);
+      expect(logs.type).toBe("logs");
+      // Same id, same object, repeated reads.
+      expect(store.activeTab).toBe(logs);
+      // Moving the tab changes its index; the memo must follow it.
+      store.moveTab(logs.id, "left");
+      expect(store.activeTab).toBe(logs);
+      expect(store.tabs[0]).toBe(logs);
+      // Replacing the array with fresh objects (a session restore) must not
+      // keep handing out the stale object.
+      const fresh = store.tabs.map((t) => ({ ...t }));
+      store.tabs = fresh;
+      expect(store.activeTab).toBe(fresh[0]);
+      expect(store.activeTab).not.toBe(logs);
+      // Closing the active tab falls back to another tab.
+      store.closeTab(fresh[0].id);
+      expect(store.activeTab?.id).toBe(pods.id);
+    });
+  });
+
   describe("tab system", () => {
     test("starts with the pods table tab active", () => {
       expect(store.tabs.length).toBe(1);

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,8 +48,10 @@ import("$lib/utils/preload").then((m) => m.preloadHeavyViews()).catch(() => {});
 // DEV/E2E-only: expose the live stores on window so the reproducible frontend
 // benchmark harness (e2e/perf-bench.spec.ts) can inject synthetic datasets and
 // drive the real render path without a cluster. Tree-shaken out of prod builds
-// (import.meta.env.DEV is statically false there).
-if (import.meta.env.DEV) {
+// (import.meta.env.DEV is statically false there). VITE_KDASH_BENCH=1 opts a
+// production build in, so the benchmark can measure the optimized bundle
+// (scripts/bench/frontend.sh) instead of the dev-mode Svelte runtime.
+if (import.meta.env.DEV || import.meta.env.VITE_KDASH_BENCH === "1") {
   void Promise.all([
     import("$lib/stores/k8s.svelte"),
     import("$lib/stores/ui.svelte"),


### PR DESCRIPTION
## Summary

- Adds a reproducible **frontend** benchmark (`scripts/bench/frontend.sh`) that runs `e2e/perf-bench.spec.ts` against a production build (`BENCH_PROD=1`, opted into the store-injection hook via `VITE_KDASH_BENCH=1`), tracking mount/scroll/filter latency plus **retained JS heap** (forced-GC sampling) and heap growth under watch churn — so a leak shows up as a number, not a hunch. `scripts/bench/summarize.ts` medians repeated runs and `scripts/bench/compare.ts` diffs two labeled runs as a markdown table.
- Extends the existing **e2e** (real cluster) benchmark with an idle-window profile: CPU % and memory per Electron process type while the app sits on the pods table with a live watch, via a new benchmark-only `bench_process_metrics` IPC handler (reads `/proc/<pid>/stat` on Linux for accurate CPU deltas, since `percentCPUUsage` reads 0 on some setups).
- Fixes several retained-memory / redundant-work paths surfaced while building the above:
  - Per-cluster/per-namespace caches (CRD discovery & columns, pod metrics, RBAC, and a new cluster-overview cache) now sweep expired entries on the way to a miss instead of pinning every namespace/context ever visited until the next context switch.
  - The resource watch and in-flight CRD-count fetches are torn down on a context switch instead of continuing to stream/reconnect against the old cluster.
  - `stream_pod_logs` caps a newline-free line at 512 KiB instead of growing main-process memory unbounded, and multi-pod log dialling is bounded to 8 concurrent streams (`mapWithConcurrency`) instead of serial round-trips.
  - The resource table skips building unused per-row usage lookups (node cost/metrics, pod usage, endpoints) for resource types that don't render them, and virtualized rows only mount hover-only chrome (checkbox, row actions) when it's actually visible.
  - `k8sStore`'s watch-flush now reuses its uid→Resource index across flushes instead of rebuilding it every batch, and `activeTab` is memoized against the tabs array instead of a linear scan per read.
  - `metrics-source.ts` now reads pod/node metrics through the shared authenticated client instead of constructing a fresh `Metrics` client (and TLS agent) per poll.
- **Consolidates the TTL/single-flight/sweep cache pattern** — independently reimplemented with subtly different guarantees (missing sweep, missing max-entries, missing identity-checked failure eviction) across `crd.ts`, `metrics.ts`, `rbac.ts`, and the new `overview.ts` cache — into one shared `electron/util/ttl-cache.ts`. This also fixes a latent race in `rbac.ts`'s cache, where failure eviction deleted by key unconditionally instead of checking the promise was still the current one.

## Test plan

- [x] `bun run typecheck:electron`
- [x] `bun test` (frontend, 1439 tests) and `bun test ./electron` (197 tests) — all green
- [ ] `LABEL=baseline ./scripts/bench/frontend.sh` / `LABEL=after ./scripts/bench/frontend.sh` + `bun scripts/bench/compare.ts` against a real change, to sanity-check the harness end to end
- [ ] `./scripts/bench/run.sh` against a seeded Kind cluster (`./scripts/dev-cluster.sh`), to confirm the idle CPU/memory profile reports sane numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved loading of cluster overviews, metrics, RBAC data, and custom resources through faster, more efficient caching.
  * Multi-pod logs now load concurrently for quicker access.
  * Reduced unnecessary data retrieval and background updates in resource tables and sidebars.

* **Bug Fixes**
  * Long log lines are safely truncated, while streamed lines retain correct ordering and formatting.
  * Watches now reset correctly when switching Kubernetes contexts.
  * Improved filtering, saved-view counts, row selection, and resource-specific table details.

* **Documentation**
  * Added guidance for running and comparing frontend performance benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->